### PR TITLE
feat(cli): support multi-loop prompts

### DIFF
--- a/cli/prompt_generator/README.md
+++ b/cli/prompt_generator/README.md
@@ -135,8 +135,12 @@ Main command to generate prompts.
 
 **Options:**
 
-- `--loop, -l <id>` - Loop/playbook ID (e.g., `lore_deepening`)
-- `--role, -r <id>` - Role/adapter ID (can be repeated)
+- `--loop, -l <token>` - Loop/playbook identifier. Accepts IDs like
+  `lore_deepening`, abbreviations like `LD`, or category tokens such as
+  `discovery`. Repeat the option to bundle multiple loops into one prompt.
+- `--role, -r <token>` - Role/adapter identifier. Accepts IDs like
+  `lore_weaver`, abbreviations like `LW`, or Role Index categories such as
+  `default` or `always`. Repeatable.
 - `--standalone, -s` - Include all loop procedures for roles
 - `--output, -o <path>` - Output file (default: stdout)
 - `--spec-dir <path>` - Spec root directory (default: `spec/`)
@@ -152,8 +156,14 @@ Main command to generate prompts.
 # Single loop
 qf-generate --loop lore_deepening -o prompt.md
 
+# Bundle Discovery loops (ID + category token)
+qf-generate --loop lore_deepening --loop discovery -o prompt.md
+
 # Multiple roles
 qf-generate -r lore_weaver -r researcher -o prompt.md
+
+# Role category shortcut (Default On)
+qf-generate -r default -o prompt.md
 
 # Standalone role prompt
 qf-generate -r lore_weaver --standalone -o prompt.md
@@ -167,7 +177,8 @@ qf-generate --loop hook_harvest --verbose -o prompt.md
 
 ### `qf-generate list-loops`
 
-List all available loops/playbooks.
+List all available loops/playbooks grouped by category, showing abbreviations,
+category tokens, and each loop's purpose.
 
 **Options:**
 
@@ -182,7 +193,8 @@ qf-generate list-loops
 
 ### `qf-generate list-roles`
 
-List all available roles/adapters.
+List all available roles/adapters grouped by Role Index category, with
+abbreviations, missions, and the category tokens you can use in the CLI.
 
 **Options:**
 

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -1,5 +1,7 @@
 """Command-line interface for QuestFoundry prompt generator."""
 
+import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -24,6 +26,74 @@ app = typer.Typer(
 console = Console()
 
 SpecSource = Literal["auto", "bundled", "release"]
+
+
+def _normalize_identifier_token(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _normalize_abbreviation(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _normalize_category_token(value: str) -> str:
+    token = re.sub(r"[^a-z0-9]", "", value.lower())
+    return token or "uncategorized"
+
+
+def _slugify_label(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "uncategorized"
+
+
+def _strip_category_prefix(value: str) -> tuple[str, bool]:
+    lowered = value.lower()
+    for prefix in ("category:", "cat:", "group:"):
+        if lowered.startswith(prefix):
+            return value[len(prefix) :], True
+    return value, False
+
+
+@dataclass
+class CategoryGroup:
+    label: str
+    slug: str
+    normalized_label: str
+    ids: list[str]
+
+
+@dataclass
+class LoopDescriptor:
+    id: str
+    name: str
+    abbreviation: str | None
+    category: str
+    purpose: str | None
+
+
+@dataclass
+class RoleDescriptor:
+    id: str
+    name: str
+    abbreviation: str | None
+    category: str
+    mission: str | None
+
+
+@dataclass
+class LoopCatalog:
+    items: dict[str, LoopDescriptor]
+    id_index: dict[str, str]
+    abbreviation_index: dict[str, str]
+    categories: dict[str, CategoryGroup]
+
+
+@dataclass
+class RoleCatalog:
+    items: dict[str, RoleDescriptor]
+    id_index: dict[str, str]
+    abbreviation_index: dict[str, str]
+    categories: dict[str, CategoryGroup]
 
 
 def _is_valid_spec_root(path: Path) -> bool:
@@ -101,38 +171,254 @@ def _resolve_spec_dir(spec_dir: Path | None, spec_source: SpecSource) -> Path:
     raise typer.Exit(1)
 
 
-def get_available_loops(compiler: SpecCompiler) -> list[str]:
-    """Get list of available playbook IDs.
+def _load_role_category_lookup(spec_dir: Path) -> dict[str, str]:
+    role_index = spec_dir / "00-north-star" / "ROLE_INDEX.md"
+    if not role_index.exists():
+        return {}
 
-    Args:
-        compiler: Initialized SpecCompiler
+    categories: dict[str, str] = {}
+    current_category: str | None = None
+    for raw_line in role_index.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("## "):
+            current_category = line[3:].strip()
+            continue
+        if line.startswith("### ") and current_category:
+            role_name = line[4:].strip()
+            if not role_name:
+                continue
+            role_name = role_name.split("(")[0].strip()
+            categories[role_name] = current_category
+    return categories
 
-    Returns:
-        List of playbook IDs
-    """
-    loops = []
-    for key in compiler.primitives.keys():
-        if key.startswith("playbook:"):
-            loop_id = key.split(":", 1)[1]
-            loops.append(loop_id)
-    return sorted(loops)
+
+def _build_loop_catalog(compiler: SpecCompiler) -> LoopCatalog:
+    items: dict[str, LoopDescriptor] = {}
+    id_index: dict[str, str] = {}
+    abbreviation_index: dict[str, str] = {}
+    categories: dict[str, CategoryGroup] = {}
+
+    for key, primitive in compiler.primitives.items():
+        if not key.startswith("playbook:"):
+            continue
+        metadata = primitive.metadata
+        loop_id = primitive.id
+        descriptor = LoopDescriptor(
+            id=loop_id,
+            name=metadata.get("playbook_name", loop_id),
+            abbreviation=metadata.get("abbreviation"),
+            category=metadata.get("category", "Uncategorized"),
+            purpose=metadata.get("purpose"),
+        )
+        items[loop_id] = descriptor
+        id_index[_normalize_identifier_token(loop_id)] = loop_id
+        if descriptor.abbreviation:
+            abbreviation_index[_normalize_abbreviation(descriptor.abbreviation)] = (
+                loop_id
+            )
+
+        slug = _slugify_label(descriptor.category)
+        normalized_label = _normalize_category_token(descriptor.category)
+        if slug not in categories:
+            categories[slug] = CategoryGroup(
+                label=descriptor.category,
+                slug=slug,
+                normalized_label=normalized_label,
+                ids=[],
+            )
+        categories[slug].ids.append(loop_id)
+
+    for group in categories.values():
+        group.ids.sort(key=lambda loop_id: items[loop_id].name)
+
+    return LoopCatalog(items, id_index, abbreviation_index, categories)
 
 
-def get_available_roles(compiler: SpecCompiler) -> list[str]:
-    """Get list of available adapter/role IDs.
+def _build_role_catalog(compiler: SpecCompiler, spec_dir: Path) -> RoleCatalog:
+    role_categories = _load_role_category_lookup(spec_dir)
+    items: dict[str, RoleDescriptor] = {}
+    id_index: dict[str, str] = {}
+    abbreviation_index: dict[str, str] = {}
+    categories: dict[str, CategoryGroup] = {}
 
-    Args:
-        compiler: Initialized SpecCompiler
+    for key, primitive in compiler.primitives.items():
+        if not key.startswith("adapter:"):
+            continue
+        metadata = primitive.metadata
+        role_id = primitive.id
+        role_name = metadata.get("role_name", role_id.replace("_", " ").title())
+        category_label = role_categories.get(role_name, "Uncategorized")
+        descriptor = RoleDescriptor(
+            id=role_id,
+            name=role_name,
+            abbreviation=metadata.get("abbreviation"),
+            category=category_label,
+            mission=metadata.get("mission"),
+        )
+        items[role_id] = descriptor
+        id_index[_normalize_identifier_token(role_id)] = role_id
+        if descriptor.abbreviation:
+            abbreviation_index[_normalize_abbreviation(descriptor.abbreviation)] = (
+                role_id
+            )
 
-    Returns:
-        List of adapter IDs
-    """
-    roles = []
-    for key in compiler.primitives.keys():
-        if key.startswith("adapter:"):
-            role_id = key.split(":", 1)[1]
-            roles.append(role_id)
-    return sorted(roles)
+        slug = _slugify_label(descriptor.category)
+        normalized_label = _normalize_category_token(descriptor.category)
+        if slug not in categories:
+            categories[slug] = CategoryGroup(
+                label=descriptor.category,
+                slug=slug,
+                normalized_label=normalized_label,
+                ids=[],
+            )
+        categories[slug].ids.append(role_id)
+
+    for group in categories.values():
+        group.ids.sort(key=lambda role_id: items[role_id].name)
+
+    return RoleCatalog(items, id_index, abbreviation_index, categories)
+
+
+def _match_category_token(
+    token: str, categories: dict[str, CategoryGroup]
+) -> CategoryGroup | None:
+    slug_candidate = _slugify_label(token)
+    if slug_candidate in categories:
+        return categories[slug_candidate]
+
+    normalized = _normalize_category_token(token)
+    matches = [
+        group
+        for group in categories.values()
+        if group.normalized_label.startswith(normalized)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+
+    matches = [
+        group
+        for group in categories.values()
+        if normalized.startswith(group.normalized_label)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _resolve_loop_ids(requested: list[str], catalog: LoopCatalog) -> list[str]:
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    for raw in requested:
+        token, forced_category = _strip_category_prefix(raw.strip())
+        normalized_id = _normalize_identifier_token(token)
+        if not forced_category and normalized_id in catalog.id_index:
+            loop_id = catalog.id_index[normalized_id]
+            if loop_id not in seen:
+                seen.add(loop_id)
+                resolved.append(loop_id)
+            continue
+
+        normalized_abbrev = _normalize_abbreviation(token)
+        if not forced_category and normalized_abbrev in catalog.abbreviation_index:
+            loop_id = catalog.abbreviation_index[normalized_abbrev]
+            if loop_id not in seen:
+                seen.add(loop_id)
+                resolved.append(loop_id)
+            continue
+
+        category_group = _match_category_token(token, catalog.categories)
+        if category_group:
+            for loop_id in category_group.ids:
+                if loop_id not in seen:
+                    seen.add(loop_id)
+                    resolved.append(loop_id)
+            continue
+
+        console.print(
+            f"[red]Unknown loop, abbreviation, or category token: '{raw}'[/red]"
+        )
+        raise typer.Exit(1)
+
+    return resolved
+
+
+def _resolve_role_ids(requested: list[str], catalog: RoleCatalog) -> list[str]:
+    resolved: list[str] = []
+    seen: set[str] = set()
+
+    for raw in requested:
+        token, forced_category = _strip_category_prefix(raw.strip())
+        normalized_id = _normalize_identifier_token(token)
+        if not forced_category and normalized_id in catalog.id_index:
+            role_id = catalog.id_index[normalized_id]
+            if role_id not in seen:
+                seen.add(role_id)
+                resolved.append(role_id)
+            continue
+
+        normalized_abbrev = _normalize_abbreviation(token)
+        if not forced_category and normalized_abbrev in catalog.abbreviation_index:
+            role_id = catalog.abbreviation_index[normalized_abbrev]
+            if role_id not in seen:
+                seen.add(role_id)
+                resolved.append(role_id)
+            continue
+
+        category_group = _match_category_token(token, catalog.categories)
+        if category_group:
+            for role_id in category_group.ids:
+                if role_id not in seen:
+                    seen.add(role_id)
+                    resolved.append(role_id)
+            continue
+
+        console.print(
+            f"[red]Unknown role, abbreviation, or category token: '{raw}'[/red]"
+        )
+        raise typer.Exit(1)
+
+    return resolved
+
+
+def _bundle_loop_prompts(
+    loop_ids: list[str],
+    assembler: PromptAssembler,
+    catalog: LoopCatalog,
+) -> str:
+    prompts: list[tuple[str, str]] = []
+    for loop_id in loop_ids:
+        prompt = assembler.assemble_web_prompt_for_loop(loop_id)
+        prompts.append((loop_id, prompt.strip()))
+
+    if len(prompts) == 1:
+        return prompts[0][1]
+
+    sections: list[str] = []
+    sections.append("# QuestFoundry Loop Bundle")
+    sections.append("")
+    sections.append("This prompt bundles the following loops:")
+    for loop_id in loop_ids:
+        descriptor = catalog.items.get(loop_id)
+        if descriptor:
+            label = descriptor.name
+            if descriptor.abbreviation:
+                label += f" ({descriptor.abbreviation})"
+        else:
+            label = loop_id
+        sections.append(f"- {label} [{loop_id}]")
+    sections.append("")
+    sections.append("---")
+    sections.append("")
+
+    for idx, (_loop_id, prompt) in enumerate(prompts, start=1):
+        if idx > 1:
+            sections.append("")
+            sections.append("---")
+            sections.append("")
+        sections.append(prompt)
+
+    return "\n".join(sections)
 
 
 @app.command()
@@ -242,13 +528,13 @@ def generate(
         if verbose:
             console.print(f"Loaded {len(compiler.primitives)} primitives")
 
+        loop_catalog = _build_loop_catalog(compiler)
+        role_catalog = _build_role_catalog(compiler, spec_dir)
+
         # Interactive mode if no loops or roles specified
         if not loop and not role:
             if verbose:
                 console.print("Entering interactive mode...")
-
-            available_loops = get_available_loops(compiler)
-            available_roles = get_available_roles(compiler)
 
             # Ask what to generate
             mode = questionary.select(
@@ -265,9 +551,21 @@ def generate(
 
             if "Loop" in mode:
                 # Select loop
+                loop_choices = [
+                    questionary.Choice(
+                        title=(
+                            f"[{desc.abbreviation or '--'}] {desc.name} "
+                            f"({desc.id}) — {desc.category}"
+                        ),
+                        value=desc.id,
+                    )
+                    for desc in sorted(
+                        loop_catalog.items.values(), key=lambda d: d.name
+                    )
+                ]
                 selected_loop = questionary.select(
                     "Select a loop:",
-                    choices=available_loops,
+                    choices=loop_choices,
                 ).ask()
 
                 if selected_loop is None:
@@ -278,9 +576,21 @@ def generate(
 
             else:
                 # Select roles
+                role_choices = [
+                    questionary.Choice(
+                        title=(
+                            f"[{desc.abbreviation or '--'}] {desc.name} "
+                            f"({desc.id}) — {desc.category}"
+                        ),
+                        value=desc.id,
+                    )
+                    for desc in sorted(
+                        role_catalog.items.values(), key=lambda d: d.name
+                    )
+                ]
                 selected_roles = questionary.checkbox(
                     "Select roles (use space to select, enter to confirm):",
-                    choices=available_roles,
+                    choices=role_choices,
                 ).ask()
 
                 if not selected_roles:
@@ -297,31 +607,28 @@ def generate(
                 if standalone_choice is not None:
                     standalone = standalone_choice
 
+        # Resolve requested IDs (abbreviations/categories supported)
+        loop_ids = _resolve_loop_ids(loop or [], loop_catalog)
+        role_ids = _resolve_role_ids(role or [], role_catalog)
+
         # Initialize assembler
         resolver = ReferenceResolver(compiler.primitives, spec_dir)
         assembler = PromptAssembler(compiler.primitives, resolver, spec_dir)
 
         # Generate prompt
-        if loop:
-            if len(loop) > 1:
-                console.print(
-                    "[yellow]Warning: Multiple loops specified, "
-                    "only first will be used[/yellow]"
-                )
-
-            loop_id = loop[0]
+        if loop_ids:
             if verbose:
-                console.print(f"Generating prompt for loop: {loop_id}")
+                console.print("Generating prompt for loops: " + ", ".join(loop_ids))
 
-            prompt = assembler.assemble_web_prompt_for_loop(loop_id)
+            prompt = _bundle_loop_prompts(loop_ids, assembler, loop_catalog)
 
-        elif role:
+        elif role_ids:
             if verbose:
-                console.print(f"Generating prompt for roles: {', '.join(role)}")
+                console.print(f"Generating prompt for roles: {', '.join(role_ids)}")
                 if standalone:
                     console.print("(standalone mode: including loop procedures)")
 
-            prompt = assembler.assemble_web_prompt_for_roles(role, standalone)
+            prompt = assembler.assemble_web_prompt_for_roles(role_ids, standalone)
 
         else:
             console.print("[red]Error: No loop or role specified[/red]")
@@ -379,16 +686,23 @@ def list_loops(
         compiler = SpecCompiler(spec_dir)
         compiler.load_all_primitives()
 
-        loops = get_available_loops(compiler)
+        catalog = _build_loop_catalog(compiler)
+
+        if not catalog.items:
+            console.print("[yellow]No loops found[/yellow]")
+            return
 
         console.print("[bold]Available Loops:[/bold]")
-        for loop_id in loops:
-            playbook = compiler.primitives.get(f"playbook:{loop_id}")
-            if playbook:
-                name = playbook.metadata.get("playbook_name", loop_id)
-                console.print(f"  • {loop_id:25s} - {name}")
-            else:
-                console.print(f"  • {loop_id}")
+        for group in sorted(catalog.categories.values(), key=lambda g: g.label):
+            console.print(
+                f"\n[bold cyan]{group.label}[/bold cyan] "
+                f"[dim](token: {group.slug})[/dim]"
+            )
+            for loop_id in group.ids:
+                descriptor = catalog.items[loop_id]
+                abbr = descriptor.abbreviation or "--"
+                purpose = descriptor.purpose or "Purpose not documented."
+                console.print(f"  • [{abbr}] {descriptor.name} ({loop_id}) — {purpose}")
 
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
@@ -420,16 +734,23 @@ def list_roles(
         compiler = SpecCompiler(spec_dir)
         compiler.load_all_primitives()
 
-        roles = get_available_roles(compiler)
+        catalog = _build_role_catalog(compiler, spec_dir)
+
+        if not catalog.items:
+            console.print("[yellow]No roles found[/yellow]")
+            return
 
         console.print("[bold]Available Roles:[/bold]")
-        for role_id in roles:
-            adapter = compiler.primitives.get(f"adapter:{role_id}")
-            if adapter:
-                name = adapter.metadata.get("role_name", role_id)
-                console.print(f"  • {role_id:25s} - {name}")
-            else:
-                console.print(f"  • {role_id}")
+        for group in sorted(catalog.categories.values(), key=lambda g: g.label):
+            console.print(
+                f"\n[bold magenta]{group.label}[/bold magenta] "
+                f"[dim](token: {group.slug})[/dim]"
+            )
+            for role_id in group.ids:
+                descriptor = catalog.items[role_id]
+                abbr = descriptor.abbreviation or "--"
+                mission = descriptor.mission or "Mission not documented."
+                console.print(f"  • [{abbr}] {descriptor.name} ({role_id}) — {mission}")
 
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -86,6 +86,7 @@ class LoopCatalog:
     id_index: dict[str, str]
     abbreviation_index: dict[str, str]
     categories: dict[str, CategoryGroup]
+    duplicate_abbreviations: dict[str, set[str]]
 
 
 @dataclass
@@ -94,6 +95,7 @@ class RoleCatalog:
     id_index: dict[str, str]
     abbreviation_index: dict[str, str]
     categories: dict[str, CategoryGroup]
+    duplicate_abbreviations: dict[str, set[str]]
 
 
 def _is_valid_spec_root(path: Path) -> bool:
@@ -197,6 +199,7 @@ def _build_loop_catalog(compiler: SpecCompiler) -> LoopCatalog:
     id_index: dict[str, str] = {}
     abbreviation_index: dict[str, str] = {}
     categories: dict[str, CategoryGroup] = {}
+    duplicate_abbreviations: dict[str, set[str]] = {}
 
     for key, primitive in compiler.primitives.items():
         if not key.startswith("playbook:"):
@@ -213,9 +216,14 @@ def _build_loop_catalog(compiler: SpecCompiler) -> LoopCatalog:
         items[loop_id] = descriptor
         id_index[_normalize_identifier_token(loop_id)] = loop_id
         if descriptor.abbreviation:
-            abbreviation_index[_normalize_abbreviation(descriptor.abbreviation)] = (
-                loop_id
-            )
+            normalized_abbrev = _normalize_abbreviation(descriptor.abbreviation)
+            existing = abbreviation_index.get(normalized_abbrev)
+            if existing and existing != loop_id:
+                duplicate_abbreviations.setdefault(normalized_abbrev, set()).update(
+                    {existing, loop_id}
+                )
+            else:
+                abbreviation_index.setdefault(normalized_abbrev, loop_id)
 
         slug = _slugify_label(descriptor.category)
         normalized_label = _normalize_category_token(descriptor.category)
@@ -231,7 +239,13 @@ def _build_loop_catalog(compiler: SpecCompiler) -> LoopCatalog:
     for group in categories.values():
         group.ids.sort(key=lambda loop_id: items[loop_id].name)
 
-    return LoopCatalog(items, id_index, abbreviation_index, categories)
+    return LoopCatalog(
+        items,
+        id_index,
+        abbreviation_index,
+        categories,
+        duplicate_abbreviations,
+    )
 
 
 def _build_role_catalog(compiler: SpecCompiler, spec_dir: Path) -> RoleCatalog:
@@ -240,6 +254,7 @@ def _build_role_catalog(compiler: SpecCompiler, spec_dir: Path) -> RoleCatalog:
     id_index: dict[str, str] = {}
     abbreviation_index: dict[str, str] = {}
     categories: dict[str, CategoryGroup] = {}
+    duplicate_abbreviations: dict[str, set[str]] = {}
 
     for key, primitive in compiler.primitives.items():
         if not key.startswith("adapter:"):
@@ -258,9 +273,14 @@ def _build_role_catalog(compiler: SpecCompiler, spec_dir: Path) -> RoleCatalog:
         items[role_id] = descriptor
         id_index[_normalize_identifier_token(role_id)] = role_id
         if descriptor.abbreviation:
-            abbreviation_index[_normalize_abbreviation(descriptor.abbreviation)] = (
-                role_id
-            )
+            normalized_abbrev = _normalize_abbreviation(descriptor.abbreviation)
+            existing = abbreviation_index.get(normalized_abbrev)
+            if existing and existing != role_id:
+                duplicate_abbreviations.setdefault(normalized_abbrev, set()).update(
+                    {existing, role_id}
+                )
+            else:
+                abbreviation_index.setdefault(normalized_abbrev, role_id)
 
         slug = _slugify_label(descriptor.category)
         normalized_label = _normalize_category_token(descriptor.category)
@@ -276,7 +296,13 @@ def _build_role_catalog(compiler: SpecCompiler, spec_dir: Path) -> RoleCatalog:
     for group in categories.values():
         group.ids.sort(key=lambda role_id: items[role_id].name)
 
-    return RoleCatalog(items, id_index, abbreviation_index, categories)
+    return RoleCatalog(
+        items,
+        id_index,
+        abbreviation_index,
+        categories,
+        duplicate_abbreviations,
+    )
 
 
 def _match_category_token(
@@ -287,63 +313,43 @@ def _match_category_token(
         return categories[slug_candidate]
 
     normalized = _normalize_category_token(token)
-    matches = [
+    prefix_matches = [
         group
         for group in categories.values()
         if group.normalized_label.startswith(normalized)
     ]
-    if len(matches) == 1:
-        return matches[0]
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
 
-    matches = [
+    superstring_matches = [
         group
         for group in categories.values()
         if normalized.startswith(group.normalized_label)
     ]
-    if len(matches) == 1:
-        return matches[0]
+    if len(superstring_matches) == 1:
+        return superstring_matches[0]
     return None
 
 
-def _resolve_loop_ids(requested: list[str], catalog: LoopCatalog) -> list[str]:
-    resolved: list[str] = []
-    seen: set[str] = set()
-
-    for raw in requested:
-        token, forced_category = _strip_category_prefix(raw.strip())
-        normalized_id = _normalize_identifier_token(token)
-        if not forced_category and normalized_id in catalog.id_index:
-            loop_id = catalog.id_index[normalized_id]
-            if loop_id not in seen:
-                seen.add(loop_id)
-                resolved.append(loop_id)
-            continue
-
-        normalized_abbrev = _normalize_abbreviation(token)
-        if not forced_category and normalized_abbrev in catalog.abbreviation_index:
-            loop_id = catalog.abbreviation_index[normalized_abbrev]
-            if loop_id not in seen:
-                seen.add(loop_id)
-                resolved.append(loop_id)
-            continue
-
-        category_group = _match_category_token(token, catalog.categories)
-        if category_group:
-            for loop_id in category_group.ids:
-                if loop_id not in seen:
-                    seen.add(loop_id)
-                    resolved.append(loop_id)
-            continue
-
+def _warn_duplicate_abbreviations(
+    entity_label: str, duplicates: dict[str, set[str]]
+) -> None:
+    if not duplicates:
+        return
+    for token in sorted(duplicates.keys()):
+        identifiers = ", ".join(sorted(duplicates[token]))
         console.print(
-            f"[red]Unknown loop, abbreviation, or category token: '{raw}'[/red]"
+            "[yellow]Warning: duplicate "
+            f"{entity_label} abbreviation '{token}' shared by: {identifiers}. "
+            "Use full IDs or category tokens instead.[/yellow]"
         )
-        raise typer.Exit(1)
-
-    return resolved
 
 
-def _resolve_role_ids(requested: list[str], catalog: RoleCatalog) -> list[str]:
+def _resolve_ids(
+    requested: list[str],
+    catalog: LoopCatalog | RoleCatalog,
+    entity_label: str,
+) -> list[str]:
     resolved: list[str] = []
     seen: set[str] = set()
 
@@ -359,22 +365,23 @@ def _resolve_role_ids(requested: list[str], catalog: RoleCatalog) -> list[str]:
 
         normalized_abbrev = _normalize_abbreviation(token)
         if not forced_category and normalized_abbrev in catalog.abbreviation_index:
-            role_id = catalog.abbreviation_index[normalized_abbrev]
-            if role_id not in seen:
-                seen.add(role_id)
-                resolved.append(role_id)
+            identifier = catalog.abbreviation_index[normalized_abbrev]
+            if identifier not in seen:
+                seen.add(identifier)
+                resolved.append(identifier)
             continue
 
         category_group = _match_category_token(token, catalog.categories)
         if category_group:
-            for role_id in category_group.ids:
-                if role_id not in seen:
-                    seen.add(role_id)
-                    resolved.append(role_id)
+            for identifier in category_group.ids:
+                if identifier not in seen:
+                    seen.add(identifier)
+                    resolved.append(identifier)
             continue
 
         console.print(
-            f"[red]Unknown role, abbreviation, or category token: '{raw}'[/red]"
+            f"[red]Unknown {entity_label}, abbreviation, or category token: "
+            f"'{raw}'[/red]"
         )
         raise typer.Exit(1)
 
@@ -411,13 +418,8 @@ def _bundle_loop_prompts(
     sections.append("---")
     sections.append("")
 
-    for idx, (_loop_id, prompt) in enumerate(prompts, start=1):
-        if idx > 1:
-            sections.append("")
-            sections.append("---")
-            sections.append("")
-        sections.append(prompt)
-
+    body = "\n\n---\n\n".join(prompt for _loop_id, prompt in prompts)
+    sections.extend(["", "---", "", body])
     return "\n".join(sections)
 
 
@@ -530,6 +532,8 @@ def generate(
 
         loop_catalog = _build_loop_catalog(compiler)
         role_catalog = _build_role_catalog(compiler, spec_dir)
+        _warn_duplicate_abbreviations("loop", loop_catalog.duplicate_abbreviations)
+        _warn_duplicate_abbreviations("role", role_catalog.duplicate_abbreviations)
 
         # Interactive mode if no loops or roles specified
         if not loop and not role:
@@ -608,8 +612,8 @@ def generate(
                     standalone = standalone_choice
 
         # Resolve requested IDs (abbreviations/categories supported)
-        loop_ids = _resolve_loop_ids(loop or [], loop_catalog)
-        role_ids = _resolve_role_ids(role or [], role_catalog)
+        loop_ids = _resolve_ids(loop or [], loop_catalog, "loop")
+        role_ids = _resolve_ids(role or [], role_catalog, "role")
 
         # Initialize assembler
         resolver = ReferenceResolver(compiler.primitives, spec_dir)
@@ -687,6 +691,7 @@ def list_loops(
         compiler.load_all_primitives()
 
         catalog = _build_loop_catalog(compiler)
+        _warn_duplicate_abbreviations("loop", catalog.duplicate_abbreviations)
 
         if not catalog.items:
             console.print("[yellow]No loops found[/yellow]")
@@ -735,6 +740,7 @@ def list_roles(
         compiler.load_all_primitives()
 
         catalog = _build_role_catalog(compiler, spec_dir)
+        _warn_duplicate_abbreviations("role", catalog.duplicate_abbreviations)
 
         if not catalog.items:
             console.print("[yellow]No roles found[/yellow]")

--- a/cli/prompt_generator/tests/test_cli.py
+++ b/cli/prompt_generator/tests/test_cli.py
@@ -12,9 +12,9 @@ runner = CliRunner()
 
 def _prepare_spec_dir(tmp_path: Path) -> Path:
     spec_root = tmp_path / "spec"
-    (spec_root / "05-behavior").mkdir(parents=True)
+    (spec_root / "05-behavior").mkdir(parents=True, exist_ok=True)
     role_index_dir = spec_root / "00-north-star"
-    role_index_dir.mkdir(parents=True)
+    role_index_dir.mkdir(parents=True, exist_ok=True)
     (role_index_dir / "ROLE_INDEX.md").write_text(
         """## Always On
 
@@ -36,6 +36,9 @@ def _prepare_spec_dir(tmp_path: Path) -> Path:
 
 def _stub_compiler_stack(monkeypatch):
     class StubCompiler:
+        duplicate_loop_abbreviations = False
+        duplicate_role_abbreviations = False
+
         def __init__(self, spec_dir: Path):
             self.spec_dir = spec_dir
             self.primitives: dict[str, object] = {}
@@ -46,7 +49,7 @@ def _stub_compiler_stack(monkeypatch):
             ) -> SimpleNamespace:
                 return SimpleNamespace(id=prim_id, metadata=metadata)
 
-            self.primitives = {
+            primitives: dict[str, object] = {
                 "playbook:lore_deepening": _primitive(
                     "lore_deepening",
                     {
@@ -83,6 +86,29 @@ def _stub_compiler_stack(monkeypatch):
                 ),
             }
 
+            if type(self).duplicate_loop_abbreviations:
+                primitives["playbook:lore_dynamo"] = _primitive(
+                    "lore_dynamo",
+                    {
+                        "playbook_name": "Lore Dynamo",
+                        "abbreviation": "L-D",
+                        "category": "Discovery",
+                        "purpose": "Variant lore loop",
+                    },
+                )
+
+            if type(self).duplicate_role_abbreviations:
+                primitives["adapter:lore_delegate"] = _primitive(
+                    "lore_delegate",
+                    {
+                        "role_name": "Lore Delegate",
+                        "abbreviation": "LW",
+                        "mission": "Assist canon work",
+                    },
+                )
+
+            self.primitives = primitives
+
     class StubResolver:
         def __init__(self, primitives: dict[str, object], spec_dir: Path):
             self.primitives = primitives
@@ -116,11 +142,11 @@ def _stub_compiler_stack(monkeypatch):
     StubPromptAssembler.calls = []
     StubPromptAssembler.last_call = None
 
-    return StubPromptAssembler
+    return StubPromptAssembler, StubCompiler
 
 
 def test_generate_loop_uses_prompt_assembler(monkeypatch, tmp_path):
-    stub_assembler = _stub_compiler_stack(monkeypatch)
+    stub_assembler, _ = _stub_compiler_stack(monkeypatch)
     spec_root = _prepare_spec_dir(tmp_path)
     output_path = tmp_path / "loop.md"
 
@@ -143,7 +169,7 @@ def test_generate_loop_uses_prompt_assembler(monkeypatch, tmp_path):
 
 
 def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
-    stub_assembler = _stub_compiler_stack(monkeypatch)
+    stub_assembler, _ = _stub_compiler_stack(monkeypatch)
     spec_root = _prepare_spec_dir(tmp_path)
     output_path = tmp_path / "roles.md"
 
@@ -181,7 +207,7 @@ def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
 
 
 def test_generate_loop_bundle_supports_multiple_loops(monkeypatch, tmp_path):
-    stub_assembler = _stub_compiler_stack(monkeypatch)
+    stub_assembler, _ = _stub_compiler_stack(monkeypatch)
     spec_root = _prepare_spec_dir(tmp_path)
     output_path = tmp_path / "bundle.md"
 
@@ -212,7 +238,7 @@ def test_generate_loop_bundle_supports_multiple_loops(monkeypatch, tmp_path):
 
 
 def test_generate_loop_accepts_abbreviation_and_category(monkeypatch, tmp_path):
-    stub_assembler = _stub_compiler_stack(monkeypatch)
+    stub_assembler, _ = _stub_compiler_stack(monkeypatch)
     spec_root = _prepare_spec_dir(tmp_path)
     output_path = tmp_path / "abbr.md"
 
@@ -337,6 +363,40 @@ def test_list_loops_shows_categories(monkeypatch, tmp_path):
 
 def test_list_roles_shows_categories(monkeypatch, tmp_path):
     _stub_compiler_stack(monkeypatch)
+
+
+def test_duplicate_loop_abbreviation_warns(monkeypatch, tmp_path):
+    _, StubCompiler = _stub_compiler_stack(monkeypatch)
+    StubCompiler.duplicate_loop_abbreviations = True
+    spec_root = _prepare_spec_dir(tmp_path)
+
+    try:
+        result = runner.invoke(
+            cli.app,
+            ["list-loops", "--spec-dir", str(spec_root)],
+        )
+    finally:
+        StubCompiler.duplicate_loop_abbreviations = False
+
+    assert result.exit_code == 0, result.output
+    assert "duplicate loop abbreviation" in result.output.lower()
+
+
+def test_duplicate_role_abbreviation_warns(monkeypatch, tmp_path):
+    _, StubCompiler = _stub_compiler_stack(monkeypatch)
+    StubCompiler.duplicate_role_abbreviations = True
+    spec_root = _prepare_spec_dir(tmp_path)
+
+    try:
+        result = runner.invoke(
+            cli.app,
+            ["list-roles", "--spec-dir", str(spec_root)],
+        )
+    finally:
+        StubCompiler.duplicate_role_abbreviations = False
+
+    assert result.exit_code == 0, result.output
+    assert "duplicate role abbreviation" in result.output.lower()
     spec_root = _prepare_spec_dir(tmp_path)
 
     result = runner.invoke(

--- a/cli/prompt_generator/tests/test_cli.py
+++ b/cli/prompt_generator/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the QuestFoundry prompt generator CLI."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
@@ -12,6 +13,24 @@ runner = CliRunner()
 def _prepare_spec_dir(tmp_path: Path) -> Path:
     spec_root = tmp_path / "spec"
     (spec_root / "05-behavior").mkdir(parents=True)
+    role_index_dir = spec_root / "00-north-star"
+    role_index_dir.mkdir(parents=True)
+    (role_index_dir / "ROLE_INDEX.md").write_text(
+        """## Always On
+
+### Showrunner
+
+## Default On (core creative)
+
+### Lore Weaver
+### Plotwright
+
+## Downstream / Consumer Roles
+
+### Player-Narrator (PN)
+""",
+        encoding="utf-8",
+    )
     return spec_root
 
 
@@ -22,9 +41,46 @@ def _stub_compiler_stack(monkeypatch):
             self.primitives: dict[str, object] = {}
 
         def load_all_primitives(self) -> None:  # pragma: no cover - simple stub
+            def _primitive(
+                prim_id: str, metadata: dict[str, object]
+            ) -> SimpleNamespace:
+                return SimpleNamespace(id=prim_id, metadata=metadata)
+
             self.primitives = {
-                "playbook:lore": object(),
-                "adapter:lore_weaver": object(),
+                "playbook:lore_deepening": _primitive(
+                    "lore_deepening",
+                    {
+                        "playbook_name": "Lore Deepening",
+                        "abbreviation": "LD",
+                        "category": "Discovery",
+                        "purpose": "Deepen accepted hooks",
+                    },
+                ),
+                "playbook:hook_harvest": _primitive(
+                    "hook_harvest",
+                    {
+                        "playbook_name": "Hook Harvest",
+                        "abbreviation": "HH",
+                        "category": "Discovery",
+                        "purpose": "Harvest hooks",
+                    },
+                ),
+                "adapter:lore_weaver": _primitive(
+                    "lore_weaver",
+                    {
+                        "role_name": "Lore Weaver",
+                        "abbreviation": "LW",
+                        "mission": "Protect canon",
+                    },
+                ),
+                "adapter:plotwright": _primitive(
+                    "plotwright",
+                    {
+                        "role_name": "Plotwright",
+                        "abbreviation": "PW",
+                        "mission": "Shape topology",
+                    },
+                ),
             }
 
     class StubResolver:
@@ -34,6 +90,7 @@ def _stub_compiler_stack(monkeypatch):
 
     class StubPromptAssembler:
         last_call: tuple | None = None
+        calls: list[tuple] = []
 
         def __init__(self, primitives, resolver, spec_dir):
             self.primitives = primitives
@@ -42,18 +99,22 @@ def _stub_compiler_stack(monkeypatch):
 
         def assemble_web_prompt_for_loop(self, loop_id: str) -> str:
             type(self).last_call = ("loop", loop_id, None)
+            type(self).calls.append(("loop", loop_id, None))
             return f"PROMPT:{loop_id}"
 
         def assemble_web_prompt_for_roles(
             self, role_ids: list[str], standalone: bool
         ) -> str:
             type(self).last_call = ("roles", tuple(role_ids), standalone)
+            type(self).calls.append(("roles", tuple(role_ids), standalone))
             joined = ",".join(role_ids)
             return f"PROMPT:roles:{joined}:{int(standalone)}"
 
     monkeypatch.setattr(cli, "SpecCompiler", StubCompiler)
     monkeypatch.setattr(cli, "ReferenceResolver", StubResolver)
     monkeypatch.setattr(cli, "PromptAssembler", StubPromptAssembler)
+    StubPromptAssembler.calls = []
+    StubPromptAssembler.last_call = None
 
     return StubPromptAssembler
 
@@ -78,7 +139,7 @@ def test_generate_loop_uses_prompt_assembler(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert output_path.read_text(encoding="utf-8") == "PROMPT:lore_deepening"
-    assert stub_assembler.last_call == ("loop", "lore_deepening", None)
+    assert stub_assembler.calls == [("loop", "lore_deepening", None)]
 
 
 def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
@@ -111,6 +172,94 @@ def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
         "roles",
         ("lore_weaver", "plotwright"),
         True,
+    )
+    assert stub_assembler.calls[-1] == (
+        "roles",
+        ("lore_weaver", "plotwright"),
+        True,
+    )
+
+
+def test_generate_loop_bundle_supports_multiple_loops(monkeypatch, tmp_path):
+    stub_assembler = _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+    output_path = tmp_path / "bundle.md"
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "generate",
+            "--loop",
+            "lore_deepening",
+            "--loop",
+            "hook_harvest",
+            "--spec-dir",
+            str(spec_root),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    contents = output_path.read_text(encoding="utf-8")
+    assert "Loop Bundle" in contents
+    assert contents.count("PROMPT:lore_deepening") == 1
+    assert contents.count("PROMPT:hook_harvest") == 1
+    assert stub_assembler.calls == [
+        ("loop", "lore_deepening", None),
+        ("loop", "hook_harvest", None),
+    ]
+
+
+def test_generate_loop_accepts_abbreviation_and_category(monkeypatch, tmp_path):
+    stub_assembler = _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+    output_path = tmp_path / "abbr.md"
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "generate",
+            "--loop",
+            "LD",
+            "--loop",
+            "discovery",
+            "--spec-dir",
+            str(spec_root),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stub_assembler.calls == [
+        ("loop", "lore_deepening", None),
+        ("loop", "hook_harvest", None),
+    ]
+
+
+def test_generate_role_category_shortcut(monkeypatch, tmp_path):
+    _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+    output_path = tmp_path / "roles_by_category.md"
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "generate",
+            "--role",
+            "default",
+            "--spec-dir",
+            str(spec_root),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        output_path.read_text(encoding="utf-8")
+        == "PROMPT:roles:lore_weaver,plotwright:0"
     )
 
 
@@ -168,3 +317,35 @@ def test_resolve_spec_dir_downloads_release(monkeypatch, tmp_path):
     resolved = cli._resolve_spec_dir(None, "release")
 
     assert resolved == release_dir
+
+
+def test_list_loops_shows_categories(monkeypatch, tmp_path):
+    _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+
+    result = runner.invoke(
+        cli.app,
+        ["list-loops", "--spec-dir", str(spec_root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    output_lower = result.output.lower()
+    assert "discovery" in output_lower
+    assert "(token: discovery)" in output_lower
+    assert "[hh] hook harvest" in output_lower
+
+
+def test_list_roles_shows_categories(monkeypatch, tmp_path):
+    _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+
+    result = runner.invoke(
+        cli.app,
+        ["list-roles", "--spec-dir", str(spec_root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    output_lower = result.output.lower()
+    assert "default on (core creative)" in output_lower
+    assert "lore weaver" in output_lower
+    assert "plotwright" in output_lower


### PR DESCRIPTION
## Summary
- allow loop and role flags to accept ids, abbreviations, or category tokens
- support bundling multiple loops plus richer list/interactive output
- document the new behavior and cover it with CLI tests

## Testing
- uv run pytest tests