### PR TITLE
feat(cli,compiler): add prompt profiles

### DIFF
--- a/cli/prompt_generator/README.md
+++ b/cli/prompt_generator/README.md
@@ -141,6 +141,9 @@ Main command to generate prompts.
 - `--role, -r <token>` - Role/adapter identifier. Accepts IDs like
   `lore_weaver`, abbreviations like `LW`, or Role Index categories such as
   `default` or `always`. Repeatable.
+- `--profile <walkthrough|reference|brief>` - Choose the output style. Use
+  `walkthrough` for a controller-centric, step-by-step prompt, `reference`
+  (default) for the full prompt, or `brief` for a condensed summary.
 - `--standalone, -s` - Include all loop procedures for roles
 - `--output, -o <path>` - Output file (default: stdout)
 - `--spec-dir <path>` - Spec root directory (default: `spec/`)
@@ -164,6 +167,9 @@ qf-generate -r lore_weaver -r researcher -o prompt.md
 
 # Role category shortcut (Default On)
 qf-generate -r default -o prompt.md
+
+# Walkthrough controller view
+qf-generate --loop hook_harvest --profile walkthrough -o guided.md
 
 # Standalone role prompt
 qf-generate -r lore_weaver --standalone -o prompt.md
@@ -215,7 +221,23 @@ The tool uses the `questfoundry-compiler` library to:
 2. Parse RACI assignments from `../../spec/01-roles/raci/by_loop.md`
 3. Resolve all `@type:id` references
 4. Assemble content into a single monolithic markdown file
-5. Include safety protocols and validation requirements
+5. Include safety protocols and validation requirements with adaptive snippets
+
+### Interaction Profiles & Controller Blocks
+
+Every generated prompt now includes a controller section tuned to the selected
+`--profile`:
+
+- **walkthrough** — Adds a controller checklist, `➡️` inline callouts that tell
+  the chat agent when to pause for user input, and detailed execution notes.
+- **reference** — Maintains the original full prompt with condensed controller
+  guidance.
+- **brief** — Produces a slim prompt with key roles, procedures, deliverables,
+  and safety highlights for constrained contexts.
+
+Controller blocks summarize activation triggers, required inputs, decision
+gates, and deliverables so the chat agent always knows when to ask the user for
+more data.
 
 The generated prompts are optimized for:
 

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -3,7 +3,7 @@
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 import questfoundry_compiler
 import questionary
@@ -391,7 +391,7 @@ def _resolve_ids(
 
 def _bundle_loop_prompts(
     loop_ids: list[str],
-    assembler: PromptAssembler,
+    assembler: Any,
     catalog: LoopCatalog,
     profile: ProfileMode,
 ) -> str:
@@ -630,7 +630,7 @@ def generate(
 
         # Initialize assembler
         resolver = ReferenceResolver(compiler.primitives, spec_dir)
-        assembler = PromptAssembler(compiler.primitives, resolver, spec_dir)
+        assembler: Any = PromptAssembler(compiler.primitives, resolver, spec_dir)
 
         # Generate prompt
         if loop_ids:

--- a/cli/prompt_generator/src/prompt_generator/cli.py
+++ b/cli/prompt_generator/src/prompt_generator/cli.py
@@ -26,6 +26,7 @@ app = typer.Typer(
 console = Console()
 
 SpecSource = Literal["auto", "bundled", "release"]
+ProfileMode = Literal["walkthrough", "reference", "brief"]
 
 
 def _normalize_identifier_token(value: str) -> str:
@@ -392,10 +393,11 @@ def _bundle_loop_prompts(
     loop_ids: list[str],
     assembler: PromptAssembler,
     catalog: LoopCatalog,
+    profile: ProfileMode,
 ) -> str:
     prompts: list[tuple[str, str]] = []
     for loop_id in loop_ids:
-        prompt = assembler.assemble_web_prompt_for_loop(loop_id)
+        prompt = assembler.assemble_web_prompt_for_loop(loop_id, profile)
         prompts.append((loop_id, prompt.strip()))
 
     if len(prompts) == 1:
@@ -481,6 +483,17 @@ def generate(
             ),
         ),
     ] = "auto",
+    profile: Annotated[
+        ProfileMode,
+        typer.Option(
+            "--profile",
+            case_sensitive=False,
+            help=(
+                "Output style. walkthrough = controller-focused, reference = "
+                "full prompt (default), brief = condensed highlights."
+            ),
+        ),
+    ] = "reference",
     verbose: Annotated[
         bool,
         typer.Option(
@@ -624,7 +637,7 @@ def generate(
             if verbose:
                 console.print("Generating prompt for loops: " + ", ".join(loop_ids))
 
-            prompt = _bundle_loop_prompts(loop_ids, assembler, loop_catalog)
+            prompt = _bundle_loop_prompts(loop_ids, assembler, loop_catalog, profile)
 
         elif role_ids:
             if verbose:
@@ -632,7 +645,9 @@ def generate(
                 if standalone:
                     console.print("(standalone mode: including loop procedures)")
 
-            prompt = assembler.assemble_web_prompt_for_roles(role_ids, standalone)
+            prompt = assembler.assemble_web_prompt_for_roles(
+                role_ids, standalone, profile
+            )
 
         else:
             console.print("[red]Error: No loop or role specified[/red]")

--- a/cli/prompt_generator/tests/test_cli.py
+++ b/cli/prompt_generator/tests/test_cli.py
@@ -123,16 +123,16 @@ def _stub_compiler_stack(monkeypatch):
             self.resolver = resolver
             self.spec_dir = spec_dir
 
-        def assemble_web_prompt_for_loop(self, loop_id: str) -> str:
-            type(self).last_call = ("loop", loop_id, None)
-            type(self).calls.append(("loop", loop_id, None))
+        def assemble_web_prompt_for_loop(self, loop_id: str, profile: str) -> str:
+            type(self).last_call = ("loop", loop_id, profile)
+            type(self).calls.append(("loop", loop_id, profile))
             return f"PROMPT:{loop_id}"
 
         def assemble_web_prompt_for_roles(
-            self, role_ids: list[str], standalone: bool
+            self, role_ids: list[str], standalone: bool, profile: str
         ) -> str:
-            type(self).last_call = ("roles", tuple(role_ids), standalone)
-            type(self).calls.append(("roles", tuple(role_ids), standalone))
+            type(self).last_call = ("roles", tuple(role_ids), standalone, profile)
+            type(self).calls.append(("roles", tuple(role_ids), standalone, profile))
             joined = ",".join(role_ids)
             return f"PROMPT:roles:{joined}:{int(standalone)}"
 
@@ -165,7 +165,28 @@ def test_generate_loop_uses_prompt_assembler(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert output_path.read_text(encoding="utf-8") == "PROMPT:lore_deepening"
-    assert stub_assembler.calls == [("loop", "lore_deepening", None)]
+    assert stub_assembler.calls == [("loop", "lore_deepening", "reference")]
+
+
+def test_generate_loop_honors_profile(monkeypatch, tmp_path):
+    stub_assembler, _ = _stub_compiler_stack(monkeypatch)
+    spec_root = _prepare_spec_dir(tmp_path)
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "generate",
+            "--loop",
+            "lore_deepening",
+            "--profile",
+            "walkthrough",
+            "--spec-dir",
+            str(spec_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert stub_assembler.calls == [("loop", "lore_deepening", "walkthrough")]
 
 
 def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
@@ -194,16 +215,9 @@ def test_generate_roles_honors_standalone(monkeypatch, tmp_path):
         output_path.read_text(encoding="utf-8")
         == "PROMPT:roles:lore_weaver,plotwright:1"
     )
-    assert stub_assembler.last_call == (
-        "roles",
-        ("lore_weaver", "plotwright"),
-        True,
-    )
-    assert stub_assembler.calls[-1] == (
-        "roles",
-        ("lore_weaver", "plotwright"),
-        True,
-    )
+    expected_call = ("roles", ("lore_weaver", "plotwright"), True, "reference")
+    assert stub_assembler.last_call == expected_call
+    assert stub_assembler.calls[-1] == expected_call
 
 
 def test_generate_loop_bundle_supports_multiple_loops(monkeypatch, tmp_path):
@@ -232,8 +246,8 @@ def test_generate_loop_bundle_supports_multiple_loops(monkeypatch, tmp_path):
     assert contents.count("PROMPT:lore_deepening") == 1
     assert contents.count("PROMPT:hook_harvest") == 1
     assert stub_assembler.calls == [
-        ("loop", "lore_deepening", None),
-        ("loop", "hook_harvest", None),
+        ("loop", "lore_deepening", "reference"),
+        ("loop", "hook_harvest", "reference"),
     ]
 
 
@@ -259,8 +273,8 @@ def test_generate_loop_accepts_abbreviation_and_category(monkeypatch, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert stub_assembler.calls == [
-        ("loop", "lore_deepening", None),
-        ("loop", "hook_harvest", None),
+        ("loop", "lore_deepening", "reference"),
+        ("loop", "hook_harvest", "reference"),
     ]
 
 

--- a/lib/compiler/src/questfoundry_compiler/assemblers.py
+++ b/lib/compiler/src/questfoundry_compiler/assemblers.py
@@ -2,8 +2,11 @@
 
 import re
 from pathlib import Path
+from typing import Any, Literal, cast
 
 from questfoundry_compiler.types import BehaviorPrimitive, CompilationError
+
+ProfileType = Literal["walkthrough", "reference", "brief"]
 
 
 class ReferenceResolver:
@@ -157,6 +160,7 @@ class StandalonePromptAssembler:
         self.primitives = primitives
         self.resolver = resolver
         self.spec_root = Path(spec_root)
+        self._role_category_cache: dict[str, str] | None = None
 
     def assemble_role_prompt(self, adapter_id: str) -> str:
         """Assemble complete standalone prompt for a role.
@@ -430,7 +434,211 @@ class PromptAssembler:
             return match.group(2)
         return None
 
-    def assemble_web_prompt_for_loop(self, playbook_id: str) -> str:
+    def _load_role_categories(self) -> dict[str, str]:
+        """Load role categories from ROLE_INDEX.md (Layer 0)."""
+
+        cache = getattr(self, "_role_category_cache", None)
+        if cache is not None:
+            return cache
+
+        role_index = self.spec_root / "00-north-star" / "ROLE_INDEX.md"
+        categories: dict[str, str] = {}
+        if role_index.exists():
+            current_category: str | None = None
+            for raw_line in role_index.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if line.startswith("## "):
+                    current_category = line[3:].strip()
+                    continue
+                if line.startswith("### ") and current_category:
+                    role_name = line[4:].strip()
+                    if not role_name:
+                        continue
+                    role_name = role_name.split("(")[0].strip()
+                    categories[role_name] = current_category
+
+        self._role_category_cache = categories
+        return categories
+
+    def _get_role_category(self, role_name: str) -> str:
+        return self._load_role_categories().get(role_name, "Uncategorized")
+
+    def _collect_role_safety_snippets(self, role_ids: set[str]) -> list[str]:
+        """Gather safety snippets referenced by participating roles."""
+
+        snippets: list[str] = []
+        seen: set[str] = set()
+        for role_id in role_ids:
+            adapter = self.primitives.get(f"adapter:{role_id}")
+            if not adapter:
+                continue
+            for snippet_ref in adapter.metadata.get("safety_protocols", []) or []:
+                if snippet_ref not in seen:
+                    seen.add(snippet_ref)
+                    snippets.append(snippet_ref)
+        return snippets
+
+    def _normalize_profile(self, profile: ProfileType | str | None) -> ProfileType:
+        if isinstance(profile, str):
+            lowered = profile.lower()
+            if lowered in {"walkthrough", "brief"}:
+                return cast(ProfileType, lowered)
+        return "reference"
+
+    def _build_loop_controller_block(
+        self,
+        playbook_name: str,
+        data: dict[str, Any],
+        raci_roles: dict[str, list[str]],
+        profile: ProfileType,
+    ) -> list[str]:
+        heading = {
+            "walkthrough": "Controller Checklist",
+            "reference": "Controller Notes",
+            "brief": "Quick Controller",
+        }[profile]
+
+        lines: list[str] = [f"## {heading}", ""]
+
+        responsible = raci_roles.get("R") or []
+        if responsible:
+            lines.append(f"**Primary Owners:** {', '.join(responsible)}")
+            lines.append("")
+
+        activation = data.get("activation_criteria") or {}
+        triggers = activation.get("triggers") or []
+        if triggers:
+            lines.append("**Activation Triggers:**")
+            for trig in triggers:
+                lines.append(f"- {trig}")
+            lines.append("")
+
+        showrunner_decision = activation.get("showrunner_decision")
+        if showrunner_decision:
+            lines.append("> ➡️ Decision Gate: " + showrunner_decision)
+            lines.append("")
+
+        inputs = data.get("inputs") or []
+        if inputs:
+            lines.append("> ➡️ Gather these inputs from the user:")
+            for item in inputs:
+                lines.append(f"> - {item}")
+            lines.append("")
+
+        deliverables = data.get("deliverables") or {}
+        if deliverables:
+            lines.append("**Deliverables to return:**")
+            for name in deliverables.keys():
+                pretty = name.replace("_", " ").title()
+                lines.append(f"- {pretty}")
+            lines.append("")
+
+        if profile == "walkthrough":
+            lines.extend(
+                [
+                    (
+                        "1. Confirm the triggers above are satisfied before "
+                        "opening the TU."
+                    ),
+                    "2. Ask the user for every input listed before Step 1.",
+                    "3. Narrate each step, pausing whenever a ➡️ callout appears.",
+                    (
+                        "4. Close the "
+                        f"{playbook_name} loop with a summary + deliverables."
+                    ),
+                    "",
+                ]
+            )
+        elif profile == "brief":
+            lines.extend(
+                [
+                    "- Confirm scope → gather inputs → act.",
+                    "- Keep narration lightweight; expand only on request.",
+                    "",
+                ]
+            )
+
+        return lines
+
+    def _format_reference_label(self, ref: str) -> str:
+        if ref.startswith("@") and ":" in ref:
+            label = ref.split(":", 1)[1]
+            label = label.replace("@", "").replace("_", " ")
+            return label.replace(".schema.json", " schema").title()
+        return ref
+
+    def _build_step_callouts(self, step_data: dict[str, Any]) -> list[str]:
+        prompts: list[str] = []
+        intents = step_data.get("protocol_intents")
+        if not intents:
+            intents = step_data.get("protocol_intent")
+        if isinstance(intents, str):
+            intents = [intents]
+        if intents:
+            prompts.append("Prepare to send intents: " + ", ".join(intents))
+
+        owner = step_data.get("owner")
+        if isinstance(owner, str):
+            owner_label = owner.split(":")[-1].replace("@adapter", "").replace("_", " ")
+            prompts.append(f"Check in with {owner_label} before continuing.")
+
+        step_name = step_data.get("name")
+        if step_name:
+            prompts.append(f"Confirm '{step_name}' is complete with the user.")
+
+        if not prompts:
+            return []
+
+        return ["> ➡️ " + " ".join(prompts), ""]
+
+    def _build_role_controller_block(
+        self,
+        role_names: list[str],
+        context_requirements: list[str],
+        profile: ProfileType,
+    ) -> list[str]:
+        if not role_names:
+            return []
+
+        heading = {
+            "walkthrough": "Role Controller",
+            "reference": "Controller Notes",
+            "brief": "Quick Controller",
+        }[profile]
+
+        lines = [f"## {heading}", ""]
+        lines.append(f"**Roles Active:** {', '.join(role_names)}")
+        lines.append("")
+
+        if context_requirements:
+            lines.append("> ➡️ Gather or confirm these before acting:")
+            for item in context_requirements:
+                lines.append(f"> - {item}")
+            lines.append("")
+
+        if profile == "walkthrough":
+            lines.extend(
+                [
+                    "1. Ask the user which role should take point first.",
+                    "2. Before switching roles, summarize current findings.",
+                    "3. Escalate any blockers immediately with a chat ping.",
+                    "",
+                ]
+            )
+        elif profile == "brief":
+            lines.extend(
+                [
+                    "- Stay high level; only dive when asked.",
+                    "- Remind the user which role is speaking when tone changes.",
+                    "",
+                ]
+            )
+
+        return lines
+
+    def assemble_web_prompt_for_loop(
+        self, playbook_id: str, profile: ProfileType = "reference"
+    ) -> str:
         """Assemble complete web prompt for a specific loop.
 
         This creates a monolithic prompt suitable for web agent simulation,
@@ -446,6 +654,8 @@ class PromptAssembler:
         Raises:
             CompilationError: If assembly fails
         """
+        profile = self._normalize_profile(profile)
+
         playbook = self.primitives.get(f"playbook:{playbook_id}")
         if not playbook:
             raise CompilationError(f"Playbook not found: id='{playbook_id}'")
@@ -453,41 +663,10 @@ class PromptAssembler:
         data = playbook.metadata
         playbook_name = data.get("playbook_name", playbook_id)
 
-        sections = []
-
-        # Header
-        sections.append(f"# QuestFoundry Web Agent Prompt: {playbook_name}")
-        sections.append("")
-        sections.append(
-            "**Purpose:** This prompt enables a web agent (LLM) to simulate "
-            "the entire QuestFoundry studio executing the "
-            f"{playbook_name} loop."
-        )
-        sections.append("")
-        sections.append("**Target:** GPT-4+, Claude Sonnet 3.5+, Gemini 1.5 Pro+")
-        sections.append("")
-        sections.append("---")
-        sections.append("")
-
-        # Overview
-        sections.append("## Loop Overview")
-        sections.append("")
-        sections.append(f"**Loop:** {playbook_name}")
-        if "category" in data:
-            sections.append(f"**Category:** {data['category']}")
-        if "purpose" in data:
-            sections.append(f"**Purpose:** {data['purpose']}")
-        if "outcome" in data:
-            sections.append(f"**Expected Outcome:** {data['outcome']}")
-        sections.append("")
-        sections.append("---")
-        sections.append("")
-
         # Get RACI from by_loop.md
         try:
             raci_roles = self._parse_raci_from_markdown(playbook_name)
         except CompilationError:
-            # Fall back to RACI from playbook YAML
             raci_roles = {"R": [], "A": [], "C": [], "I": []}
             if "raci" in data:
                 for role_type_key, role_type_val in [
@@ -508,6 +687,42 @@ class PromptAssembler:
         for role_list in raci_roles.values():
             all_roles.update(role_list)
 
+        sections = []
+
+        # Header
+        sections.append(f"# QuestFoundry Web Agent Prompt: {playbook_name}")
+        sections.append("")
+        sections.append(
+            "**Purpose:** This prompt enables a web agent (LLM) to simulate "
+            "the entire QuestFoundry studio executing the "
+            f"{playbook_name} loop."
+        )
+        sections.append("")
+        controller = self._build_loop_controller_block(
+            playbook_name, data, raci_roles, profile
+        )
+        if controller:
+            sections.extend(controller)
+            sections.append("")
+        sections.append("**Target:** GPT-4+, Claude Sonnet 3.5+, Gemini 1.5 Pro+")
+        sections.append("")
+        sections.append("---")
+        sections.append("")
+
+        # Overview
+        sections.append("## Loop Overview")
+        sections.append("")
+        sections.append(f"**Loop:** {playbook_name}")
+        if "category" in data:
+            sections.append(f"**Category:** {data['category']}")
+        if "purpose" in data:
+            sections.append(f"**Purpose:** {data['purpose']}")
+        if "outcome" in data:
+            sections.append(f"**Expected Outcome:** {data['outcome']}")
+        sections.append("")
+        sections.append("---")
+        sections.append("")
+
         # RACI Matrix
         sections.append("## RACI Matrix")
         sections.append("")
@@ -523,98 +738,121 @@ class PromptAssembler:
         sections.append("---")
         sections.append("")
 
-        # Always include Showrunner expertise first
-        sections.append("## Showrunner Expertise")
-        sections.append("")
-        sections.append(
-            "*The Showrunner orchestrates the loop and coordinates all roles.*"
-        )
-        sections.append("")
-        try:
-            showrunner_expertise = self.resolver.resolve_reference(
-                "@expertise:showrunner_expertise", inline_content=True
+        include_role_details = profile != "brief"
+        if include_role_details:
+            sections.append("## Showrunner Expertise")
+            sections.append("")
+            sections.append(
+                "*The Showrunner orchestrates the loop and coordinates all roles.*"
             )
-            sections.append(showrunner_expertise)
-        except CompilationError:
-            sections.append("<!-- Showrunner expertise not found -->")
-        sections.append("")
-        sections.append("---")
-        sections.append("")
-
-        # Role Expertises
-        sections.append("## Role Expertises")
-        sections.append("")
-        for role_id in sorted(all_roles):
-            if role_id == "showrunner":
-                continue  # Already included above
-
-            adapter = self.primitives.get(f"adapter:{role_id}")
-            if not adapter:
-                continue
-
-            adapter_data = adapter.metadata
-            role_name = adapter_data.get("role_name", role_id)
-
-            sections.append(f"### {role_name}")
+            sections.append("")
+            try:
+                showrunner_expertise = self.resolver.resolve_reference(
+                    "@expertise:showrunner_expertise", inline_content=True
+                )
+                sections.append(showrunner_expertise)
+            except CompilationError:
+                sections.append("<!-- Showrunner expertise not found -->")
+            sections.append("")
+            sections.append("---")
             sections.append("")
 
-            if "mission" in adapter_data:
-                sections.append(f"**Mission:** {adapter_data['mission']}")
+            sections.append("## Role Expertises")
+            sections.append("")
+            for role_id in sorted(all_roles):
+                if role_id == "showrunner":
+                    continue  # Already included above
+
+                adapter = self.primitives.get(f"adapter:{role_id}")
+                if not adapter:
+                    continue
+
+                adapter_data = adapter.metadata
+                role_name = adapter_data.get("role_name", role_id)
+
+                sections.append(f"### {role_name}")
                 sections.append("")
 
-            # Include expertise
-            if "expertise" in adapter_data:
-                try:
-                    expertise_content = self.resolver.resolve_reference(
-                        adapter_data["expertise"], inline_content=True
-                    )
-                    sections.append(expertise_content)
-                    sections.append("")
-                except CompilationError:
-                    sections.append("<!-- Expertise not found -->")
+                if "mission" in adapter_data:
+                    sections.append(f"**Mission:** {adapter_data['mission']}")
                     sections.append("")
 
-        sections.append("---")
-        sections.append("")
+                if "expertise" in adapter_data:
+                    try:
+                        expertise_content = self.resolver.resolve_reference(
+                            adapter_data["expertise"], inline_content=True
+                        )
+                        sections.append(expertise_content)
+                        sections.append("")
+                    except CompilationError:
+                        sections.append("<!-- Expertise not found -->")
+                        sections.append("")
+
+            sections.append("---")
+            sections.append("")
+        else:
+            sections.append("## Key Roles")
+            sections.append("")
+            for role_id in sorted(all_roles):
+                adapter = self.primitives.get(f"adapter:{role_id}")
+                if not adapter:
+                    continue
+                role_name = adapter.metadata.get("role_name", role_id)
+                category = self._get_role_category(role_name)
+                sections.append(f"- {role_name} — {category}")
+            sections.append("")
+            sections.append("---")
+            sections.append("")
 
         # Primary Procedures
-        sections.append("## Primary Procedures")
-        sections.append("")
-        sections.append(
-            f"*These are the core procedures for the {playbook_name} loop.*"
-        )
-        sections.append("")
-
         if "procedures" in data and "primary" in data["procedures"]:
-            for proc_ref in data["procedures"]["primary"]:
-                try:
-                    proc_content = self.resolver.resolve_reference(
-                        proc_ref, inline_content=True
-                    )
-                    sections.append(proc_content)
-                    sections.append("")
-                except CompilationError:
-                    sections.append(f"<!-- Error loading procedure {proc_ref} -->")
-                    sections.append("")
+            sections.append("## Primary Procedures")
+            sections.append("")
+            sections.append(
+                f"*These are the core procedures for the {playbook_name} loop.*"
+            )
+            sections.append("")
 
-        sections.append("---")
-        sections.append("")
+            for proc_ref in data["procedures"]["primary"]:
+                if profile == "brief":
+                    label = self._format_reference_label(proc_ref)
+                    sections.append(f"- {label}")
+                else:
+                    try:
+                        proc_content = self.resolver.resolve_reference(
+                            proc_ref, inline_content=True
+                        )
+                        sections.append(proc_content)
+                        sections.append("")
+                    except CompilationError:
+                        sections.append(f"<!-- Error loading procedure {proc_ref} -->")
+                        sections.append("")
+
+            if profile == "brief":
+                sections.append("")
+            sections.append("---")
+            sections.append("")
 
         # Supporting Procedures
         if "procedures" in data and "supporting" in data["procedures"]:
             sections.append("## Supporting Procedures")
             sections.append("")
             for proc_ref in data["procedures"]["supporting"]:
-                try:
-                    proc_content = self.resolver.resolve_reference(
-                        proc_ref, inline_content=True
-                    )
-                    sections.append(proc_content)
-                    sections.append("")
-                except CompilationError:
-                    sections.append(f"<!-- Error loading procedure {proc_ref} -->")
-                    sections.append("")
+                if profile == "brief":
+                    sections.append(f"- {self._format_reference_label(proc_ref)}")
+                else:
+                    try:
+                        proc_content = self.resolver.resolve_reference(
+                            proc_ref, inline_content=True
+                        )
+                        sections.append(proc_content)
+                        sections.append("")
+                    except CompilationError:
+                        sections.append(f"<!-- Error loading procedure {proc_ref} -->")
+                        sections.append("")
 
+            if profile == "brief":
+                sections.append("")
             sections.append("---")
             sections.append("")
 
@@ -638,20 +876,34 @@ class PromptAssembler:
                 sections.append(f"<!-- Error loading validation requirements: {e} -->")
                 sections.append("")
 
-        # Add common safety snippets
-        common_snippets = [
+        snippet_refs = [
             "@snippet:spoiler_hygiene_check",
             "@snippet:pn_safety_warning",
         ]
-        for snippet_ref in common_snippets:
-            try:
-                snippet_content = self.resolver.resolve_reference(
-                    snippet_ref, inline_content=True
-                )
-                sections.append(snippet_content)
-                sections.append("")
-            except CompilationError:
-                pass  # Snippet may not exist
+        snippet_refs.extend(self._collect_role_safety_snippets(all_roles))
+
+        deduped: list[str] = []
+        seen_snippets: set[str] = set()
+        for ref in snippet_refs:
+            if ref and ref not in seen_snippets:
+                seen_snippets.add(ref)
+                deduped.append(ref)
+
+        for snippet_ref in deduped:
+            if profile == "brief":
+                sections.append(f"- {self._format_reference_label(snippet_ref)}")
+            else:
+                try:
+                    snippet_content = self.resolver.resolve_reference(
+                        snippet_ref, inline_content=True
+                    )
+                    sections.append(snippet_content)
+                    sections.append("")
+                except CompilationError:
+                    pass
+
+        if profile == "brief" and deduped:
+            sections.append("")
 
         sections.append("---")
         sections.append("")
@@ -666,12 +918,19 @@ class PromptAssembler:
                 owner = step_data.get("owner", "?")
                 action = step_data.get("action", "")
 
-                sections.append(f"### Step {step_num}: {step_name}")
-                sections.append("")
-                sections.append(f"**Owner:** {owner}")
-                if action:
-                    sections.append(f"**Action:** {action}")
-                sections.append("")
+                if profile == "brief":
+                    summary = f"- Step {step_num}: {step_name} (Owner: {owner})"
+                    sections.append(summary)
+                else:
+                    sections.append(f"### Step {step_num}: {step_name}")
+                    sections.append("")
+                    sections.append(f"**Owner:** {owner}")
+                    if action:
+                        sections.append(f"**Action:** {action}")
+                    sections.append("")
+                    if profile == "walkthrough":
+                        callouts = self._build_step_callouts(step_data)
+                        sections.extend(callouts)
 
             sections.append("---")
             sections.append("")
@@ -691,50 +950,75 @@ class PromptAssembler:
         # Footer
         sections.append("## Usage Instructions")
         sections.append("")
-        sections.append(
-            "1. You are simulating the entire QuestFoundry studio in this chat."
-        )
-        sections.append(
-            f"2. The Customer will provide inputs to start the {playbook_name} loop."
-        )
-        sections.append(
-            "3. Act as the Showrunner to coordinate all roles (LW, SR, etc.)."
-        )
-        sections.append(
-            "4. Follow the procedures and steps outlined above in sequence."
-        )
-        sections.append(
-            "5. Produce artifacts matching the referenced schemas where applicable."
-        )
-        sections.append("6. Respect all safety protocols and quality bars.")
+        if profile == "walkthrough":
+            sections.append(
+                "1. Confirm activation triggers and gather inputs listed in the"
+                " controller section."
+            )
+            sections.append("2. Narrate each execution step and wait for user cues.")
+            sections.append(
+                "3. Pause at every ➡️ callout to collect data or confirm decisions."
+            )
+            sections.append(
+                "4. Summarize loop outcomes and deliverables before closing the TU."
+            )
+        elif profile == "brief":
+            sections.append("- Run this loop quickly: confirm scope → act → report.")
+            sections.append(
+                "- Reference full procedures only if the user asks for detail."
+            )
+            sections.append("- Always restate risks and safety notes at handoff.")
+        else:
+            sections.append(
+                "1. You are simulating the entire QuestFoundry studio in this chat."
+            )
+            sections.append(
+                "2. The Customer will provide inputs to start the "
+                f"{playbook_name} loop."
+            )
+            sections.append(
+                "3. Act as the Showrunner to coordinate all roles (LW, SR, etc.)."
+            )
+            sections.append(
+                "4. Follow the procedures and steps outlined above in sequence."
+            )
+            sections.append(
+                "5. Produce artifacts matching the referenced schemas where applicable."
+            )
+            sections.append("6. Respect all safety protocols and quality bars.")
         sections.append("")
 
         return "\n".join(sections)
 
     def assemble_web_prompt_for_roles(
-        self, role_ids: list[str], standalone: bool = False
+        self,
+        role_ids: list[str],
+        standalone: bool = False,
+        profile: ProfileType = "reference",
     ) -> str:
-        """Assemble complete web prompt for specific roles.
+        """Assemble complete web prompt for specific roles."""
 
-        Args:
-            role_ids: List of adapter IDs (e.g., ['lore_weaver', 'plotwright'])
-            standalone: If True, include all procedures from loops these roles
-                       participate in
+        profile = self._normalize_profile(profile)
+        sections: list[str] = []
 
-        Returns:
-            Complete assembled markdown prompt
-
-        Raises:
-            CompilationError: If assembly fails
-        """
-        sections = []
-
-        # Header
-        role_names = []
+        role_names: list[str] = []
+        adapter_entries: list[tuple[str, BehaviorPrimitive | None]] = []
+        aggregated_context: list[str] = []
+        loop_participation: dict[str, list[str]] = {}
         for role_id in role_ids:
             adapter = self.primitives.get(f"adapter:{role_id}")
+            adapter_entries.append((role_id, adapter))
             if adapter:
-                role_names.append(adapter.metadata.get("role_name", role_id))
+                metadata = adapter.metadata
+                role_names.append(metadata.get("role_name", role_id))
+                aggregated_context.extend(
+                    metadata.get("context_requirements", []) or []
+                )
+                for loop_entry in metadata.get("loops", []) or []:
+                    ref = loop_entry.get("playbook")
+                    if isinstance(ref, str) and ":" in ref:
+                        loop_id = ref.split(":", 1)[1]
+                        loop_participation.setdefault(loop_id, []).append(role_id)
             else:
                 role_names.append(role_id)
 
@@ -747,86 +1031,129 @@ class PromptAssembler:
         sections.append("")
         sections.append("**Target:** GPT-4+, Claude Sonnet 3.5+, Gemini 1.5 Pro+")
         sections.append("")
+        controller = self._build_role_controller_block(
+            role_names, aggregated_context, profile
+        )
+        if controller:
+            sections.extend(controller)
+            sections.append("")
         sections.append("---")
         sections.append("")
 
-        # For each role
-        for role_id in role_ids:
-            adapter = self.primitives.get(f"adapter:{role_id}")
-            if not adapter:
-                sections.append(f"<!-- Adapter not found: {role_id} -->")
-                sections.append("")
-                continue
-
-            adapter_data = adapter.metadata
-            role_name = adapter_data.get("role_name", role_id)
-
-            sections.append(f"## {role_name}")
+        if profile == "brief":
+            sections.append("## Role Summaries")
             sections.append("")
-
-            # Mission
-            if "mission" in adapter_data:
-                sections.append(f"**Mission:** {adapter_data['mission']}")
-                sections.append("")
-
-            # Expertise
-            if "expertise" in adapter_data:
-                sections.append("### Expertise")
-                sections.append("")
-                try:
-                    expertise_content = self.resolver.resolve_reference(
-                        adapter_data["expertise"], inline_content=True
-                    )
-                    sections.append(expertise_content)
+            for role_id, adapter in adapter_entries:
+                if not adapter:
+                    sections.append(f"- {role_id}: unavailable")
+                    continue
+                adapter_data = adapter.metadata
+                role_name = adapter_data.get("role_name", role_id)
+                mission = adapter_data.get("mission", "See expertise notes.")
+                sections.append(f"- **{role_name}:** {mission}")
+            sections.append("")
+            sections.append("---")
+            sections.append("")
+        else:
+            seen_snippets: set[str] = set()
+            for role_id, adapter in adapter_entries:
+                if not adapter:
+                    sections.append(f"<!-- Adapter not found: {role_id} -->")
                     sections.append("")
-                except CompilationError:
-                    sections.append("<!-- Expertise not found -->")
+                    continue
+
+                adapter_data = adapter.metadata
+                role_name = adapter_data.get("role_name", role_id)
+
+                sections.append(f"## {role_name}")
+                sections.append("")
+
+                if "mission" in adapter_data:
+                    sections.append(f"**Mission:** {adapter_data['mission']}")
                     sections.append("")
 
-            # Primary Procedures
-            if "procedures" in adapter_data and "primary" in adapter_data["procedures"]:
-                sections.append("### Primary Procedures")
-                sections.append("")
-                for proc_ref in adapter_data["procedures"]["primary"]:
+                if "expertise" in adapter_data:
+                    sections.append("### Expertise")
+                    sections.append("")
                     try:
-                        proc_content = self.resolver.resolve_reference(
-                            proc_ref, inline_content=True
+                        expertise_content = self.resolver.resolve_reference(
+                            adapter_data["expertise"], inline_content=True
                         )
-                        sections.append(proc_content)
+                        sections.append(expertise_content)
                         sections.append("")
                     except CompilationError:
-                        sections.append(f"<!-- Error loading procedure {proc_ref} -->")
+                        sections.append("<!-- Expertise not found -->")
                         sections.append("")
 
-            # Loop Participation
-            if "loops" in adapter_data:
-                sections.append("### Loop Participation")
-                sections.append("")
-                for loop in adapter_data["loops"]:
-                    playbook_ref = loop.get("playbook", "")
-                    raci = loop.get("raci", "")
-                    desc = loop.get("description", "")
+                if "procedures" in adapter_data:
+                    if "primary" in adapter_data["procedures"]:
+                        sections.append("### Primary Procedures")
+                        sections.append("")
+                        for proc_ref in adapter_data["procedures"]["primary"]:
+                            try:
+                                proc_content = self.resolver.resolve_reference(
+                                    proc_ref, inline_content=True
+                                )
+                                sections.append(proc_content)
+                                sections.append("")
+                            except CompilationError:
+                                sections.append(
+                                    f"<!-- Error loading procedure {proc_ref} -->"
+                                )
+                                sections.append("")
+                    if "supporting" in adapter_data["procedures"]:
+                        sections.append("### Supporting Procedures")
+                        sections.append("")
+                        for proc_ref in adapter_data["procedures"]["supporting"]:
+                            try:
+                                proc_content = self.resolver.resolve_reference(
+                                    proc_ref, inline_content=True
+                                )
+                                sections.append(proc_content)
+                                sections.append("")
+                            except CompilationError:
+                                sections.append(
+                                    f"<!-- Error loading procedure {proc_ref} -->"
+                                )
+                                sections.append("")
 
-                    # Extract playbook ID
-                    playbook_id = self._get_adapter_id_from_ref(playbook_ref)
-                    if not playbook_id:
-                        # Try direct extraction
-                        match = self.resolver.reference_pattern.match(playbook_ref)
-                        if match:
-                            playbook_id = match.group(2)
-
-                    sections.append(f"**{playbook_id}** ({raci})")
-                    if desc:
-                        sections.append(f": {desc}")
+                if "protocol_intents" in adapter_data:
+                    sections.append("### Protocol Intents")
                     sections.append("")
+                    if "receives" in adapter_data["protocol_intents"]:
+                        sections.append("**Receives:**")
+                        for intent in adapter_data["protocol_intents"]["receives"]:
+                            sections.append(f"- {intent}")
+                        sections.append("")
+                    if "sends" in adapter_data["protocol_intents"]:
+                        sections.append("**Sends:**")
+                        for intent in adapter_data["protocol_intents"]["sends"]:
+                            sections.append(f"- {intent}")
+                        sections.append("")
 
-                    # If standalone mode, include procedures from this loop
-                    if standalone and playbook_id:
-                        playbook = self.primitives.get(f"playbook:{playbook_id}")
-                        if playbook:
-                            playbook_data = playbook.metadata
-                            if "procedures" in playbook_data:
-                                if "primary" in playbook_data["procedures"]:
+                if "loops" in adapter_data:
+                    sections.append("### Loop Participation")
+                    sections.append("")
+                    for loop_info in adapter_data["loops"]:
+                        playbook_ref = loop_info.get("playbook")
+                        raci = loop_info.get("raci", "?")
+                        desc = loop_info.get("description", "")
+                        playbook_id = None
+                        if isinstance(playbook_ref, str):
+                            playbook_id = playbook_ref.split(":", 1)[1]
+                        sections.append(f"- **{playbook_id}** ({raci})")
+                        if desc:
+                            sections.append(f": {desc}")
+                        sections.append("")
+
+                        if standalone and playbook_id:
+                            playbook = self.primitives.get(f"playbook:{playbook_id}")
+                            if playbook:
+                                playbook_data = playbook.metadata
+                                if (
+                                    "procedures" in playbook_data
+                                    and "primary" in playbook_data["procedures"]
+                                ):
                                     sections.append(f"*Procedures from {playbook_id}:*")
                                     sections.append("")
                                     for proc_ref in playbook_data["procedures"][
@@ -841,40 +1168,78 @@ class PromptAssembler:
                                             sections.append(proc_content)
                                             sections.append("")
                                         except CompilationError:
-                                            # Procedure not found or failed to resolve
                                             pass
 
-            # Safety Protocols
-            if "safety_protocols" in adapter_data:
-                sections.append("### Safety Protocols")
-                sections.append("")
-                for snippet_ref in adapter_data["safety_protocols"]:
-                    try:
-                        snippet_content = self.resolver.resolve_reference(
-                            snippet_ref, inline_content=True
-                        )
-                        sections.append(snippet_content)
-                        sections.append("")
-                    except CompilationError:
-                        # Safety protocol snippet not found
-                        pass
+                if "safety_protocols" in adapter_data:
+                    sections.append("### Safety Protocols")
+                    sections.append("")
+                    for snippet_ref in adapter_data["safety_protocols"]:
+                        if snippet_ref in seen_snippets:
+                            continue
+                        seen_snippets.add(snippet_ref)
+                        try:
+                            snippet_content = self.resolver.resolve_reference(
+                                snippet_ref, inline_content=True
+                            )
+                            sections.append(snippet_content)
+                            sections.append("")
+                        except CompilationError:
+                            pass
 
+                sections.append("---")
+                sections.append("")
+
+        shared_loops = {
+            loop_id: members
+            for loop_id, members in loop_participation.items()
+            if len(members) > 1
+        }
+        if shared_loops:
+            sections.append("## Cross-Role Coordination")
+            sections.append("")
+            for loop_id, members in sorted(shared_loops.items()):
+                playbook = self.primitives.get(f"playbook:{loop_id}")
+                loop_name = loop_id
+                if playbook:
+                    loop_name = playbook.metadata.get("playbook_name", loop_id)
+                member_names = []
+                for member in members:
+                    adapter = self.primitives.get(f"adapter:{member}")
+                    member_names.append(
+                        adapter.metadata.get("role_name", member) if adapter else member
+                    )
+                sections.append(
+                    f"- **{loop_name}:** coordinate {', '.join(member_names)}"
+                )
+            sections.append("")
             sections.append("---")
             sections.append("")
 
-        # Footer
         sections.append("## Usage Instructions")
         sections.append("")
-        sections.append(
-            "1. You are acting as the specified QuestFoundry role(s) in this chat."
-        )
-        sections.append(
-            "2. Follow the procedures and expertise guidelines outlined above."
-        )
-        sections.append("3. Respect all safety protocols and quality bars.")
-        sections.append(
-            "4. Coordinate with other roles as indicated in loop participation."
-        )
+        if profile == "walkthrough":
+            sections.append("1. Act in-order for each role, pausing for user input.")
+            sections.append(
+                "2. Use the controller callouts to request live context "
+                "before handoffs."
+            )
+            sections.append(
+                "3. Highlight shared loops when coordinating multiple roles."
+            )
+        elif profile == "brief":
+            sections.append("- Summarize missions and ask when to dive deeper.")
+            sections.append("- Keep replies short but enforce safety reminders.")
+        else:
+            sections.append(
+                "1. You are acting as the specified QuestFoundry role(s) in this chat."
+            )
+            sections.append(
+                "2. Follow the procedures and expertise guidelines outlined above."
+            )
+            sections.append("3. Respect all safety protocols and quality bars.")
+            sections.append(
+                "4. Coordinate with other roles as indicated in loop participation."
+            )
         sections.append("")
 
         return "\n".join(sections)

--- a/lib/compiler/src/questfoundry_compiler/assemblers.py
+++ b/lib/compiler/src/questfoundry_compiler/assemblers.py
@@ -160,7 +160,6 @@ class StandalonePromptAssembler:
         self.primitives = primitives
         self.resolver = resolver
         self.spec_root = Path(spec_root)
-        self._role_category_cache: dict[str, str] | None = None
 
     def assemble_role_prompt(self, adapter_id: str) -> str:
         """Assemble complete standalone prompt for a role.
@@ -882,12 +881,7 @@ class PromptAssembler:
         ]
         snippet_refs.extend(self._collect_role_safety_snippets(all_roles))
 
-        deduped: list[str] = []
-        seen_snippets: set[str] = set()
-        for ref in snippet_refs:
-            if ref and ref not in seen_snippets:
-                seen_snippets.add(ref)
-                deduped.append(ref)
+        deduped = list(dict.fromkeys(ref for ref in snippet_refs if ref))
 
         for snippet_ref in deduped:
             if profile == "brief":
@@ -996,7 +990,19 @@ class PromptAssembler:
         standalone: bool = False,
         profile: ProfileType = "reference",
     ) -> str:
-        """Assemble complete web prompt for specific roles."""
+        """Assemble complete web prompt for specific roles.
+
+        Args:
+            role_ids: Adapter IDs (e.g., `['lore_weaver', 'plotwright']`).
+            standalone: Include playbook procedures referenced by the roles.
+            profile: Interaction profile to shape the controller output.
+
+        Returns:
+            Markdown prompt ready for delivery to a chat agent.
+
+        Raises:
+            CompilationError: If any required primitive cannot be resolved.
+        """
 
         profile = self._normalize_profile(profile)
         sections: list[str] = []

--- a/lib/compiler/tests/test_prompt_assembler.py
+++ b/lib/compiler/tests/test_prompt_assembler.py
@@ -1,0 +1,41 @@
+"""Integration tests for PromptAssembler profiles."""
+
+from pathlib import Path
+
+from questfoundry_compiler import PromptAssembler, ReferenceResolver, SpecCompiler
+
+
+def _build_assembler() -> PromptAssembler:
+    spec_dir = Path(__file__).resolve().parents[3] / "spec"
+    compiler = SpecCompiler(spec_dir)
+    compiler.load_all_primitives()
+    resolver = ReferenceResolver(compiler.primitives, spec_dir)
+    return PromptAssembler(compiler.primitives, resolver, spec_dir)
+
+
+def test_loop_walkthrough_profile_has_controller_callouts() -> None:
+    assembler = _build_assembler()
+    prompt = assembler.assemble_web_prompt_for_loop("hook_harvest", "walkthrough")
+
+    assert "Controller Checklist" in prompt
+    assert "➡️" in prompt
+    assert "## Showrunner Expertise" in prompt
+
+
+def test_loop_brief_profile_skips_role_expertises() -> None:
+    assembler = _build_assembler()
+    prompt = assembler.assemble_web_prompt_for_loop("hook_harvest", "brief")
+
+    assert "## Key Roles" in prompt
+    assert "## Showrunner Expertise" not in prompt
+
+
+def test_role_prompt_walkthrough_records_coordination() -> None:
+    assembler = _build_assembler()
+    prompt = assembler.assemble_web_prompt_for_roles(
+        ["plotwright", "scene_smith"], profile="walkthrough"
+    )
+
+    assert "Role Controller" in prompt
+    assert "Cross-Role Coordination" in prompt
+    assert "Story Spark" in prompt

--- a/lib/compiler/uv.lock
+++ b/lib/compiler/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "questfoundry-compiler"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- add a `--profile` flag to qf-generate and expose walkthrough/reference/brief output modes
- enhance PromptAssembler to emit controller sections, adaptive snippets, inline callouts, and role coordination summaries based on profile
- add regression tests + documentation so the new behavior is locked in

## Testing
- uv run pytest tests (cli/prompt_generator)
- uv run pytest tests (lib/compiler)