### PR TITLE
Add spec release fetcher to qf-generate

### DIFF
--- a/cli/prompt_generator/README.md
+++ b/cli/prompt_generator/README.md
@@ -140,6 +140,10 @@ Main command to generate prompts.
 - `--standalone, -s` - Include all loop procedures for roles
 - `--output, -o <path>` - Output file (default: stdout)
 - `--spec-dir <path>` - Spec root directory (default: `spec/`)
+- `--spec-source <auto|bundled|release>` - Choose how the spec is resolved. `auto`
+  searches the repo tree then falls back to the bundled minimal spec, `bundled`
+  forces the bundled copy, and `release` downloads the latest GitHub release
+  into `~/.cache/questfoundry/spec/`.
 - `--verbose, -v` - Show detailed progress
 
 **Examples:**
@@ -168,6 +172,7 @@ List all available loops/playbooks.
 **Options:**
 
 - `--spec-dir <path>` - Spec root directory
+- `--spec-source <auto|bundled|release>` - Same semantics as the main command.
 
 **Example:**
 
@@ -182,6 +187,7 @@ List all available roles/adapters.
 **Options:**
 
 - `--spec-dir <path>` - Spec root directory
+- `--spec-source <auto|bundled|release>` - Same semantics as the main command.
 
 **Example:**
 
@@ -205,6 +211,19 @@ The generated prompts are optimized for:
 - **Context preservation** - Clear structure with sections
 - **Self-contained** - No external file dependencies
 - **LLM-friendly** - Formatted for optimal LLM comprehension
+
+## Spec Sources & Releases
+
+`qf-generate` bundles a minimal snapshot of the spec for offline use. With
+`--spec-source auto` (the default) the CLI searches for a local `spec/`
+directory by walking up from the current working directory and falls back to
+the bundled snapshot when nothing is found.
+
+Use `--spec-source release` to download the latest published spec release from
+GitHub (trusted per QuestFoundry policy). Releases are cached under
+`~/.cache/questfoundry/spec/<tag>` so subsequent invocations reuse them without a
+network call. You can also force the bundled snapshot via `--spec-source
+bundled` when you explicitly want the paired minimal spec.
 
 ## Development
 

--- a/cli/prompt_generator/pyproject.toml
+++ b/cli/prompt_generator/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "questfoundry-compiler",
+    "questfoundry-compiler>=0.3.1",
     "typer>=0.9.0",
     "rich>=13.0.0",
     "questionary>=2.0.0",

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -1,7 +1,7 @@
 """Command-line interface for QuestFoundry prompt generator."""
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import questfoundry_compiler  # type: ignore[import-untyped]
 import questionary
@@ -14,12 +14,16 @@ from questfoundry_compiler import (  # type: ignore[import-untyped]
 )
 from rich.console import Console
 
+from prompt_generator import spec_fetcher
+
 app = typer.Typer(
     name="qf-generate",
     help="Generate monolithic web agent prompts from QuestFoundry behavior primitives",
     add_completion=False,
 )
 console = Console()
+
+SpecSource = Literal["auto", "bundled", "release"]
 
 
 def _is_valid_spec_root(path: Path) -> bool:
@@ -48,7 +52,7 @@ def _bundled_spec_dir() -> Path | None:
     return None
 
 
-def _resolve_spec_dir(spec_dir: Path | None) -> Path:
+def _resolve_spec_dir(spec_dir: Path | None, spec_source: SpecSource) -> Path:
     if spec_dir is not None:
         resolved = spec_dir
         if not spec_dir.is_absolute():
@@ -58,19 +62,42 @@ def _resolve_spec_dir(spec_dir: Path | None) -> Path:
             raise typer.Exit(1)
         return resolved
 
+    def download_release_spec() -> Path:
+        try:
+            release_dir = spec_fetcher.download_latest_release_spec()
+        except spec_fetcher.SpecFetchError as exc:
+            console.print(f"[red]Failed to download released spec: {exc}[/red]")
+            raise typer.Exit(1)
+        console.print(
+            f"[green]Using released QuestFoundry spec from {release_dir}[/green]"
+        )
+        return release_dir
+
+    if spec_source == "bundled":
+        bundled = _bundled_spec_dir()
+        if bundled:
+            return bundled
+        console.print(
+            "[red]Bundled spec directory missing. Provide --spec-dir or use "
+            "--spec-source release.[/red]"
+        )
+        raise typer.Exit(1)
+
+    if spec_source == "release":
+        return download_release_spec()
+
     repo_spec = _find_repo_spec([Path.cwd()])
     if repo_spec:
         return repo_spec
 
     bundled = _bundled_spec_dir()
     if bundled:
-        console.print(
-            "[yellow]Spec directory not found locally; "
-            "using bundled copy from questfoundry-compiler[/yellow]"
-        )
         return bundled
 
-    console.print("[red]Error: Spec directory not found. Provide --spec-dir.[/red]")
+    console.print(
+        "[red]Error: Spec directory not found. Provide --spec-dir or use "
+        "--spec-source release to download the latest published spec.[/red]"
+    )
     raise typer.Exit(1)
 
 
@@ -155,6 +182,17 @@ def generate(
             help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
     ] = None,
+    spec_source: Annotated[
+        SpecSource,
+        typer.Option(
+            "--spec-source",
+            case_sensitive=False,
+            help=(
+                "Where to load QuestFoundry spec data from. Options: auto, "
+                "bundled, release."
+            ),
+        ),
+    ] = "auto",
     verbose: Annotated[
         bool,
         typer.Option(
@@ -186,7 +224,7 @@ def generate(
         # Interactive mode
         qf-generate
     """
-    spec_dir = _resolve_spec_dir(spec_dir)
+    spec_dir = _resolve_spec_dir(spec_dir, spec_source)
 
     behavior_dir = spec_dir / "05-behavior"
     if not behavior_dir.exists():
@@ -325,9 +363,17 @@ def list_loops(
             help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
     ] = None,
+    spec_source: Annotated[
+        SpecSource,
+        typer.Option(
+            "--spec-source",
+            case_sensitive=False,
+            help="Where to load QuestFoundry spec data from (auto/bundled/release)",
+        ),
+    ] = "auto",
 ) -> None:
     """List all available loops/playbooks."""
-    spec_dir = _resolve_spec_dir(spec_dir)
+    spec_dir = _resolve_spec_dir(spec_dir, spec_source)
 
     try:
         compiler = SpecCompiler(spec_dir)
@@ -358,9 +404,17 @@ def list_roles(
             help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
     ] = None,
+    spec_source: Annotated[
+        SpecSource,
+        typer.Option(
+            "--spec-source",
+            case_sensitive=False,
+            help="Where to load QuestFoundry spec data from (auto/bundled/release)",
+        ),
+    ] = "auto",
 ) -> None:
     """List all available roles/adapters."""
-    spec_dir = _resolve_spec_dir(spec_dir)
+    spec_dir = _resolve_spec_dir(spec_dir, spec_source)
 
     try:
         compiler = SpecCompiler(spec_dir)

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Annotated
 
+import questfoundry_compiler  # type: ignore[import-untyped]
 import questionary
 import typer
 from questfoundry_compiler import (  # type: ignore[import-untyped]
@@ -19,6 +20,58 @@ app = typer.Typer(
     add_completion=False,
 )
 console = Console()
+
+
+def _is_valid_spec_root(path: Path) -> bool:
+    return path.is_dir() and (path / "05-behavior").is_dir()
+
+
+def _find_repo_spec(start_dirs: list[Path]) -> Path | None:
+    seen: set[Path] = set()
+    for start in start_dirs:
+        current = start.resolve()
+        for candidate in (current, *current.parents):
+            spec_candidate = (candidate / "spec").resolve()
+            if spec_candidate in seen:
+                continue
+            seen.add(spec_candidate)
+            if _is_valid_spec_root(spec_candidate):
+                return spec_candidate
+    return None
+
+
+def _bundled_spec_dir() -> Path | None:
+    package_root = Path(questfoundry_compiler.__file__).resolve().parent
+    bundled = package_root / "_bundled_spec"
+    if _is_valid_spec_root(bundled):
+        return bundled
+    return None
+
+
+def _resolve_spec_dir(spec_dir: Path | None) -> Path:
+    if spec_dir is not None:
+        resolved = spec_dir
+        if not spec_dir.is_absolute():
+            resolved = (Path.cwd() / spec_dir).resolve()
+        if not _is_valid_spec_root(resolved):
+            console.print(f"[red]Error: Spec directory not found: {resolved}[/red]")
+            raise typer.Exit(1)
+        return resolved
+
+    repo_spec = _find_repo_spec([Path.cwd()])
+    if repo_spec:
+        return repo_spec
+
+    bundled = _bundled_spec_dir()
+    if bundled:
+        console.print(
+            "[yellow]Spec directory not found locally; "
+            "using bundled copy from questfoundry-compiler[/yellow]"
+        )
+        return bundled
+
+    console.print("[red]Error: Spec directory not found. Provide --spec-dir.[/red]")
+    raise typer.Exit(1)
 
 
 def get_available_loops(compiler: SpecCompiler) -> list[str]:
@@ -96,12 +149,12 @@ def generate(
         ),
     ] = None,
     spec_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--spec-dir",
-            help="Root directory of spec/ (default: spec/)",
+            help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
-    ] = Path("spec"),
+    ] = None,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -133,15 +186,7 @@ def generate(
         # Interactive mode
         qf-generate
     """
-    # Resolve spec directory
-    if not spec_dir.is_absolute():
-        # Make it relative to current working directory
-        spec_dir = spec_dir.resolve()
-
-    # Validate spec directory exists
-    if not spec_dir.exists():
-        console.print(f"[red]Error: Spec directory not found: {spec_dir}[/red]")
-        raise typer.Exit(1)
+    spec_dir = _resolve_spec_dir(spec_dir)
 
     behavior_dir = spec_dir / "05-behavior"
     if not behavior_dir.exists():
@@ -274,21 +319,15 @@ def generate(
 @app.command()
 def list_loops(
     spec_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--spec-dir",
-            help="Root directory of spec/ (default: spec/)",
+            help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
-    ] = Path("spec"),
+    ] = None,
 ) -> None:
     """List all available loops/playbooks."""
-    # Resolve spec directory
-    if not spec_dir.is_absolute():
-        spec_dir = spec_dir.resolve()
-
-    if not spec_dir.exists():
-        console.print(f"[red]Error: Spec directory not found: {spec_dir}[/red]")
-        raise typer.Exit(1)
+    spec_dir = _resolve_spec_dir(spec_dir)
 
     try:
         compiler = SpecCompiler(spec_dir)
@@ -313,21 +352,15 @@ def list_loops(
 @app.command()
 def list_roles(
     spec_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--spec-dir",
-            help="Root directory of spec/ (default: spec/)",
+            help="Root directory of spec/ (auto-detected or bundled if omitted)",
         ),
-    ] = Path("spec"),
+    ] = None,
 ) -> None:
     """List all available roles/adapters."""
-    # Resolve spec directory
-    if not spec_dir.is_absolute():
-        spec_dir = spec_dir.resolve()
-
-    if not spec_dir.exists():
-        console.print(f"[red]Error: Spec directory not found: {spec_dir}[/red]")
-        raise typer.Exit(1)
+    spec_dir = _resolve_spec_dir(spec_dir)
 
     try:
         compiler = SpecCompiler(spec_dir)

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 from typing import Annotated, Literal
 
-import questfoundry_compiler  # type: ignore[import-untyped]
+import questfoundry_compiler
 import questionary
 import typer
-from questfoundry_compiler import (  # type: ignore[import-untyped]
+from questfoundry_compiler import (
     CompilationError,
     PromptAssembler,
     ReferenceResolver,

--- a/cli/prompt_generator/src/prompt_generator/spec_fetcher.py
+++ b/cli/prompt_generator/src/prompt_generator/spec_fetcher.py
@@ -1,0 +1,107 @@
+"""Utilities to download released QuestFoundry specs from GitHub."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Final
+
+DEFAULT_CACHE_DIR: Final = Path.home() / ".cache" / "questfoundry" / "spec"
+GITHUB_REPO: Final = "pvliesdonk/questfoundry-spec"
+API_BASE: Final = f"https://api.github.com/repos/{GITHUB_REPO}"
+USER_AGENT: Final = "questfoundry-prompt-generator"
+
+
+class SpecFetchError(RuntimeError):
+    """Raised when fetching a released spec fails."""
+
+
+def _request_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status >= 400:  # pragma: no cover
+                raise SpecFetchError(f"Request failed with status {response.status}")
+            payload = response.read().decode("utf-8")
+            return json.loads(payload)
+    except urllib.error.URLError as exc:  # pragma: no cover
+        raise SpecFetchError(f"Unable to reach GitHub: {exc}") from exc
+
+
+def _download_file(url: str, destination: Path) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with (
+            urllib.request.urlopen(request, timeout=120) as response,
+            destination.open("wb") as output,
+        ):
+            shutil.copyfileobj(response, output)
+    except urllib.error.URLError as exc:
+        raise SpecFetchError(f"Failed to download release archive: {exc}") from exc
+
+
+def _extract_zip(archive_path: Path, target_dir: Path) -> None:
+    with zipfile.ZipFile(archive_path) as archive:
+        extract_root = Path(tempfile.mkdtemp(prefix="qf-spec-extract-"))
+        try:
+            archive.extractall(extract_root)
+            try:
+                unpacked_root = next(extract_root.iterdir())
+            except StopIteration as exc:  # pragma: no cover
+                raise SpecFetchError("Downloaded archive was empty") from exc
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            shutil.copytree(unpacked_root, target_dir)
+        finally:
+            shutil.rmtree(extract_root, ignore_errors=True)
+
+
+def _is_valid_spec_root(spec_root: Path) -> bool:
+    return (spec_root / "05-behavior").is_dir()
+
+
+def _fetch_release_info(tag: str | None = None) -> dict:
+    if tag:
+        url = f"{API_BASE}/releases/tags/{tag}"
+    else:
+        url = f"{API_BASE}/releases/latest"
+    return _request_json(url)
+
+
+def download_latest_release_spec(
+    cache_dir: Path | None = None, tag: str | None = None
+) -> Path:
+    """Download the latest QuestFoundry spec release if needed."""
+
+    cache_root = cache_dir or DEFAULT_CACHE_DIR
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    release_info = _fetch_release_info(tag)
+    tag_name = release_info["tag_name"]
+    spec_dir = cache_root / tag_name
+    if _is_valid_spec_root(spec_dir):
+        return spec_dir
+
+    archive_url = release_info.get("zipball_url")
+    if not archive_url:
+        raise SpecFetchError("Release response missing archive URL")
+
+    with tempfile.TemporaryDirectory(prefix="qf-spec-download-") as tmp:
+        archive_path = Path(tmp) / "spec-release.zip"
+        _download_file(archive_url, archive_path)
+        _extract_zip(archive_path, spec_dir)
+
+    if not _is_valid_spec_root(spec_dir):
+        raise SpecFetchError("Downloaded spec archive is missing 05-behavior/")
+
+    metadata = {"tag": tag_name, "source": archive_url}
+    (spec_dir / ".questfoundry-spec.json").write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )
+
+    return spec_dir

--- a/cli/prompt_generator/src/prompt_generator/spec_fetcher.py
+++ b/cli/prompt_generator/src/prompt_generator/spec_fetcher.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 DEFAULT_CACHE_DIR: Final = Path.home() / ".cache" / "questfoundry" / "spec"
 GITHUB_REPO: Final = "pvliesdonk/questfoundry-spec"
@@ -21,7 +21,7 @@ class SpecFetchError(RuntimeError):
     """Raised when fetching a released spec fails."""
 
 
-def _request_json(url: str) -> dict:
+def _request_json(url: str) -> dict[str, Any]:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
@@ -65,7 +65,7 @@ def _is_valid_spec_root(spec_root: Path) -> bool:
     return (spec_root / "05-behavior").is_dir()
 
 
-def _fetch_release_info(tag: str | None = None) -> dict:
+def _fetch_release_info(tag: str | None = None) -> dict[str, Any]:
     if tag:
         url = f"{API_BASE}/releases/tags/{tag}"
     else:

--- a/cli/prompt_generator/tests/test_cli.py
+++ b/cli/prompt_generator/tests/test_cli.py
@@ -124,3 +124,29 @@ def test_generate_fails_when_spec_missing(tmp_path):
 
     assert result.exit_code == 1
     assert "Spec directory not found" in result.output
+
+
+def test_resolve_spec_dir_detects_parent(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    spec_root = repo_root / "spec"
+    (spec_root / "05-behavior").mkdir(parents=True)
+    workdir = repo_root / "cli" / "prompt_generator"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+
+    resolved = cli._resolve_spec_dir(None)
+
+    assert resolved == spec_root
+
+
+def test_resolve_spec_dir_prefers_bundled(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    (bundled / "05-behavior").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(cli, "_find_repo_spec", lambda _start_dirs: None)
+    monkeypatch.setattr(cli, "_bundled_spec_dir", lambda: bundled)
+
+    resolved = cli._resolve_spec_dir(None)
+
+    assert resolved == bundled

--- a/cli/prompt_generator/tests/test_cli.py
+++ b/cli/prompt_generator/tests/test_cli.py
@@ -134,7 +134,7 @@ def test_resolve_spec_dir_detects_parent(monkeypatch, tmp_path):
     workdir.mkdir(parents=True)
     monkeypatch.chdir(workdir)
 
-    resolved = cli._resolve_spec_dir(None)
+    resolved = cli._resolve_spec_dir(None, "auto")
 
     assert resolved == spec_root
 
@@ -147,6 +147,24 @@ def test_resolve_spec_dir_prefers_bundled(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "_find_repo_spec", lambda _start_dirs: None)
     monkeypatch.setattr(cli, "_bundled_spec_dir", lambda: bundled)
 
-    resolved = cli._resolve_spec_dir(None)
+    resolved = cli._resolve_spec_dir(None, "auto")
 
     assert resolved == bundled
+
+
+def test_resolve_spec_dir_downloads_release(monkeypatch, tmp_path):
+    release_dir = tmp_path / "release"
+    (release_dir / "05-behavior").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(cli, "_find_repo_spec", lambda _start_dirs: None)
+    monkeypatch.setattr(cli, "_bundled_spec_dir", lambda: None)
+    monkeypatch.setattr(
+        cli.spec_fetcher,
+        "download_latest_release_spec",
+        lambda: release_dir,
+    )
+
+    resolved = cli._resolve_spec_dir(None, "release")
+
+    assert resolved == release_dir

--- a/cli/prompt_generator/uv.lock
+++ b/cli/prompt_generator/uv.lock
@@ -609,14 +609,14 @@ wheels = [
 
 [[package]]
 name = "questfoundry-compiler"
-version = "0.2.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/68/c0813516431358bb8a0142d10b7e68f1f2e7d6a0c0919f1ff4d39f665a13/questfoundry_compiler-0.2.0.tar.gz", hash = "sha256:f3f881946153f6adabdb070e5eb0afdd616b9e8d4d4eadde1b045693b1b59ca9", size = 19631, upload-time = "2025-11-15T15:15:28.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/4b/9d8faebe24433834876deb4bf32eb8ca5faa695f94af6376ff56c562a71b/questfoundry_compiler-0.3.1.tar.gz", hash = "sha256:ee1e6707468d1f7d0db28674d0fcf8830f04c81ebfff2c1ced46770e1a8837e5", size = 23964, upload-time = "2025-11-16T11:53:23.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/43/8a5e1e3ee3d0d59718af0c5db536a3eee56d5e69470d7b1ae76a59936959/questfoundry_compiler-0.2.0-py3-none-any.whl", hash = "sha256:412e5d852bf8dd99400b34d6b77b3ff621f20d0f85fd9b5abfeb0c5f2227f33c", size = 21389, upload-time = "2025-11-15T15:15:26.975Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/0145b7661c704bcdb076b6a40eb75ae12f5602b62d65d18223adb421f6c0/questfoundry_compiler-0.3.1-py3-none-any.whl", hash = "sha256:badd9174ad518548a6c50df4feef0b7d9c3161650aff6fce24ad2927c434d276", size = 25586, upload-time = "2025-11-16T11:53:21.285Z" },
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ name = "questfoundry-prompt-generator"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "questfoundry-compiler" },
+    { name = "questfoundry-compiler", specifier = ">=0.3.1" },
     { name = "questionary" },
     { name = "rich" },
     { name = "typer" },
@@ -647,7 +647,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "questfoundry-compiler" },
+    { name = "questfoundry-compiler", specifier = ">=0.3.1" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },

--- a/lib/compiler/pyproject.toml
+++ b/lib/compiler/pyproject.toml
@@ -63,6 +63,11 @@ all-checks = ["format-check", "lint", "typecheck", "test"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/questfoundry_compiler"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"../../spec/05-behavior" = "questfoundry_compiler/_bundled_spec/05-behavior"
+"../../spec/03-schemas" = "questfoundry_compiler/_bundled_spec/03-schemas"
+"../../spec/01-roles/charters" = "questfoundry_compiler/_bundled_spec/01-roles/charters"
+
 [tool.hatch.build.targets.sdist]
 include = [
     "/src",
@@ -70,6 +75,11 @@ include = [
     "/README.md",
     "/LICENSE",
 ]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../../spec/05-behavior" = "questfoundry_compiler/_bundled_spec/05-behavior"
+"../../spec/03-schemas" = "questfoundry_compiler/_bundled_spec/03-schemas"
+"../../spec/01-roles/charters" = "questfoundry_compiler/_bundled_spec/01-roles/charters"
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
## Summary
- add a GitHub release fetcher so `qf-generate` can fall back to the latest published spec when a repo copy is missing
- expose a `--spec-source` option for all CLI commands and document the new behavior
- bump the dependency to `questfoundry-compiler>=0.3.1` so the bundled minimal spec is always present

## Testing
- `uv run pytest`
