### PR TITLE
feat(runtime): complete Phase 1 - single agent execution

### DIFF
--- a/docs/design/PHASE1_SINGLE_AGENT.md
+++ b/docs/design/PHASE1_SINGLE_AGENT.md
@@ -1,0 +1,382 @@
+# Phase 1: Single Agent Execution
+
+> **Issue**: #145
+> **Status**: ✅ Complete
+> **Branch**: `epic/phase1-single-agent`
+> **Tests**: 197 passing (110 new for Phase 1)
+
+## Overview
+
+Get a single agent to receive input, process it via LLM, and return a streaming response. Foundation for all agent interactions. Includes session tracking and parallel async support from the start.
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Streaming | From start | Better UX, harder to retrofit |
+| Sessions | From start | Need turn tracking for context |
+| Async | Parallel-ready | Multiple agents can run concurrently |
+| Context overflow | Hard error | Force prompt engineering, no silent truncation |
+| Response format | Free text | Structured output in Phase 2 with tools |
+
+---
+
+## 1. LLM Provider Abstraction
+
+### File Structure
+
+```
+src/questfoundry/runtime/providers/
+├── __init__.py      # ProviderRegistry, get_provider()
+├── base.py          # LLMProvider ABC, LLMMessage, LLMResponse
+├── ollama.py        # OllamaProvider (langchain-ollama)
+├── openai.py        # OpenAIProvider (langchain-openai)
+└── google.py        # GoogleProvider (langchain-google-genai)
+```
+
+### Provider Interface
+
+```python
+class LLMProvider(ABC):
+    """Abstract base for LLM providers."""
+
+    @abstractmethod
+    async def invoke(
+        self,
+        messages: list[LLMMessage],
+        options: InvokeOptions,
+    ) -> LLMResponse:
+        """Send messages and get complete response."""
+
+    @abstractmethod
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        options: InvokeOptions,
+    ) -> AsyncIterator[StreamChunk]:
+        """Stream response chunks."""
+
+    @abstractmethod
+    async def check_availability(self) -> bool:
+        """Check if provider is reachable."""
+
+    @abstractmethod
+    def get_context_size(self, model: str) -> int:
+        """Get context window size for model."""
+```
+
+### Context Size Configuration
+
+Add to `qf.yaml`:
+
+```yaml
+models:
+  creative:
+    ollama: qwen3:8b
+    openai: gpt-4o
+    google: gemini-1.5-pro
+    context_size:
+      ollama: 32768      # qwen3:8b default
+      openai: 128000     # gpt-4o
+      google: 1000000    # gemini-1.5-pro
+```
+
+### Token Counting
+
+```python
+@dataclass
+class TokenUsage:
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+@dataclass
+class LLMResponse:
+    content: str
+    model: str
+    provider: str
+    usage: TokenUsage
+    duration_ms: float
+    raw: Any  # Provider-specific response
+```
+
+### Error Handling
+
+- `ProviderUnavailableError` - Provider not reachable
+- `ContextOverflowError` - Prompt exceeds model context size
+- `ProviderError` - General provider failure
+- Retry 3x with exponential backoff (1s, 2s, 4s)
+
+---
+
+## 2. Session Management
+
+### File Structure
+
+```
+src/questfoundry/runtime/session/
+├── __init__.py      # Exports: Session, Turn
+├── session.py       # Session class
+└── turn.py          # Turn tracking
+```
+
+### Session Model
+
+```python
+@dataclass
+class Session:
+    id: str
+    project_id: str
+    entry_agent: str
+    started_at: datetime
+    status: Literal["active", "completed", "error"]
+    turns: list[Turn]
+
+@dataclass
+class Turn:
+    id: int
+    agent_id: str
+    input: str
+    output: str | None
+    started_at: datetime
+    ended_at: datetime | None
+    usage: TokenUsage | None
+    status: Literal["pending", "streaming", "completed", "error"]
+```
+
+Sessions are stored in project SQLite (tables already exist from Phase 0).
+
+---
+
+## 3. Agent Runtime
+
+### File Structure
+
+```
+src/questfoundry/runtime/agent/
+├── __init__.py      # Exports: AgentRuntime, activate_agent()
+├── runtime.py       # AgentRuntime class
+├── context.py       # ContextBuilder - knowledge injection
+└── prompt.py        # PromptBuilder - system prompt construction
+```
+
+### Agent Activation Flow
+
+```
+1. Load agent definition from Studio
+2. Build context (knowledge injection)
+3. Build system prompt
+4. Validate context size < model limit
+5. Create/update session turn
+6. Stream LLM response
+7. Update turn with result
+```
+
+### Context Builder
+
+Knowledge injection based on agent's `knowledge_requirements`:
+
+```python
+class ContextBuilder:
+    def build(self, agent: Agent, studio: Studio) -> AgentContext:
+        """Build context for agent activation."""
+        context = AgentContext()
+
+        # Constitution (if agent requires)
+        if agent.knowledge_requirements.constitution:
+            context.add_knowledge(studio.constitution, layer="constitution")
+
+        # Must-know entries
+        for entry_id in agent.knowledge_requirements.must_know:
+            entry = studio.get_knowledge(entry_id)
+            context.add_knowledge(entry, layer="must_know")
+
+        # Role-specific entries (include as menu for now)
+        for entry_id in agent.knowledge_requirements.role_specific:
+            entry = studio.get_knowledge(entry_id)
+            context.add_menu_item(entry)
+
+        return context
+```
+
+### Prompt Builder
+
+System prompt structure:
+
+```
+[Agent Identity]
+You are {agent.name}. {agent.description}
+
+[Knowledge - Constitution]
+{constitution.text}
+
+[Knowledge - Must Know]
+{must_know entries}
+
+[Constraints]
+{agent.constraints as bullet points}
+
+[Capabilities]
+{agent.capabilities summary}
+
+[Available Knowledge]
+You can consult: {menu of role_specific entries}
+```
+
+### Context Size Validation
+
+```python
+def validate_context_size(self, messages: list[LLMMessage], model: str) -> None:
+    """Raise ContextOverflowError if prompt exceeds model limit."""
+    total_tokens = self.count_tokens(messages)
+    max_tokens = self.provider.get_context_size(model)
+
+    if total_tokens > max_tokens:
+        raise ContextOverflowError(
+            f"Prompt ({total_tokens} tokens) exceeds model context "
+            f"({max_tokens} tokens). Reduce knowledge or use larger model."
+        )
+```
+
+---
+
+## 4. CLI Commands
+
+### Interactive REPL
+
+```bash
+# Start interactive session (auto-creates 'default' project)
+qf ask
+
+# With specific project
+qf ask my_story
+
+# Output:
+# QuestFoundry Interactive Session
+# Project: my_story
+# Agent: Showrunner (showrunner)
+# Type 'exit' or Ctrl+D to quit
+#
+# > Hello, who are you?
+# [streaming response...]
+```
+
+### Single-Shot
+
+```bash
+# Quick query (auto-creates 'default' project)
+qf ask "Hello, who are you?"
+
+# With specific project
+qf ask my_story "Hello, who are you?"
+
+# Specify entry agent
+qf ask my_story --entry-agent player_narrator "Tell me about this world"
+```
+
+### Verbose Flags
+
+```bash
+# Show token usage after responses
+qf ask -v "Hello"
+
+# Show timing and model info
+qf ask -vv "Hello"
+
+# Show full prompts being sent
+qf ask -vvv "Hello"
+```
+
+### Full Options
+
+```
+qf ask [OPTIONS] [PROJECT] [PROMPT]
+
+Arguments:
+  PROJECT  Project ID (auto-creates 'default' if omitted)
+  PROMPT   Prompt (omit for REPL mode)
+
+Options:
+  -e, --entry-agent TEXT  Entry agent ID
+  -d, --domain PATH       Path to domain directory [default: domain-v4]
+  -p, --projects-dir PATH Projects directory [default: projects]
+  -m, --model TEXT        Model to use
+  -v, --verbose           Increase verbosity (-v: tokens, -vv: timing, -vvv: prompts)
+```
+
+---
+
+## 5. Observability
+
+### Event Logging
+
+JSONL events to `project_dir/logs/events.jsonl`:
+
+```json
+{"event": "session_start", "session_id": "...", "agent": "showrunner", "ts": "..."}
+{"event": "turn_start", "turn_id": 1, "input": "Hello", "ts": "..."}
+{"event": "llm_call", "model": "qwen3:8b", "prompt_tokens": 1234, "ts": "..."}
+{"event": "turn_complete", "turn_id": 1, "completion_tokens": 567, "ts": "..."}
+```
+
+### LangSmith Integration
+
+When `LANGSMITH_TRACING=true`:
+
+```
+Session: my_story/session_abc123
+└── Turn 1
+    └── LLM Call (qwen3:8b)
+        ├── Input: [system, user messages]
+        └── Output: [assistant response]
+```
+
+---
+
+## Implementation Order
+
+| Component | Tests | Status |
+|-----------|-------|--------|
+| Providers (base + ollama + streaming) | 33 | ✅ |
+| Session management | 36 | ✅ |
+| PromptBuilder | 14 | ✅ |
+| ContextBuilder | 10 | ✅ |
+| AgentRuntime | 13 | ✅ |
+| CLI `qf ask` | 10 | ✅ |
+
+**Actual: 110 new tests for Phase 1 (197 total)**
+
+---
+
+## Acceptance Criteria
+
+```bash
+# Interactive REPL
+qf ask --project test_story
+> Hello, who are you?
+# [Streaming response from Showrunner]
+
+# Single-shot
+qf ask --project test_story "What can you help with?"
+# [Streaming response]
+
+# Different entry agent
+qf ask --project test_story --entry-agent player_narrator "Tell me about this world"
+# [Streaming response from Player Narrator]
+
+# Context overflow error
+qf ask --project test_story "..." # with massive prompt
+# Error: Prompt (50000 tokens) exceeds model context (32768 tokens)
+```
+
+---
+
+## Dependencies
+
+- Phase 0 (domain loader, configuration, project storage)
+
+## References
+
+- `domain-v4/agents/showrunner.json` - Example entry agent
+- `domain-v4/knowledge/layers.json` - Knowledge injection rules
+- `domain-v4/governance/constitution.json` - Constitution content

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -6,31 +6,71 @@ Commands:
 - config show: Display resolved configuration
 - roles: List agents with archetypes and capabilities
 - projects: Manage story projects
+- ask: Interactive session with agents
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
+
+if TYPE_CHECKING:
+    from questfoundry.runtime import AgentRuntime
+    from questfoundry.runtime.models import Agent, Studio
+    from questfoundry.runtime.providers import OllamaProvider
+    from questfoundry.runtime.session import Session
+    from questfoundry.runtime.storage import Project
 from rich.console import Console
+from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.table import Table
+
+# Global verbosity level (set by callback)
+_verbosity: int = 0
+
+console = Console()
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Configure logging based on verbosity level."""
+    global _verbosity
+    _verbosity = verbosity
+
+    if verbosity == 0:
+        level = logging.WARNING
+    elif verbosity == 1:
+        level = logging.INFO
+    else:  # 2+
+        level = logging.DEBUG
+
+    # Configure root logger with Rich handler
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(console=console, rich_tracebacks=True, show_path=verbosity >= 2)],
+        force=True,
+    )
+
+    # Also set questfoundry logger
+    logging.getLogger("questfoundry").setLevel(level)
+
+
+def _verbosity_callback(_ctx: typer.Context, value: int) -> int:
+    """Process verbosity level and configure logging."""
+    _configure_logging(value)
+    return value
+
 
 app = typer.Typer(
     name="qf",
     help="QuestFoundry - AI-powered interactive fiction studio",
     no_args_is_help=True,
 )
-console = Console()
-
-
-# Global options
-def verbose_callback(value: int) -> int:
-    """Process verbosity level."""
-    return value
 
 
 # =============================================================================
@@ -215,7 +255,7 @@ async def _roles_async(domain_path: Path) -> None:
 # Projects Subcommand
 # =============================================================================
 
-projects_app = typer.Typer(help="Manage story projects")
+projects_app = typer.Typer(help="Manage story projects", no_args_is_help=True)
 app.add_typer(projects_app, name="projects")
 
 
@@ -292,6 +332,337 @@ def projects_create(
     console.print(f"[green]✓[/green] Created project [bold]{name}[/bold]")
     console.print(f"  Path: {project_path}")
     console.print(f"  Studio: {studio}")
+
+
+# =============================================================================
+# Ask Command - Interactive Session
+# =============================================================================
+
+
+@app.command()
+def ask(
+    project: Annotated[
+        str | None,
+        typer.Argument(help="Project ID (auto-creates 'default' if omitted)"),
+    ] = None,
+    prompt: Annotated[str | None, typer.Argument(help="Prompt (omit for REPL mode)")] = None,
+    entry_agent: Annotated[
+        str | None,
+        typer.Option("--entry-agent", "-e", help="Entry agent ID"),
+    ] = None,
+    domain: Annotated[
+        Path,
+        typer.Option("--domain", "-d", help="Path to domain directory"),
+    ] = Path("domain-v4"),
+    projects_dir: Annotated[
+        Path,
+        typer.Option("--projects-dir", "-p", help="Projects directory"),
+    ] = Path("projects"),
+    model: Annotated[
+        str | None,
+        typer.Option("--model", "-m", help="Model to use"),
+    ] = None,
+    verbose: Annotated[  # noqa: ARG001 - callback sets global _verbosity
+        int,
+        typer.Option(
+            "--verbose",
+            "-v",
+            count=True,
+            help="Increase verbosity (-v: info+tokens, -vv: debug+timing, -vvv: full prompts)",
+            callback=_verbosity_callback,
+        ),
+    ] = 0,
+) -> None:
+    """Interactive session or single-shot query with an agent."""
+    # Auto-create default project if not specified
+    if project is None:
+        project = "default"
+        _ensure_default_project(projects_dir)
+
+    if prompt:
+        asyncio.run(_ask_single(project, prompt, entry_agent, domain, projects_dir, model))
+    else:
+        asyncio.run(_ask_repl(project, entry_agent, domain, projects_dir, model))
+
+
+def _ensure_default_project(projects_dir: Path) -> None:
+    """Create the default project if it doesn't exist."""
+    from questfoundry.runtime.storage import Project
+
+    default_path = projects_dir / "default"
+    if not default_path.exists():
+        console.print("[dim]Creating default project...[/dim]")
+        Project.create(
+            path=default_path,
+            name="Default Project",
+            description="Auto-created default project for quick sessions",
+            studio_id="questfoundry",
+        )
+        console.print("[green]✓[/green] Created default project")
+        console.print()
+
+
+async def _setup_runtime(
+    project_id: str,
+    entry_agent_id: str | None,
+    domain_path: Path,
+    projects_dir: Path,
+    model: str | None,
+) -> tuple[Project, Studio, AgentRuntime, Agent, Session, OllamaProvider]:
+    """
+    Set up the runtime components for an ask session.
+
+    Returns:
+        Tuple of (project, studio, runtime, agent, session, provider)
+    """
+    from questfoundry.runtime import AgentRuntime, load_studio
+    from questfoundry.runtime.config import load_config
+    from questfoundry.runtime.providers import OllamaProvider
+    from questfoundry.runtime.session import Session
+    from questfoundry.runtime.storage import Project
+
+    logger = logging.getLogger("questfoundry.cli")
+
+    # Load configuration
+    logger.debug("Loading configuration...")
+    config = load_config()
+
+    # Load project
+    project_path = projects_dir / project_id
+    logger.debug(f"Opening project at {project_path}")
+    try:
+        project = Project.open(project_path)
+    except FileNotFoundError:
+        console.print(f"[red]✗ Project not found: {project_id}[/red]")
+        console.print(f"[dim]Expected at: {project_path}[/dim]")
+        raise typer.Exit(1) from None
+
+    # Load domain
+    logger.debug(f"Loading domain from {domain_path}")
+    result = await load_studio(domain_path)
+    if not result.success or not result.studio:
+        console.print("[red]✗ Failed to load domain[/red]")
+        for error in result.errors:
+            console.print(f"  [red]• {error.message}[/red]")
+        project.close()
+        raise typer.Exit(1)
+
+    studio: Studio = result.studio
+    logger.info(f"Loaded studio: {studio.name} ({len(studio.agents)} agents)")
+
+    # Get provider and model from config
+    provider_config = config.providers.get(config.default_provider)
+    host: str = (
+        provider_config.host
+        if provider_config and provider_config.host
+        else "http://localhost:11434"
+    )
+    model_to_use: str = model or (
+        provider_config.default_model
+        if provider_config and provider_config.default_model
+        else "qwen3:8b"
+    )
+
+    # Create provider
+    logger.debug(f"Connecting to Ollama at {host}")
+    provider = OllamaProvider(host=host)
+
+    # Check provider availability
+    if not await provider.check_availability():
+        console.print(f"[red]✗ Ollama not available at {host}[/red]")
+        console.print("[dim]Start Ollama with: ollama serve[/dim]")
+        project.close()
+        raise typer.Exit(1)
+
+    logger.info(f"Using model: {model_to_use}")
+
+    # Create runtime
+    runtime = AgentRuntime(
+        provider=provider,
+        studio=studio,
+        domain_path=domain_path,
+        model=model_to_use,
+    )
+
+    # Get entry agent
+    if entry_agent_id:
+        agent = runtime.get_agent(entry_agent_id)
+        if not agent:
+            console.print(f"[red]✗ Agent not found: {entry_agent_id}[/red]")
+            available = [a.id for a in studio.agents]
+            console.print(f"[dim]Available: {', '.join(available)}[/dim]")
+            project.close()
+            raise typer.Exit(1)
+    else:
+        agent = runtime.get_entry_agent()
+        if not agent:
+            console.print("[red]✗ No entry agent defined in studio[/red]")
+            project.close()
+            raise typer.Exit(1)
+
+    logger.info(f"Entry agent: {agent.name} ({agent.id})")
+
+    # Create session
+    session = Session.create(project=project, entry_agent=agent.id)
+    logger.debug(f"Created session: {session.id}")
+
+    return project, studio, runtime, agent, session, provider
+
+
+async def _stream_response(
+    runtime: AgentRuntime, agent: Agent, user_input: str, session: Session
+) -> str:
+    """Stream a response from the agent and return full content."""
+    import time
+
+    from rich.live import Live
+    from rich.text import Text
+
+    logger = logging.getLogger("questfoundry.cli")
+
+    full_content = ""
+    start_time = time.time()
+    final_usage = None
+
+    # Show prompt at -vvv
+    if _verbosity >= 3:
+        context = runtime.build_context(agent)
+        messages = runtime.build_messages(agent, user_input, context)
+        console.print()
+        console.print("[dim]─── Prompt ───[/dim]")
+        for msg in messages:
+            role_color = {"system": "yellow", "user": "green", "assistant": "blue"}.get(
+                msg.role, "white"
+            )
+            console.print(f"[{role_color}]{msg.role}:[/{role_color}]")
+            # Truncate long system prompts
+            content = msg.content
+            if msg.role == "system" and len(content) > 2000:
+                content = content[:2000] + f"\n... ({len(msg.content)} chars total)"
+            console.print(f"[dim]{content}[/dim]")
+            console.print()
+        console.print("[dim]─── Response ───[/dim]")
+
+    with Live(Text(""), console=console, refresh_per_second=10) as live:
+        async for chunk in runtime.activate_streaming(agent, user_input, session):
+            if chunk.done:
+                final_usage = chunk
+            else:
+                full_content += chunk.content
+                live.update(Text(full_content))
+
+    duration_ms = (time.time() - start_time) * 1000
+
+    # Show token usage at -v+
+    if _verbosity >= 1 and final_usage:
+        tokens_info = []
+        if final_usage.prompt_tokens:
+            tokens_info.append(f"prompt: {final_usage.prompt_tokens}")
+        if final_usage.completion_tokens:
+            tokens_info.append(f"completion: {final_usage.completion_tokens}")
+        if final_usage.total_tokens:
+            tokens_info.append(f"total: {final_usage.total_tokens}")
+        if tokens_info:
+            console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
+
+    # Show timing at -vv+
+    if _verbosity >= 2:
+        console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
+        logger.debug(f"Response generated in {duration_ms:.0f}ms")
+
+    return full_content
+
+
+async def _ask_single(
+    project_id: str,
+    prompt: str,
+    entry_agent_id: str | None,
+    domain_path: Path,
+    projects_dir: Path,
+    model: str | None,
+) -> None:
+    """Execute a single-shot query."""
+    from questfoundry.runtime.providers import ContextOverflowError, ProviderError
+
+    project, _studio, runtime, agent, session, provider = await _setup_runtime(
+        project_id, entry_agent_id, domain_path, projects_dir, model
+    )
+
+    try:
+        console.print(f"[dim]{agent.name}:[/dim]")
+        await _stream_response(runtime, agent, prompt, session)
+        console.print()
+    except ContextOverflowError as e:
+        console.print(f"[red]✗ Context overflow: {e}[/red]")
+    except ProviderError as e:
+        console.print(f"[red]✗ Provider error: {e}[/red]")
+    finally:
+        await provider.close()
+        project.close()
+
+
+async def _ask_repl(
+    project_id: str,
+    entry_agent_id: str | None,
+    domain_path: Path,
+    projects_dir: Path,
+    model: str | None,
+) -> None:
+    """Run interactive REPL mode."""
+    from questfoundry.runtime.providers import ContextOverflowError, ProviderError
+
+    project, _studio, runtime, agent, session, provider = await _setup_runtime(
+        project_id, entry_agent_id, domain_path, projects_dir, model
+    )
+
+    # Print header
+    console.print()
+    console.print("[bold]QuestFoundry Interactive Session[/bold]")
+    console.print(f"Project: [cyan]{project_id}[/cyan]")
+    console.print(f"Agent: [green]{agent.name}[/green] ({agent.id})")
+    console.print("[dim]Type 'exit' or Ctrl+D to quit[/dim]")
+    console.print()
+
+    try:
+        while True:
+            try:
+                # Get input
+                user_input = console.input("[bold]> [/bold]")
+
+                # Check for exit
+                if user_input.lower() in ("exit", "quit", "/exit", "/quit"):
+                    break
+
+                if not user_input.strip():
+                    continue
+
+                # Stream response
+                console.print(f"[dim]{agent.name}:[/dim]")
+                await _stream_response(runtime, agent, user_input, session)
+                console.print()
+
+            except ContextOverflowError as e:
+                console.print(f"[red]✗ Context overflow: {e}[/red]")
+                console.print("[dim]Try a shorter message or start a new session[/dim]")
+                console.print()
+            except ProviderError as e:
+                console.print(f"[red]✗ Provider error: {e}[/red]")
+                console.print()
+
+    except (KeyboardInterrupt, EOFError):
+        console.print()
+
+    finally:
+        # Show session summary
+        console.print()
+        console.print(f"[dim]Session ended: {session.turn_count} turns[/dim]")
+        await provider.close()
+        project.close()
+
+
+# =============================================================================
+# Projects Subcommand
+# =============================================================================
 
 
 @projects_app.command("info")

--- a/src/questfoundry/runtime/__init__.py
+++ b/src/questfoundry/runtime/__init__.py
@@ -4,17 +4,40 @@ QuestFoundry Runtime - Domain-agnostic studio execution engine.
 This runtime implements the meta-model contract (meta/schemas/) and can
 execute any studio definition following that schema.
 
-Status: Phase 0 - Foundation (in progress)
+Status: Phase 1 - Single Agent Execution (in progress)
 """
 
+from questfoundry.runtime.agent import (
+    ActivationResult,
+    AgentContext,
+    AgentRuntime,
+    BuiltPrompt,
+    ContextBuilder,
+    PromptBuilder,
+    activate_agent,
+    build_context,
+    build_prompt,
+)
 from questfoundry.runtime.domain import LoadError, LoadResult, load_studio
 from questfoundry.runtime.models import (
+    Agent,
     Archetype,
     FieldType,
     MessageType,
     StoreSemantics,
     Studio,
 )
+from questfoundry.runtime.providers import (
+    ContextOverflowError,
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    LLMResponse,
+    OllamaProvider,
+    ProviderError,
+    StreamChunk,
+)
+from questfoundry.runtime.session import Session, SessionStatus, TokenUsage, Turn, TurnStatus
 
 __all__ = [
     # Domain loading
@@ -27,5 +50,31 @@ __all__ = [
     "MessageType",
     "StoreSemantics",
     # Models
+    "Agent",
     "Studio",
+    # Providers
+    "LLMProvider",
+    "LLMMessage",
+    "LLMResponse",
+    "StreamChunk",
+    "InvokeOptions",
+    "ProviderError",
+    "ContextOverflowError",
+    "OllamaProvider",
+    # Sessions
+    "Session",
+    "SessionStatus",
+    "Turn",
+    "TurnStatus",
+    "TokenUsage",
+    # Agent Runtime
+    "AgentRuntime",
+    "ActivationResult",
+    "activate_agent",
+    "ContextBuilder",
+    "AgentContext",
+    "build_context",
+    "PromptBuilder",
+    "BuiltPrompt",
+    "build_prompt",
 ]

--- a/src/questfoundry/runtime/__init__.py
+++ b/src/questfoundry/runtime/__init__.py
@@ -4,7 +4,7 @@ QuestFoundry Runtime - Domain-agnostic studio execution engine.
 This runtime implements the meta-model contract (meta/schemas/) and can
 execute any studio definition following that schema.
 
-Status: Phase 1 - Single Agent Execution (in progress)
+Status: Phase 1 - Single Agent Execution (complete)
 """
 
 from questfoundry.runtime.agent import (
@@ -27,13 +27,16 @@ from questfoundry.runtime.models import (
     StoreSemantics,
     Studio,
 )
+from questfoundry.runtime.observability import EventLogger, EventType, TracingManager
 from questfoundry.runtime.providers import (
     ContextOverflowError,
+    GoogleProvider,
     InvokeOptions,
     LLMMessage,
     LLMProvider,
     LLMResponse,
     OllamaProvider,
+    OpenAIProvider,
     ProviderError,
     StreamChunk,
 )
@@ -61,6 +64,8 @@ __all__ = [
     "ProviderError",
     "ContextOverflowError",
     "OllamaProvider",
+    "OpenAIProvider",
+    "GoogleProvider",
     # Sessions
     "Session",
     "SessionStatus",
@@ -77,4 +82,8 @@ __all__ = [
     "PromptBuilder",
     "BuiltPrompt",
     "build_prompt",
+    # Observability
+    "EventLogger",
+    "EventType",
+    "TracingManager",
 ]

--- a/src/questfoundry/runtime/agent/__init__.py
+++ b/src/questfoundry/runtime/agent/__init__.py
@@ -1,0 +1,33 @@
+"""
+Agent runtime for executing agent activations.
+
+This module provides the core runtime for activating agents:
+- AgentRuntime: Main runtime class
+- ContextBuilder: Gathers knowledge for agents
+- PromptBuilder: Constructs system prompts
+"""
+
+from questfoundry.runtime.agent.context import AgentContext, ContextBuilder, build_context
+from questfoundry.runtime.agent.prompt import (
+    BuiltPrompt,
+    PromptBuilder,
+    PromptSection,
+    build_prompt,
+)
+from questfoundry.runtime.agent.runtime import ActivationResult, AgentRuntime, activate_agent
+
+__all__ = [
+    # Runtime
+    "AgentRuntime",
+    "ActivationResult",
+    "activate_agent",
+    # Context
+    "ContextBuilder",
+    "AgentContext",
+    "build_context",
+    # Prompt
+    "PromptBuilder",
+    "PromptSection",
+    "BuiltPrompt",
+    "build_prompt",
+]

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -1,0 +1,251 @@
+"""
+Context builder for agent activation.
+
+Gathers and prepares all context needed for an agent, including
+knowledge injection and conversation history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models import Agent, KnowledgeEntry, Studio
+
+
+@dataclass
+class AgentContext:
+    """
+    Context prepared for agent activation.
+
+    Contains all the knowledge and information needed to build
+    the system prompt and run the agent.
+    """
+
+    # Constitution text (if agent requires it)
+    constitution_text: str | None = None
+
+    # Must-know knowledge entries (always injected)
+    must_know_entries: list[dict[str, str]] = field(default_factory=list)
+
+    # Role-specific knowledge menu (available for lookup)
+    role_specific_menu: list[dict[str, str]] = field(default_factory=list)
+
+    # Token estimates for context budget
+    constitution_tokens: int = 0
+    must_know_tokens: int = 0
+    menu_tokens: int = 0
+
+    # Rough estimate: 4 chars per token
+    CHARS_PER_TOKEN: int = 4
+
+    @property
+    def total_tokens(self) -> int:
+        """Estimated total tokens for all context."""
+        return self.constitution_tokens + self.must_know_tokens + self.menu_tokens
+
+
+class ContextBuilder:
+    """
+    Builds context for agent activation.
+
+    Gathers knowledge based on agent's knowledge_requirements and
+    prepares it for injection into the system prompt.
+    """
+
+    # Rough estimate: 4 chars per token
+    CHARS_PER_TOKEN = 4
+
+    def __init__(self, domain_path: Path | None = None):
+        """
+        Initialize context builder.
+
+        Args:
+            domain_path: Path to domain directory (for loading knowledge files)
+        """
+        self._domain_path = domain_path
+        self._knowledge_cache: dict[str, dict[str, Any]] = {}
+
+    def build(self, agent: Agent, studio: Studio) -> AgentContext:
+        """
+        Build context for agent activation.
+
+        Args:
+            agent: The agent to build context for
+            studio: The studio containing knowledge entries
+
+        Returns:
+            AgentContext with all prepared knowledge
+        """
+        context = AgentContext()
+
+        if not agent.knowledge_requirements:
+            return context
+
+        reqs = agent.knowledge_requirements
+
+        # 1. Constitution (if required)
+        if reqs.constitution:
+            constitution_text = self._get_constitution_text(studio)
+            if constitution_text:
+                context.constitution_text = constitution_text
+                context.constitution_tokens = len(constitution_text) // self.CHARS_PER_TOKEN
+
+        # 2. Must-know entries
+        for entry_id in reqs.must_know:
+            entry = self._find_knowledge_entry(entry_id, studio)
+            if entry:
+                entry_dict = self._format_entry_for_injection(entry)
+                context.must_know_entries.append(entry_dict)
+                context.must_know_tokens += (
+                    len(entry_dict.get("content", "")) // self.CHARS_PER_TOKEN
+                )
+
+        # 3. Role-specific entries (as menu items)
+        for entry_id in reqs.role_specific:
+            entry = self._find_knowledge_entry(entry_id, studio)
+            if entry:
+                menu_item = self._format_entry_for_menu(entry)
+                context.role_specific_menu.append(menu_item)
+                context.menu_tokens += len(menu_item.get("summary", "")) // self.CHARS_PER_TOKEN
+
+        return context
+
+    def _get_constitution_text(self, studio: Studio) -> str | None:
+        """Get constitution text from studio."""
+        # Try to load constitution from knowledge_config or file
+        if studio.knowledge_config and "constitution" in studio.knowledge_config:
+            const_data = studio.knowledge_config["constitution"]
+            if isinstance(const_data, dict):
+                # Check for principles
+                principles = const_data.get("principles", [])
+                if principles:
+                    return self._format_constitution(const_data)
+
+        # Try loading from file if domain_path is set
+        if self._domain_path:
+            return self._load_constitution_from_file()
+
+        return None
+
+    def _load_constitution_from_file(self) -> str | None:
+        """Load constitution from governance/constitution.json."""
+        if not self._domain_path:
+            return None
+
+        const_path = self._domain_path / "governance" / "constitution.json"
+        if const_path.exists():
+            import json
+
+            data = json.loads(const_path.read_text())
+            return self._format_constitution(data)
+
+        return None
+
+    def _format_constitution(self, data: dict[str, Any]) -> str:
+        """Format constitution data into text."""
+        lines = []
+
+        # Preamble
+        preamble = data.get("preamble")
+        if preamble:
+            lines.append(preamble)
+            lines.append("")
+
+        # Principles
+        principles = data.get("principles", [])
+        for p in principles:
+            if isinstance(p, dict):
+                statement = p.get("statement", "")
+                if statement:
+                    lines.append(f"- {statement}")
+
+        return "\n".join(lines)
+
+    def _find_knowledge_entry(
+        self,
+        entry_id: str,
+        _studio: Studio,
+    ) -> KnowledgeEntry | None:
+        """Find a knowledge entry by ID."""
+        # Check if studio has knowledge entries loaded
+        # For now, we'll need to load from files if domain_path is set
+        # _studio reserved for future use when knowledge is embedded in Studio
+        if self._domain_path:
+            return self._load_knowledge_entry(entry_id)
+
+        return None
+
+    def _load_knowledge_entry(self, entry_id: str) -> KnowledgeEntry | None:
+        """Load a knowledge entry from the domain."""
+        if not self._domain_path:
+            return None
+
+        # Check cache first
+        if entry_id in self._knowledge_cache:
+            from questfoundry.runtime.models.base import KnowledgeEntry
+
+            return KnowledgeEntry(**self._knowledge_cache[entry_id])
+
+        # Search in knowledge directories
+        import json
+
+        knowledge_dirs = [
+            self._domain_path / "knowledge" / "must_know",
+            self._domain_path / "knowledge" / "should_know",
+            self._domain_path / "knowledge" / "role_specific",
+        ]
+
+        for dir_path in knowledge_dirs:
+            if dir_path.exists():
+                for file_path in dir_path.glob("*.json"):
+                    try:
+                        data = json.loads(file_path.read_text())
+                        if data.get("id") == entry_id:
+                            self._knowledge_cache[entry_id] = data
+                            from questfoundry.runtime.models.base import KnowledgeEntry
+
+                            return KnowledgeEntry(**data)
+                    except (json.JSONDecodeError, KeyError):
+                        continue
+
+        return None
+
+    def _format_entry_for_injection(self, entry: KnowledgeEntry) -> dict[str, str]:
+        """Format a knowledge entry for prompt injection."""
+        content = ""
+
+        if entry.content:
+            if isinstance(entry.content, dict):
+                # Inline content
+                if entry.content.get("type") == "inline":
+                    content = entry.content.get("text", "")
+            elif isinstance(entry.content, str):
+                content = entry.content
+
+        return {
+            "id": entry.id,
+            "name": entry.name or entry.id,
+            "content": content,
+        }
+
+    def _format_entry_for_menu(self, entry: KnowledgeEntry) -> dict[str, str]:
+        """Format a knowledge entry for the knowledge menu."""
+        return {
+            "id": entry.id,
+            "name": entry.name or entry.id,
+            "summary": entry.summary or "",
+        }
+
+
+# Convenience function
+def build_context(
+    agent: Agent,
+    studio: Studio,
+    domain_path: Path | None = None,
+) -> AgentContext:
+    """Build context for an agent."""
+    builder = ContextBuilder(domain_path=domain_path)
+    return builder.build(agent, studio)

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -1,0 +1,255 @@
+"""
+Prompt builder for agent system prompts.
+
+Constructs the system prompt from agent definition and injected knowledge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models import Agent
+
+
+@dataclass
+class PromptSection:
+    """A section of the system prompt."""
+
+    name: str
+    content: str
+    priority: int = 0  # Higher = more important, included first
+
+
+@dataclass
+class BuiltPrompt:
+    """Result of prompt building."""
+
+    text: str
+    sections: list[PromptSection]
+    token_estimate: int  # Rough estimate based on character count
+
+
+class PromptBuilder:
+    """
+    Builds system prompts for agent activation.
+
+    The prompt structure:
+    1. Agent Identity
+    2. Knowledge - Constitution
+    3. Knowledge - Must Know
+    4. Constraints
+    5. Capabilities
+    6. Available Knowledge (menu)
+    """
+
+    # Rough estimate: 4 chars per token
+    CHARS_PER_TOKEN = 4
+
+    def __init__(self) -> None:
+        """Initialize prompt builder."""
+        self._sections: list[PromptSection] = []
+
+    def reset(self) -> None:
+        """Clear all sections."""
+        self._sections = []
+
+    def add_section(
+        self,
+        name: str,
+        content: str,
+        priority: int = 0,
+    ) -> None:
+        """
+        Add a section to the prompt.
+
+        Args:
+            name: Section name (for debugging)
+            content: Section text
+            priority: Higher = more important
+        """
+        self._sections.append(PromptSection(name=name, content=content, priority=priority))
+
+    def build_for_agent(
+        self,
+        agent: Agent,
+        constitution_text: str | None = None,
+        must_know_entries: list[dict[str, str]] | None = None,
+        role_specific_menu: list[dict[str, str]] | None = None,
+    ) -> BuiltPrompt:
+        """
+        Build the system prompt for an agent.
+
+        Args:
+            agent: The agent definition
+            constitution_text: Full constitution text to inject
+            must_know_entries: List of {id, name, content} for must_know knowledge
+            role_specific_menu: List of {id, name, summary} for available knowledge
+
+        Returns:
+            Built prompt with text and metadata
+        """
+        self.reset()
+
+        # 1. Agent Identity (highest priority)
+        identity = self._build_identity_section(agent)
+        self.add_section("identity", identity, priority=100)
+
+        # 2. Constitution
+        if constitution_text:
+            self.add_section(
+                "constitution", self._format_constitution(constitution_text), priority=90
+            )
+
+        # 3. Must Know
+        if must_know_entries:
+            must_know = self._build_must_know_section(must_know_entries)
+            self.add_section("must_know", must_know, priority=80)
+
+        # 4. Constraints
+        if agent.constraints:
+            constraints = self._build_constraints_section(agent)
+            self.add_section("constraints", constraints, priority=70)
+
+        # 5. Capabilities
+        if agent.capabilities:
+            capabilities = self._build_capabilities_section(agent)
+            self.add_section("capabilities", capabilities, priority=60)
+
+        # 6. Available Knowledge Menu
+        if role_specific_menu:
+            menu = self._build_knowledge_menu(role_specific_menu)
+            self.add_section("knowledge_menu", menu, priority=50)
+
+        return self._assemble()
+
+    def _build_identity_section(self, agent: Agent) -> str:
+        """Build the agent identity section."""
+        lines = []
+        lines.append(f"You are {agent.name}.")
+
+        if agent.description:
+            lines.append(agent.description)
+
+        if agent.archetypes:
+            archetypes_str = ", ".join(agent.archetypes)
+            lines.append(f"Your role archetype(s): {archetypes_str}")
+
+        return "\n".join(lines)
+
+    def _format_constitution(self, text: str) -> str:
+        """Format constitution for injection."""
+        return f"## Constitution (Inviolable Principles)\n\n{text}"
+
+    def _build_must_know_section(self, entries: list[dict[str, str]]) -> str:
+        """Build the must-know knowledge section."""
+        lines = ["## Critical Knowledge\n"]
+
+        for entry in entries:
+            name = entry.get("name", entry.get("id", "Unknown"))
+            content = entry.get("content", "")
+
+            lines.append(f"### {name}\n")
+            lines.append(content)
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _build_constraints_section(self, agent: Agent) -> str:
+        """Build the constraints section."""
+        lines = ["## Constraints\n"]
+
+        # Group by severity
+        critical = []
+        warnings = []
+
+        for c in agent.constraints:
+            if c.severity == "critical":
+                critical.append(c)
+            else:
+                warnings.append(c)
+
+        if critical:
+            lines.append("**Critical (Never Violate):**")
+            for c in critical:
+                lines.append(f"- {c.rule}")
+            lines.append("")
+
+        if warnings:
+            lines.append("**Guidelines:**")
+            for c in warnings:
+                lines.append(f"- {c.rule}")
+
+        return "\n".join(lines)
+
+    def _build_capabilities_section(self, agent: Agent) -> str:
+        """Build the capabilities section."""
+        lines = ["## Your Capabilities\n"]
+
+        # Group by category
+        by_category: dict[str, list[str]] = {}
+
+        for cap in agent.capabilities:
+            category = cap.category or "general"
+            if category not in by_category:
+                by_category[category] = []
+
+            desc = cap.description or cap.name
+            by_category[category].append(desc)
+
+        for category, caps in by_category.items():
+            lines.append(f"**{category.replace('_', ' ').title()}:**")
+            for c in caps:
+                lines.append(f"- {c}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _build_knowledge_menu(self, entries: list[dict[str, str]]) -> str:
+        """Build the available knowledge menu."""
+        lines = ["## Available Knowledge\n"]
+        lines.append("You can consult the following knowledge entries:\n")
+
+        for entry in entries:
+            name = entry.get("name", entry.get("id", "Unknown"))
+            summary = entry.get("summary", "")
+            entry_id = entry.get("id", "")
+
+            lines.append(f"- **{name}** (`{entry_id}`): {summary}")
+
+        return "\n".join(lines)
+
+    def _assemble(self) -> BuiltPrompt:
+        """Assemble sections into final prompt."""
+        # Sort by priority (descending)
+        sorted_sections = sorted(self._sections, key=lambda s: -s.priority)
+
+        # Join with double newlines
+        text = "\n\n".join(s.content for s in sorted_sections)
+
+        # Estimate tokens
+        token_estimate = len(text) // self.CHARS_PER_TOKEN
+
+        return BuiltPrompt(
+            text=text,
+            sections=sorted_sections,
+            token_estimate=token_estimate,
+        )
+
+
+# Convenience function
+def build_prompt(
+    agent: Agent,
+    constitution_text: str | None = None,
+    must_know_entries: list[dict[str, str]] | None = None,
+    role_specific_menu: list[dict[str, str]] | None = None,
+) -> BuiltPrompt:
+    """Build a prompt for an agent."""
+    builder = PromptBuilder()
+    return builder.build_for_agent(
+        agent=agent,
+        constitution_text=constitution_text,
+        must_know_entries=must_know_entries,
+        role_specific_menu=role_specific_menu,
+    )

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -7,10 +7,15 @@ The AgentRuntime handles the full lifecycle of an agent activation:
 3. Validate context size
 4. Execute LLM call (streaming or non-streaming)
 5. Track turn in session
+
+With observability integration:
+- JSONL event logging to project_dir/logs/events.jsonl
+- LangSmith tracing (when LANGSMITH_TRACING=true)
 """
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +34,7 @@ from questfoundry.runtime.session import Session, TokenUsage, Turn
 
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, Studio
+    from questfoundry.runtime.observability import EventLogger, TracingManager
 
 
 @dataclass
@@ -46,7 +52,8 @@ class AgentRuntime:
     Runtime for executing agent activations.
 
     Handles context building, prompt construction, LLM invocation,
-    and session/turn management.
+    and session/turn management. Optionally integrates with observability
+    for JSONL event logging and LangSmith tracing.
     """
 
     def __init__(
@@ -56,6 +63,8 @@ class AgentRuntime:
         domain_path: Path | None = None,
         model: str = "qwen3:8b",
         context_limit: int | None = None,
+        event_logger: EventLogger | None = None,
+        tracing_manager: TracingManager | None = None,
     ):
         """
         Initialize agent runtime.
@@ -66,12 +75,16 @@ class AgentRuntime:
             domain_path: Path to domain directory (for knowledge loading)
             model: Model to use for LLM calls
             context_limit: Maximum context size (tokens), raises error if exceeded
+            event_logger: Optional JSONL event logger
+            tracing_manager: Optional LangSmith tracing manager
         """
         self._provider = provider
         self._studio = studio
         self._domain_path = domain_path
         self._model = model
         self._context_limit = context_limit
+        self._event_logger = event_logger
+        self._tracing_manager = tracing_manager
 
         self._context_builder = ContextBuilder(domain_path=domain_path)
         self._prompt_builder = PromptBuilder()
@@ -186,15 +199,46 @@ class AgentRuntime:
         """
         # Start turn
         turn = session.start_turn(agent.id, user_input)
+        start_time = time.time()
+
+        # Log turn start
+        if self._event_logger:
+            self._event_logger.turn_start(
+                session_id=session.id,
+                turn_id=turn.turn_number,
+                agent_id=agent.id,
+                input_text=user_input,
+            )
 
         try:
             # Build context and messages
             context = self.build_context(agent)
-            history = session.get_history()[:-2] if len(session.turns) > 1 else None
+
+            # Log context building
+            if self._event_logger:
+                self._event_logger.context_build(
+                    session_id=session.id,
+                    agent_id=agent.id,
+                    knowledge_count=len(context.must_know_entries),
+                    total_chars=context.total_tokens * 4,  # Rough estimate,
+                )
+
+            history = session.get_history()[:-1] if len(session.turns) > 1 else None
             messages = self.build_messages(agent, user_input, context, history)
 
             # Validate context size
             self.validate_context_size(messages)
+
+            # Log LLM call start
+            estimated_tokens = self.estimate_tokens(messages)
+            if self._event_logger:
+                self._event_logger.llm_call_start(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    model=self._model,
+                    provider=self._provider.name,
+                    prompt_tokens=estimated_tokens,
+                )
 
             # Invoke LLM
             response = await self._provider.invoke(messages, self._model, options)
@@ -206,6 +250,26 @@ class AgentRuntime:
                 total_tokens=response.total_tokens,
             )
             session.complete_turn(turn, response.content, usage)
+            duration_ms = (time.time() - start_time) * 1000
+
+            # Log completion
+            if self._event_logger:
+                self._event_logger.llm_call_complete(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    model=self._model,
+                    completion_tokens=response.completion_tokens,
+                    total_tokens=response.total_tokens,
+                    duration_ms=response.duration_ms,
+                )
+                self._event_logger.turn_complete(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    output_length=len(response.content),
+                    prompt_tokens=response.prompt_tokens,
+                    completion_tokens=response.completion_tokens,
+                    duration_ms=duration_ms,
+                )
 
             return ActivationResult(
                 content=response.content,
@@ -216,6 +280,13 @@ class AgentRuntime:
 
         except Exception as e:
             session.error_turn(turn, str(e))
+            # Log error
+            if self._event_logger:
+                self._event_logger.turn_error(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    error=str(e),
+                )
             raise
 
     async def activate_streaming(
@@ -243,15 +314,46 @@ class AgentRuntime:
         """
         # Start turn
         turn = session.start_turn(agent.id, user_input)
+        start_time = time.time()
+
+        # Log turn start
+        if self._event_logger:
+            self._event_logger.turn_start(
+                session_id=session.id,
+                turn_id=turn.turn_number,
+                agent_id=agent.id,
+                input_text=user_input,
+            )
 
         try:
             # Build context and messages
             context = self.build_context(agent)
-            history = session.get_history()[:-2] if len(session.turns) > 1 else None
+
+            # Log context building
+            if self._event_logger:
+                self._event_logger.context_build(
+                    session_id=session.id,
+                    agent_id=agent.id,
+                    knowledge_count=len(context.must_know_entries),
+                    total_chars=context.total_tokens * 4,  # Rough estimate,
+                )
+
+            history = session.get_history()[:-1] if len(session.turns) > 1 else None
             messages = self.build_messages(agent, user_input, context, history)
 
             # Validate context size
             self.validate_context_size(messages)
+
+            # Log LLM call start
+            estimated_tokens = self.estimate_tokens(messages)
+            if self._event_logger:
+                self._event_logger.llm_call_start(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    model=self._model,
+                    provider=self._provider.name,
+                    prompt_tokens=estimated_tokens,
+                )
 
             # Collect response for turn completion
             full_content = ""
@@ -272,9 +374,36 @@ class AgentRuntime:
 
             # Complete turn after streaming finishes
             session.complete_turn(turn, full_content, final_usage)
+            duration_ms = (time.time() - start_time) * 1000
+
+            # Log completion
+            if self._event_logger:
+                self._event_logger.llm_call_complete(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    model=self._model,
+                    completion_tokens=final_usage.completion_tokens if final_usage else None,
+                    total_tokens=final_usage.total_tokens if final_usage else None,
+                    duration_ms=duration_ms,
+                )
+                self._event_logger.turn_complete(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    output_length=len(full_content),
+                    prompt_tokens=final_usage.prompt_tokens if final_usage else None,
+                    completion_tokens=final_usage.completion_tokens if final_usage else None,
+                    duration_ms=duration_ms,
+                )
 
         except Exception as e:
             session.error_turn(turn, str(e))
+            # Log error
+            if self._event_logger:
+                self._event_logger.turn_error(
+                    session_id=session.id,
+                    turn_id=turn.turn_number,
+                    error=str(e),
+                )
             raise
 
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -1,0 +1,314 @@
+"""
+Agent runtime for executing agent activations.
+
+The AgentRuntime handles the full lifecycle of an agent activation:
+1. Load agent and build context
+2. Build system prompt
+3. Validate context size
+4. Execute LLM call (streaming or non-streaming)
+5. Track turn in session
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from questfoundry.runtime.agent.context import AgentContext, ContextBuilder
+from questfoundry.runtime.agent.prompt import PromptBuilder, build_prompt
+from questfoundry.runtime.providers import (
+    ContextOverflowError,
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    StreamChunk,
+)
+from questfoundry.runtime.session import Session, TokenUsage, Turn
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models import Agent, Studio
+
+
+@dataclass
+class ActivationResult:
+    """Result of an agent activation."""
+
+    content: str
+    agent_id: str
+    turn: Turn
+    usage: TokenUsage | None = None
+
+
+class AgentRuntime:
+    """
+    Runtime for executing agent activations.
+
+    Handles context building, prompt construction, LLM invocation,
+    and session/turn management.
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        studio: Studio,
+        domain_path: Path | None = None,
+        model: str = "qwen3:8b",
+        context_limit: int | None = None,
+    ):
+        """
+        Initialize agent runtime.
+
+        Args:
+            provider: LLM provider to use
+            studio: Loaded studio definition
+            domain_path: Path to domain directory (for knowledge loading)
+            model: Model to use for LLM calls
+            context_limit: Maximum context size (tokens), raises error if exceeded
+        """
+        self._provider = provider
+        self._studio = studio
+        self._domain_path = domain_path
+        self._model = model
+        self._context_limit = context_limit
+
+        self._context_builder = ContextBuilder(domain_path=domain_path)
+        self._prompt_builder = PromptBuilder()
+
+    def get_agent(self, agent_id: str) -> Agent | None:
+        """Get an agent by ID."""
+        for agent in self._studio.agents:
+            if agent.id == agent_id:
+                return agent
+        return None
+
+    def get_entry_agent(self) -> Agent | None:
+        """Get the first entry agent."""
+        for agent in self._studio.agents:
+            if agent.is_entry_agent:
+                return agent
+        return None
+
+    def build_context(self, agent: Agent) -> AgentContext:
+        """Build context for an agent."""
+        return self._context_builder.build(agent, self._studio)
+
+    def build_messages(
+        self,
+        agent: Agent,
+        user_input: str,
+        context: AgentContext | None = None,
+        history: list[dict[str, str]] | None = None,
+    ) -> list[LLMMessage]:
+        """
+        Build messages for LLM invocation.
+
+        Args:
+            agent: The agent to activate
+            user_input: User's input message
+            context: Pre-built context (built if not provided)
+            history: Conversation history [{role, content}, ...]
+
+        Returns:
+            List of LLMMessage for the provider
+        """
+        if context is None:
+            context = self.build_context(agent)
+
+        # Build system prompt
+        prompt = build_prompt(
+            agent=agent,
+            constitution_text=context.constitution_text,
+            must_know_entries=context.must_know_entries,
+            role_specific_menu=context.role_specific_menu,
+        )
+
+        messages: list[LLMMessage] = []
+
+        # System message
+        messages.append(LLMMessage(role="system", content=prompt.text))
+
+        # History
+        if history:
+            for h in history:
+                messages.append(LLMMessage(role=h["role"], content=h["content"]))
+
+        # User input
+        messages.append(LLMMessage(role="user", content=user_input))
+
+        return messages
+
+    def estimate_tokens(self, messages: list[LLMMessage]) -> int:
+        """Estimate token count for messages."""
+        total_chars = sum(len(m.content) for m in messages)
+        return total_chars // 4  # Rough estimate
+
+    def validate_context_size(self, messages: list[LLMMessage]) -> None:
+        """
+        Validate that messages fit within context limit.
+
+        Raises:
+            ContextOverflowError: If messages exceed context limit
+        """
+        if self._context_limit is None:
+            return
+
+        estimated = self.estimate_tokens(messages)
+        if estimated > self._context_limit:
+            raise ContextOverflowError(
+                f"Prompt ({estimated} tokens) exceeds model context "
+                f"({self._context_limit} tokens). Reduce knowledge or use larger model."
+            )
+
+    async def activate(
+        self,
+        agent: Agent,
+        user_input: str,
+        session: Session,
+        options: InvokeOptions | None = None,
+    ) -> ActivationResult:
+        """
+        Activate an agent (non-streaming).
+
+        Args:
+            agent: The agent to activate
+            user_input: User's input message
+            session: Session to track the turn in
+            options: LLM invocation options
+
+        Returns:
+            ActivationResult with response content and turn
+
+        Raises:
+            ContextOverflowError: If prompt exceeds context limit
+            ProviderError: If LLM call fails
+        """
+        # Start turn
+        turn = session.start_turn(agent.id, user_input)
+
+        try:
+            # Build context and messages
+            context = self.build_context(agent)
+            history = session.get_history()[:-2] if len(session.turns) > 1 else None
+            messages = self.build_messages(agent, user_input, context, history)
+
+            # Validate context size
+            self.validate_context_size(messages)
+
+            # Invoke LLM
+            response = await self._provider.invoke(messages, self._model, options)
+
+            # Complete turn
+            usage = TokenUsage(
+                prompt_tokens=response.prompt_tokens,
+                completion_tokens=response.completion_tokens,
+                total_tokens=response.total_tokens,
+            )
+            session.complete_turn(turn, response.content, usage)
+
+            return ActivationResult(
+                content=response.content,
+                agent_id=agent.id,
+                turn=turn,
+                usage=usage,
+            )
+
+        except Exception as e:
+            session.error_turn(turn, str(e))
+            raise
+
+    async def activate_streaming(
+        self,
+        agent: Agent,
+        user_input: str,
+        session: Session,
+        options: InvokeOptions | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """
+        Activate an agent with streaming response.
+
+        Args:
+            agent: The agent to activate
+            user_input: User's input message
+            session: Session to track the turn in
+            options: LLM invocation options
+
+        Yields:
+            StreamChunk with content
+
+        Raises:
+            ContextOverflowError: If prompt exceeds context limit
+            ProviderError: If LLM call fails
+        """
+        # Start turn
+        turn = session.start_turn(agent.id, user_input)
+
+        try:
+            # Build context and messages
+            context = self.build_context(agent)
+            history = session.get_history()[:-2] if len(session.turns) > 1 else None
+            messages = self.build_messages(agent, user_input, context, history)
+
+            # Validate context size
+            self.validate_context_size(messages)
+
+            # Collect response for turn completion
+            full_content = ""
+            final_usage: TokenUsage | None = None
+
+            # Stream from provider
+            async for chunk in self._provider.stream(messages, self._model, options):
+                full_content += chunk.content
+
+                if chunk.done:
+                    final_usage = TokenUsage(
+                        prompt_tokens=chunk.prompt_tokens,
+                        completion_tokens=chunk.completion_tokens,
+                        total_tokens=chunk.total_tokens,
+                    )
+
+                yield chunk
+
+            # Complete turn after streaming finishes
+            session.complete_turn(turn, full_content, final_usage)
+
+        except Exception as e:
+            session.error_turn(turn, str(e))
+            raise
+
+
+async def activate_agent(
+    agent_id: str,
+    user_input: str,
+    runtime: AgentRuntime,
+    session: Session,
+    streaming: bool = True,
+    options: InvokeOptions | None = None,
+) -> ActivationResult | AsyncIterator[StreamChunk]:
+    """
+    Convenience function to activate an agent.
+
+    Args:
+        agent_id: ID of the agent to activate
+        user_input: User's input message
+        runtime: The agent runtime
+        session: Session to track the turn
+        streaming: Whether to use streaming
+        options: LLM invocation options
+
+    Returns:
+        ActivationResult (non-streaming) or AsyncIterator[StreamChunk] (streaming)
+
+    Raises:
+        ValueError: If agent not found
+        ContextOverflowError: If prompt exceeds context limit
+    """
+    agent = runtime.get_agent(agent_id)
+    if not agent:
+        raise ValueError(f"Agent not found: {agent_id}")
+
+    if streaming:
+        return runtime.activate_streaming(agent, user_input, session, options)
+    else:
+        return await runtime.activate(agent, user_input, session, options)

--- a/src/questfoundry/runtime/models/__init__.py
+++ b/src/questfoundry/runtime/models/__init__.py
@@ -2,18 +2,38 @@
 Runtime models - Pydantic models for meta/ schemas.
 """
 
-from questfoundry.runtime.models.base import Studio
+from questfoundry.runtime.models.base import (
+    Agent,
+    ArtifactType,
+    KnowledgeEntry,
+    KnowledgeRequirements,
+    Playbook,
+    Store,
+    Studio,
+    Tool,
+)
 from questfoundry.runtime.models.enums import (
     Archetype,
     FieldType,
+    KnowledgeLayer,
     MessageType,
     StoreSemantics,
 )
 
 __all__ = [
+    # Enums
     "Archetype",
     "FieldType",
+    "KnowledgeLayer",
     "MessageType",
     "StoreSemantics",
+    # Models
+    "Agent",
+    "ArtifactType",
+    "KnowledgeEntry",
+    "KnowledgeRequirements",
+    "Playbook",
+    "Store",
     "Studio",
+    "Tool",
 ]

--- a/src/questfoundry/runtime/observability/__init__.py
+++ b/src/questfoundry/runtime/observability/__init__.py
@@ -1,0 +1,16 @@
+"""
+Observability module for QuestFoundry runtime.
+
+Provides:
+- JSONL event logging
+- LangSmith tracing integration
+"""
+
+from questfoundry.runtime.observability.events import EventLogger, EventType
+from questfoundry.runtime.observability.tracing import TracingManager
+
+__all__ = [
+    "EventLogger",
+    "EventType",
+    "TracingManager",
+]

--- a/src/questfoundry/runtime/observability/events.py
+++ b/src/questfoundry/runtime/observability/events.py
@@ -1,0 +1,291 @@
+"""
+JSONL Event Logger for QuestFoundry runtime.
+
+Logs structured events to project_dir/logs/events.jsonl for debugging and analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class EventType(str, Enum):
+    """Types of events that can be logged."""
+
+    # Session lifecycle
+    SESSION_START = "session_start"
+    SESSION_COMPLETE = "session_complete"
+    SESSION_ERROR = "session_error"
+
+    # Turn lifecycle
+    TURN_START = "turn_start"
+    TURN_COMPLETE = "turn_complete"
+    TURN_ERROR = "turn_error"
+
+    # LLM calls
+    LLM_CALL_START = "llm_call_start"
+    LLM_CALL_COMPLETE = "llm_call_complete"
+    LLM_CALL_ERROR = "llm_call_error"
+
+    # Agent events
+    AGENT_ACTIVATE = "agent_activate"
+    CONTEXT_BUILD = "context_build"
+    PROMPT_BUILD = "prompt_build"
+
+    # Knowledge events
+    KNOWLEDGE_INJECT = "knowledge_inject"
+
+
+class EventLogger:
+    """
+    Logs structured events to JSONL files.
+
+    Events are appended to project_dir/logs/events.jsonl in JSON Lines format.
+    Each line is a complete JSON object with timestamp, event type, and payload.
+    """
+
+    def __init__(self, project_path: Path):
+        """
+        Initialize event logger for a project.
+
+        Args:
+            project_path: Path to the project directory
+        """
+        self._project_path = project_path
+        self._logs_dir = project_path / "logs"
+        self._events_file = self._logs_dir / "events.jsonl"
+        self._ensure_logs_dir()
+
+    def _ensure_logs_dir(self) -> None:
+        """Create logs directory if it doesn't exist."""
+        self._logs_dir.mkdir(parents=True, exist_ok=True)
+
+    def _now(self) -> str:
+        """Get current timestamp in ISO format."""
+        return datetime.now(UTC).isoformat()
+
+    def log(
+        self,
+        event_type: EventType,
+        *,
+        session_id: str | None = None,
+        turn_id: int | None = None,
+        agent_id: str | None = None,
+        **payload: Any,
+    ) -> None:
+        """
+        Log an event to the JSONL file.
+
+        Args:
+            event_type: Type of event
+            session_id: Session identifier (if applicable)
+            turn_id: Turn number (if applicable)
+            agent_id: Agent identifier (if applicable)
+            **payload: Additional event-specific data
+        """
+        event: dict[str, Any] = {
+            "ts": self._now(),
+            "event": event_type.value,
+        }
+
+        if session_id:
+            event["session_id"] = session_id
+        if turn_id is not None:
+            event["turn_id"] = turn_id
+        if agent_id:
+            event["agent_id"] = agent_id
+
+        event.update(payload)
+
+        try:
+            with open(self._events_file, "a") as f:
+                f.write(json.dumps(event) + "\n")
+        except Exception as e:
+            logger.warning(f"Failed to write event to log: {e}")
+
+    # Convenience methods for common events
+
+    def session_start(
+        self,
+        session_id: str,
+        agent_id: str,
+        project_id: str,
+    ) -> None:
+        """Log session start event."""
+        self.log(
+            EventType.SESSION_START,
+            session_id=session_id,
+            agent_id=agent_id,
+            project_id=project_id,
+        )
+
+    def session_complete(
+        self,
+        session_id: str,
+        turn_count: int,
+        total_tokens: int | None = None,
+    ) -> None:
+        """Log session completion event."""
+        self.log(
+            EventType.SESSION_COMPLETE,
+            session_id=session_id,
+            turn_count=turn_count,
+            total_tokens=total_tokens,
+        )
+
+    def session_error(
+        self,
+        session_id: str,
+        error: str,
+    ) -> None:
+        """Log session error event."""
+        self.log(
+            EventType.SESSION_ERROR,
+            session_id=session_id,
+            error=error,
+        )
+
+    def turn_start(
+        self,
+        session_id: str,
+        turn_id: int,
+        agent_id: str,
+        input_text: str,
+    ) -> None:
+        """Log turn start event."""
+        self.log(
+            EventType.TURN_START,
+            session_id=session_id,
+            turn_id=turn_id,
+            agent_id=agent_id,
+            input=input_text[:500],  # Truncate for logs
+        )
+
+    def turn_complete(
+        self,
+        session_id: str,
+        turn_id: int,
+        output_length: int,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Log turn completion event."""
+        self.log(
+            EventType.TURN_COMPLETE,
+            session_id=session_id,
+            turn_id=turn_id,
+            output_length=output_length,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            duration_ms=duration_ms,
+        )
+
+    def turn_error(
+        self,
+        session_id: str,
+        turn_id: int,
+        error: str,
+    ) -> None:
+        """Log turn error event."""
+        self.log(
+            EventType.TURN_ERROR,
+            session_id=session_id,
+            turn_id=turn_id,
+            error=error,
+        )
+
+    def llm_call_start(
+        self,
+        session_id: str,
+        turn_id: int,
+        model: str,
+        provider: str,
+        prompt_tokens: int | None = None,
+    ) -> None:
+        """Log LLM call start event."""
+        self.log(
+            EventType.LLM_CALL_START,
+            session_id=session_id,
+            turn_id=turn_id,
+            model=model,
+            provider=provider,
+            prompt_tokens=prompt_tokens,
+        )
+
+    def llm_call_complete(
+        self,
+        session_id: str,
+        turn_id: int,
+        model: str,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Log LLM call completion event."""
+        self.log(
+            EventType.LLM_CALL_COMPLETE,
+            session_id=session_id,
+            turn_id=turn_id,
+            model=model,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            duration_ms=duration_ms,
+        )
+
+    def llm_call_error(
+        self,
+        session_id: str,
+        turn_id: int,
+        model: str,
+        error: str,
+    ) -> None:
+        """Log LLM call error event."""
+        self.log(
+            EventType.LLM_CALL_ERROR,
+            session_id=session_id,
+            turn_id=turn_id,
+            model=model,
+            error=error,
+        )
+
+    def context_build(
+        self,
+        session_id: str,
+        agent_id: str,
+        knowledge_count: int,
+        total_chars: int,
+    ) -> None:
+        """Log context building event."""
+        self.log(
+            EventType.CONTEXT_BUILD,
+            session_id=session_id,
+            agent_id=agent_id,
+            knowledge_count=knowledge_count,
+            total_chars=total_chars,
+        )
+
+    def knowledge_inject(
+        self,
+        session_id: str,
+        agent_id: str,
+        knowledge_id: str,
+        layer: str,
+        char_count: int,
+    ) -> None:
+        """Log knowledge injection event."""
+        self.log(
+            EventType.KNOWLEDGE_INJECT,
+            session_id=session_id,
+            agent_id=agent_id,
+            knowledge_id=knowledge_id,
+            layer=layer,
+            char_count=char_count,
+        )

--- a/src/questfoundry/runtime/observability/tracing.py
+++ b/src/questfoundry/runtime/observability/tracing.py
@@ -1,0 +1,324 @@
+"""
+LangSmith Tracing integration for QuestFoundry runtime.
+
+Provides hierarchical tracing with:
+- Session as the top-level chain
+- Turns as child runs within the session
+- LLM calls as child runs within turns
+
+Enabled when LANGSMITH_TRACING=true environment variable is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from langsmith import Client
+    from langsmith.run_trees import RunTree
+
+logger = logging.getLogger(__name__)
+
+
+def is_tracing_enabled() -> bool:
+    """Check if LangSmith tracing is enabled."""
+    return os.environ.get("LANGSMITH_TRACING", "").lower() in ("true", "1", "yes")
+
+
+class TracingManager:
+    """
+    Manages LangSmith tracing for a session.
+
+    Creates a hierarchical trace structure:
+    - Session (chain) - top level
+      - Turn 1 (chain) - child of session
+        - LLM Call (llm) - child of turn
+      - Turn 2 (chain)
+        - LLM Call (llm)
+      ...
+
+    Usage:
+        tracer = TracingManager(project_name="questfoundry")
+        with tracer.session("session_123", agent_id="showrunner") as session_run:
+            with tracer.turn(1, "Hello") as turn_run:
+                # LLM calls automatically traced via langchain
+                response = await llm.ainvoke(messages)
+            turn_run.end(outputs={"response": response})
+        session_run.end()
+    """
+
+    def __init__(
+        self,
+        project_name: str = "questfoundry",
+        *,
+        enabled: bool | None = None,
+    ):
+        """
+        Initialize tracing manager.
+
+        Args:
+            project_name: LangSmith project name (default: questfoundry)
+            enabled: Override automatic detection (default: check env var)
+        """
+        self._project_name = project_name
+        self._enabled = enabled if enabled is not None else is_tracing_enabled()
+        self._client: Client | None = None
+        self._session_run: RunTree | None = None
+        self._current_turn_run: RunTree | None = None
+
+    @property
+    def enabled(self) -> bool:
+        """Check if tracing is enabled."""
+        return self._enabled
+
+    def _get_client(self) -> Client | None:
+        """Get or create LangSmith client."""
+        if not self._enabled:
+            return None
+
+        if self._client is None:
+            try:
+                from langsmith import Client
+
+                self._client = Client()
+            except ImportError:
+                logger.warning("langsmith package not installed, tracing disabled")
+                self._enabled = False
+                return None
+            except Exception as e:
+                logger.warning(f"Failed to create LangSmith client: {e}")
+                self._enabled = False
+                return None
+
+        return self._client
+
+    @contextmanager
+    def session(
+        self,
+        session_id: str,
+        agent_id: str,
+        project_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Generator[RunTree | None, None, None]:
+        """
+        Create a session-level trace (chain).
+
+        Args:
+            session_id: Unique session identifier
+            agent_id: Entry agent ID
+            project_id: Project identifier
+            metadata: Additional metadata
+
+        Yields:
+            RunTree for the session (or None if tracing disabled)
+        """
+        if not self._enabled:
+            yield None
+            return
+
+        try:
+            from langsmith.run_trees import RunTree
+
+            run_id = uuid4()
+            run_name = f"Session: {session_id[:8]}"
+
+            inputs = {
+                "session_id": session_id,
+                "agent_id": agent_id,
+            }
+            if project_id:
+                inputs["project_id"] = project_id
+
+            run_metadata = {
+                "session_id": session_id,
+                "agent_id": agent_id,
+                **(metadata or {}),
+            }
+
+            self._session_run = RunTree(
+                name=run_name,
+                run_type="chain",
+                id=run_id,
+                inputs=inputs,
+                extra={"metadata": run_metadata},
+                project_name=self._project_name,
+            )
+
+            logger.debug(f"Started LangSmith session trace: {run_id}")
+            yield self._session_run
+
+        except ImportError:
+            logger.warning("langsmith package not installed")
+            self._enabled = False
+            yield None
+
+        except Exception as e:
+            logger.warning(f"Failed to create session trace: {e}")
+            yield None
+
+        finally:
+            if self._session_run:
+                try:
+                    self._session_run.post()
+                except Exception as e:
+                    logger.warning(f"Failed to post session trace: {e}")
+            self._session_run = None
+
+    @contextmanager
+    def turn(
+        self,
+        turn_id: int,
+        user_input: str,
+        agent_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Generator[RunTree | None, None, None]:
+        """
+        Create a turn-level trace (chain) as child of session.
+
+        Args:
+            turn_id: Turn number
+            user_input: User's input text
+            agent_id: Agent handling this turn
+            metadata: Additional metadata
+
+        Yields:
+            RunTree for the turn (or None if tracing disabled)
+        """
+        if not self._enabled or not self._session_run:
+            yield None
+            return
+
+        try:
+            run_name = f"Turn {turn_id}"
+
+            inputs = {
+                "turn_id": turn_id,
+                "user_input": user_input[:1000],  # Truncate for readability
+            }
+            if agent_id:
+                inputs["agent_id"] = agent_id
+
+            run_metadata = {
+                "turn_id": turn_id,
+                **(metadata or {}),
+            }
+
+            self._current_turn_run = self._session_run.create_child(
+                name=run_name,
+                run_type="chain",
+                inputs=inputs,
+                extra={"metadata": run_metadata},
+            )
+
+            logger.debug(f"Started LangSmith turn trace: Turn {turn_id}")
+            yield self._current_turn_run
+
+        except Exception as e:
+            logger.warning(f"Failed to create turn trace: {e}")
+            yield None
+
+        finally:
+            if self._current_turn_run:
+                try:
+                    self._current_turn_run.post()
+                except Exception as e:
+                    logger.warning(f"Failed to post turn trace: {e}")
+            self._current_turn_run = None
+
+    def end_turn(
+        self,
+        output: str | None = None,
+        error: str | None = None,
+        token_usage: dict[str, int] | None = None,
+    ) -> None:
+        """
+        End the current turn trace with outputs.
+
+        Args:
+            output: Response output
+            error: Error message if turn failed
+            token_usage: Token usage stats
+        """
+        if not self._current_turn_run:
+            return
+
+        try:
+            outputs: dict[str, Any] = {}
+            if output:
+                outputs["output"] = output[:2000]  # Truncate for readability
+            if token_usage:
+                outputs["token_usage"] = token_usage
+
+            if error:
+                self._current_turn_run.end(error=error)
+            else:
+                self._current_turn_run.end(outputs=outputs)
+
+        except Exception as e:
+            logger.warning(f"Failed to end turn trace: {e}")
+
+    def end_session(
+        self,
+        turn_count: int = 0,
+        total_tokens: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        """
+        End the session trace with summary.
+
+        Args:
+            turn_count: Number of turns completed
+            total_tokens: Total tokens used
+            error: Error message if session failed
+        """
+        if not self._session_run:
+            return
+
+        try:
+            outputs: dict[str, Any] = {
+                "turn_count": turn_count,
+            }
+            if total_tokens:
+                outputs["total_tokens"] = total_tokens
+
+            if error:
+                self._session_run.end(error=error)
+            else:
+                self._session_run.end(outputs=outputs)
+
+        except Exception as e:
+            logger.warning(f"Failed to end session trace: {e}")
+
+    def get_langchain_callbacks(self) -> list[Any]:
+        """
+        Get LangChain callbacks for the current turn.
+
+        Returns callbacks that will trace LLM calls as children of the current turn.
+        """
+        if not self._enabled or not self._current_turn_run:
+            return []
+
+        try:
+            from langchain_core.tracers import LangChainTracer
+
+            # Create a tracer that uses the current turn as parent
+            tracer = LangChainTracer(
+                project_name=self._project_name,
+                client=self._get_client(),
+            )
+            # Set the parent run ID so LLM calls nest under the turn
+            tracer.parent_run_id = self._current_turn_run.id  # type: ignore[attr-defined]
+
+            return [tracer]
+
+        except ImportError:
+            return []
+        except Exception as e:
+            logger.warning(f"Failed to create LangChain callbacks: {e}")
+            return []

--- a/src/questfoundry/runtime/providers/__init__.py
+++ b/src/questfoundry/runtime/providers/__init__.py
@@ -1,0 +1,37 @@
+"""
+LLM Provider abstractions.
+
+Provides a unified interface for different LLM backends:
+- Ollama (local)
+- OpenAI
+- Google (Gemini)
+"""
+
+from questfoundry.runtime.providers.base import (
+    ContextOverflowError,
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    LLMResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+from questfoundry.runtime.providers.ollama import OllamaProvider
+
+__all__ = [
+    # Base types
+    "LLMProvider",
+    "LLMMessage",
+    "LLMResponse",
+    "StreamChunk",
+    "InvokeOptions",
+    # Exceptions
+    "ProviderError",
+    "ProviderUnavailableError",
+    "ProviderConfigError",
+    "ContextOverflowError",
+    # Implementations
+    "OllamaProvider",
+]

--- a/src/questfoundry/runtime/providers/__init__.py
+++ b/src/questfoundry/runtime/providers/__init__.py
@@ -18,7 +18,9 @@ from questfoundry.runtime.providers.base import (
     ProviderUnavailableError,
     StreamChunk,
 )
+from questfoundry.runtime.providers.google import GoogleProvider
 from questfoundry.runtime.providers.ollama import OllamaProvider
+from questfoundry.runtime.providers.openai import OpenAIProvider
 
 __all__ = [
     # Base types
@@ -34,4 +36,6 @@ __all__ = [
     "ContextOverflowError",
     # Implementations
     "OllamaProvider",
+    "OpenAIProvider",
+    "GoogleProvider",
 ]

--- a/src/questfoundry/runtime/providers/base.py
+++ b/src/questfoundry/runtime/providers/base.py
@@ -127,7 +127,7 @@ class LLMProvider(ABC):
         ...
 
     @abstractmethod
-    def stream(
+    async def stream(
         self,
         messages: list[LLMMessage],
         model: str,
@@ -148,7 +148,7 @@ class LLMProvider(ABC):
             ProviderUnavailableError: If provider is not reachable
             ProviderError: For other errors
         """
-        ...
+        yield StreamChunk(content="")
 
     @abstractmethod
     async def check_availability(self) -> bool:

--- a/src/questfoundry/runtime/providers/base.py
+++ b/src/questfoundry/runtime/providers/base.py
@@ -1,0 +1,171 @@
+"""
+Base LLM Provider interface.
+
+All providers implement this interface for consistent behavior.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ProviderError(Exception):
+    """Base exception for provider errors."""
+
+    pass
+
+
+class ProviderUnavailableError(ProviderError):
+    """Provider is not available (network error, not running, etc.)."""
+
+    pass
+
+
+class ProviderConfigError(ProviderError):
+    """Provider configuration error (missing API key, etc.)."""
+
+    pass
+
+
+class ContextOverflowError(ProviderError):
+    """Prompt exceeds model's context window size."""
+
+    pass
+
+
+@dataclass
+class LLMMessage:
+    """A message in the conversation."""
+
+    role: str  # "system", "user", "assistant"
+    content: str
+
+
+@dataclass
+class LLMResponse:
+    """Response from an LLM invocation."""
+
+    content: str
+    model: str
+    provider: str
+
+    # Token usage
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    # Timing
+    duration_ms: float | None = None
+
+    # Raw response for debugging
+    raw: Any = None
+
+
+@dataclass
+class StreamChunk:
+    """A chunk of streamed response."""
+
+    content: str
+    done: bool = False
+
+    # Final chunk includes usage stats
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+@dataclass
+class InvokeOptions:
+    """Options for LLM invocation."""
+
+    temperature: float = 0.7
+    max_tokens: int | None = None
+    stop_sequences: list[str] = field(default_factory=list)
+    timeout_seconds: float = 120.0
+
+
+class LLMProvider(ABC):
+    """
+    Abstract base class for LLM providers.
+
+    All providers must implement:
+    - invoke(): Send messages and get a response
+    - check_availability(): Verify the provider is reachable
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Provider name (e.g., 'ollama', 'openai')."""
+        ...
+
+    @abstractmethod
+    async def invoke(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> LLMResponse:
+        """
+        Send messages to the LLM and get a response.
+
+        Args:
+            messages: Conversation messages (system, user, assistant)
+            model: Model identifier (e.g., 'qwen3:8b', 'gpt-4o')
+            options: Invocation options (temperature, max_tokens, etc.)
+
+        Returns:
+            LLMResponse with content and metadata
+
+        Raises:
+            ProviderUnavailableError: If provider is not reachable
+            ProviderError: For other errors
+        """
+        ...
+
+    @abstractmethod
+    def stream(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """
+        Stream response chunks from the LLM.
+
+        Args:
+            messages: Conversation messages (system, user, assistant)
+            model: Model identifier (e.g., 'qwen3:8b', 'gpt-4o')
+            options: Invocation options (temperature, max_tokens, etc.)
+
+        Yields:
+            StreamChunk with content, final chunk has done=True and usage stats
+
+        Raises:
+            ProviderUnavailableError: If provider is not reachable
+            ProviderError: For other errors
+        """
+        ...
+
+    @abstractmethod
+    async def check_availability(self) -> bool:
+        """
+        Check if the provider is available and reachable.
+
+        Returns:
+            True if provider is ready to accept requests
+        """
+        ...
+
+    @abstractmethod
+    async def list_models(self) -> list[str]:
+        """
+        List available models from this provider.
+
+        Returns:
+            List of model identifiers
+        """
+        ...

--- a/src/questfoundry/runtime/providers/google.py
+++ b/src/questfoundry/runtime/providers/google.py
@@ -1,0 +1,223 @@
+"""
+Google (Gemini) LLM Provider implementation.
+
+Uses langchain-google-genai for communication with Google's Gemini API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+
+from questfoundry.runtime.providers.base import (
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    LLMResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleProvider(LLMProvider):
+    """
+    Google Gemini provider using langchain-google-genai.
+
+    Requires GOOGLE_API_KEY environment variable or explicit api_key.
+    """
+
+    def __init__(self, api_key: str | None = None):
+        """
+        Initialize Google provider.
+
+        Args:
+            api_key: Google API key (defaults to GOOGLE_API_KEY env var)
+        """
+        self._api_key = api_key or os.environ.get("GOOGLE_API_KEY")
+
+        if not self._api_key:
+            raise ProviderConfigError(
+                "Google API key required. Set GOOGLE_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+    @property
+    def name(self) -> str:
+        return "google"
+
+    def _get_llm(self, model: str, options: InvokeOptions):  # type: ignore[no-untyped-def]
+        """Create a ChatGoogleGenerativeAI instance with the given settings."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
+        return ChatGoogleGenerativeAI(
+            model=model,
+            google_api_key=self._api_key,
+            temperature=options.temperature,
+            timeout=options.timeout_seconds,
+            max_output_tokens=options.max_tokens,
+            stop=options.stop_sequences if options.stop_sequences else None,
+        )
+
+    def _convert_messages(self, messages: list[LLMMessage]):  # type: ignore[no-untyped-def]
+        """Convert LLMMessage to langchain format."""
+        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+        langchain_messages: list[BaseMessage] = []
+        for msg in messages:
+            if msg.role == "system":
+                langchain_messages.append(SystemMessage(content=msg.content))
+            elif msg.role == "user":
+                langchain_messages.append(HumanMessage(content=msg.content))
+            elif msg.role == "assistant":
+                langchain_messages.append(AIMessage(content=msg.content))
+
+        return langchain_messages
+
+    async def invoke(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> LLMResponse:
+        """
+        Send messages to Google Gemini and get a response.
+
+        Uses langchain-google-genai for the actual invocation.
+        """
+        options = options or InvokeOptions()
+
+        llm = self._get_llm(model, options)
+        langchain_messages = self._convert_messages(messages)
+
+        start_time = time.time()
+        try:
+            response = await asyncio.wait_for(
+                llm.ainvoke(langchain_messages),
+                timeout=options.timeout_seconds,
+            )
+        except TimeoutError as e:
+            raise ProviderError(f"Google request timed out after {options.timeout_seconds}s") from e
+        except Exception as e:
+            error_msg = str(e)
+            if "api_key" in error_msg.lower() or "authentication" in error_msg.lower():
+                raise ProviderUnavailableError(f"Google authentication failed: {e}") from e
+            raise ProviderError(f"Google invocation failed: {e}") from e
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        # Extract token usage
+        usage_metadata = getattr(response, "usage_metadata", None)
+        prompt_tokens = None
+        completion_tokens = None
+        total_tokens = None
+
+        if usage_metadata:
+            prompt_tokens = usage_metadata.get("input_tokens")
+            completion_tokens = usage_metadata.get("output_tokens")
+            total_tokens = usage_metadata.get("total_tokens")
+
+        # Extract content
+        content = response.content
+        if isinstance(content, list):
+            content = str(content[0]) if content else ""
+
+        return LLMResponse(
+            content=content,
+            model=model,
+            provider=self.name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            duration_ms=duration_ms,
+            raw=response,
+        )
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """
+        Stream response chunks from Google Gemini.
+
+        Uses langchain-google-genai's astream for streaming.
+        """
+        options = options or InvokeOptions()
+
+        llm = self._get_llm(model, options)
+        langchain_messages = self._convert_messages(messages)
+
+        try:
+            prompt_tokens: int | None = None
+            completion_tokens: int | None = None
+            total_tokens: int | None = None
+
+            async for chunk in llm.astream(langchain_messages):
+                content = chunk.content
+                if isinstance(content, list):
+                    content = str(content[0]) if content else ""
+
+                # Check for usage metadata on final chunk
+                usage_metadata = getattr(chunk, "usage_metadata", None)
+                if usage_metadata:
+                    prompt_tokens = usage_metadata.get("input_tokens")
+                    completion_tokens = usage_metadata.get("output_tokens")
+                    total_tokens = usage_metadata.get("total_tokens")
+
+                yield StreamChunk(
+                    content=content,
+                    done=False,
+                )
+
+            # Final chunk with done=True and usage stats
+            yield StreamChunk(
+                content="",
+                done=True,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+
+        except Exception as e:
+            raise ProviderError(f"Google streaming failed: {e}") from e
+
+    async def check_availability(self) -> bool:
+        """Check if Google API is reachable with valid credentials."""
+        try:
+            import google.generativeai as genai  # type: ignore[import-untyped]
+
+            genai.configure(api_key=self._api_key)
+            # List models to verify API key works
+            list(genai.list_models())
+            return True
+        except Exception as e:
+            logger.debug(f"Google availability check failed: {e}")
+            return False
+
+    async def list_models(self) -> list[str]:
+        """List models available from Google."""
+        try:
+            import google.generativeai as genai
+
+            genai.configure(api_key=self._api_key)
+            models = list(genai.list_models())
+            return [
+                m.name.replace("models/", "")
+                for m in models
+                if "generateContent" in (m.supported_generation_methods or [])
+            ]
+        except Exception as e:
+            logger.debug(f"Failed to list Google models: {e}")
+            return []
+
+    async def close(self) -> None:
+        """No persistent connections to close for Google."""
+        pass

--- a/src/questfoundry/runtime/providers/ollama.py
+++ b/src/questfoundry/runtime/providers/ollama.py
@@ -1,0 +1,241 @@
+"""
+Ollama LLM Provider implementation.
+
+Uses langchain-ollama for communication with local Ollama instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator
+
+import httpx
+from langchain_ollama import ChatOllama
+
+from questfoundry.runtime.providers.base import (
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    LLMResponse,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaProvider(LLMProvider):
+    """
+    Ollama provider using langchain-ollama.
+
+    Connects to a local or remote Ollama instance.
+    """
+
+    def __init__(self, host: str = "http://localhost:11434"):
+        """
+        Initialize Ollama provider.
+
+        Args:
+            host: Ollama server URL (default: http://localhost:11434)
+        """
+        self._host = host.rstrip("/")
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=30.0)
+        return self._client
+
+    async def invoke(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> LLMResponse:
+        """
+        Send messages to Ollama and get a response.
+
+        Uses langchain-ollama for the actual invocation.
+        """
+        options = options or InvokeOptions()
+
+        # Check availability first
+        if not await self.check_availability():
+            raise ProviderUnavailableError(f"Ollama not available at {self._host}")
+
+        # Build langchain ChatOllama
+        llm = ChatOllama(
+            model=model,
+            base_url=self._host,
+            temperature=options.temperature,
+            num_predict=options.max_tokens,
+            stop=options.stop_sequences if options.stop_sequences else None,
+        )
+
+        # Convert messages to langchain format
+        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+        langchain_messages: list[BaseMessage] = []
+        for msg in messages:
+            if msg.role == "system":
+                langchain_messages.append(SystemMessage(content=msg.content))
+            elif msg.role == "user":
+                langchain_messages.append(HumanMessage(content=msg.content))
+            elif msg.role == "assistant":
+                langchain_messages.append(AIMessage(content=msg.content))
+
+        # Invoke with timeout
+        start_time = time.time()
+        try:
+            response = await asyncio.wait_for(
+                llm.ainvoke(langchain_messages),
+                timeout=options.timeout_seconds,
+            )
+        except TimeoutError as e:
+            raise ProviderError(f"Ollama request timed out after {options.timeout_seconds}s") from e
+        except Exception as e:
+            raise ProviderError(f"Ollama invocation failed: {e}") from e
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        # Extract token usage if available
+        usage_metadata = getattr(response, "usage_metadata", None)
+        prompt_tokens = None
+        completion_tokens = None
+        total_tokens = None
+
+        if usage_metadata:
+            prompt_tokens = usage_metadata.get("input_tokens")
+            completion_tokens = usage_metadata.get("output_tokens")
+            total_tokens = usage_metadata.get("total_tokens")
+
+        # Extract content (handle potential list type from langchain)
+        content = response.content
+        if isinstance(content, list):
+            content = str(content[0]) if content else ""
+
+        return LLMResponse(
+            content=content,
+            model=model,
+            provider=self.name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            duration_ms=duration_ms,
+            raw=response,
+        )
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """
+        Stream response chunks from Ollama.
+
+        Uses langchain-ollama's astream for streaming.
+        """
+        options = options or InvokeOptions()
+
+        # Check availability first
+        if not await self.check_availability():
+            raise ProviderUnavailableError(f"Ollama not available at {self._host}")
+
+        # Build langchain ChatOllama
+        llm = ChatOllama(
+            model=model,
+            base_url=self._host,
+            temperature=options.temperature,
+            num_predict=options.max_tokens,
+            stop=options.stop_sequences if options.stop_sequences else None,
+        )
+
+        # Convert messages to langchain format
+        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+        langchain_messages: list[BaseMessage] = []
+        for msg in messages:
+            if msg.role == "system":
+                langchain_messages.append(SystemMessage(content=msg.content))
+            elif msg.role == "user":
+                langchain_messages.append(HumanMessage(content=msg.content))
+            elif msg.role == "assistant":
+                langchain_messages.append(AIMessage(content=msg.content))
+
+        # Stream with timeout
+        try:
+            prompt_tokens: int | None = None
+            completion_tokens: int | None = None
+            total_tokens: int | None = None
+
+            async for chunk in llm.astream(langchain_messages):
+                # Extract content from chunk
+                content = chunk.content
+                if isinstance(content, list):
+                    content = str(content[0]) if content else ""
+
+                # Check for usage metadata on final chunk
+                usage_metadata = getattr(chunk, "usage_metadata", None)
+                if usage_metadata:
+                    prompt_tokens = usage_metadata.get("input_tokens")
+                    completion_tokens = usage_metadata.get("output_tokens")
+                    total_tokens = usage_metadata.get("total_tokens")
+
+                yield StreamChunk(
+                    content=content,
+                    done=False,
+                )
+
+            # Final chunk with done=True and usage stats
+            yield StreamChunk(
+                content="",
+                done=True,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+
+        except Exception as e:
+            raise ProviderError(f"Ollama streaming failed: {e}") from e
+
+    async def check_availability(self) -> bool:
+        """Check if Ollama is running and reachable."""
+        try:
+            client = await self._get_client()
+            response = await client.get(f"{self._host}/api/tags")
+            return response.status_code == 200
+        except Exception as e:
+            logger.debug(f"Ollama availability check failed: {e}")
+            return False
+
+    async def list_models(self) -> list[str]:
+        """List models available in Ollama."""
+        try:
+            client = await self._get_client()
+            response = await client.get(f"{self._host}/api/tags")
+            if response.status_code == 200:
+                data = response.json()
+                return [model["name"] for model in data.get("models", [])]
+            return []
+        except Exception as e:
+            logger.debug(f"Failed to list Ollama models: {e}")
+            return []
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/src/questfoundry/runtime/providers/openai.py
+++ b/src/questfoundry/runtime/providers/openai.py
@@ -1,0 +1,226 @@
+"""
+OpenAI LLM Provider implementation.
+
+Uses langchain-openai for communication with OpenAI API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+
+from questfoundry.runtime.providers.base import (
+    InvokeOptions,
+    LLMMessage,
+    LLMProvider,
+    LLMResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """
+    OpenAI provider using langchain-openai.
+
+    Requires OPENAI_API_KEY environment variable or explicit api_key.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ):
+        """
+        Initialize OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key (defaults to OPENAI_API_KEY env var)
+            base_url: Optional custom base URL (for Azure or compatible APIs)
+        """
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self._base_url = base_url
+
+        if not self._api_key:
+            raise ProviderConfigError(
+                "OpenAI API key required. Set OPENAI_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    def _get_llm(self, model: str, options: InvokeOptions):  # type: ignore[no-untyped-def]
+        """Create a ChatOpenAI instance with the given settings."""
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            model=model,
+            api_key=self._api_key,
+            temperature=options.temperature,
+            timeout=options.timeout_seconds,
+            max_tokens=options.max_tokens,
+            stop=options.stop_sequences if options.stop_sequences else None,
+            base_url=self._base_url,
+        )
+
+    def _convert_messages(self, messages: list[LLMMessage]):  # type: ignore[no-untyped-def]
+        """Convert LLMMessage to langchain format."""
+        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+        langchain_messages: list[BaseMessage] = []
+        for msg in messages:
+            if msg.role == "system":
+                langchain_messages.append(SystemMessage(content=msg.content))
+            elif msg.role == "user":
+                langchain_messages.append(HumanMessage(content=msg.content))
+            elif msg.role == "assistant":
+                langchain_messages.append(AIMessage(content=msg.content))
+
+        return langchain_messages
+
+    async def invoke(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> LLMResponse:
+        """
+        Send messages to OpenAI and get a response.
+
+        Uses langchain-openai for the actual invocation.
+        """
+        options = options or InvokeOptions()
+
+        llm = self._get_llm(model, options)
+        langchain_messages = self._convert_messages(messages)
+
+        start_time = time.time()
+        try:
+            response = await asyncio.wait_for(
+                llm.ainvoke(langchain_messages),
+                timeout=options.timeout_seconds,
+            )
+        except TimeoutError as e:
+            raise ProviderError(f"OpenAI request timed out after {options.timeout_seconds}s") from e
+        except Exception as e:
+            error_msg = str(e)
+            if "api_key" in error_msg.lower() or "authentication" in error_msg.lower():
+                raise ProviderUnavailableError(f"OpenAI authentication failed: {e}") from e
+            raise ProviderError(f"OpenAI invocation failed: {e}") from e
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        # Extract token usage
+        usage_metadata = getattr(response, "usage_metadata", None)
+        prompt_tokens = None
+        completion_tokens = None
+        total_tokens = None
+
+        if usage_metadata:
+            prompt_tokens = usage_metadata.get("input_tokens")
+            completion_tokens = usage_metadata.get("output_tokens")
+            total_tokens = usage_metadata.get("total_tokens")
+
+        # Extract content
+        content = response.content
+        if isinstance(content, list):
+            content = str(content[0]) if content else ""
+
+        return LLMResponse(
+            content=content,
+            model=model,
+            provider=self.name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            duration_ms=duration_ms,
+            raw=response,
+        )
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        model: str,
+        options: InvokeOptions | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """
+        Stream response chunks from OpenAI.
+
+        Uses langchain-openai's astream for streaming.
+        """
+        options = options or InvokeOptions()
+
+        llm = self._get_llm(model, options)
+        langchain_messages = self._convert_messages(messages)
+
+        try:
+            prompt_tokens: int | None = None
+            completion_tokens: int | None = None
+            total_tokens: int | None = None
+
+            async for chunk in llm.astream(langchain_messages):
+                content = chunk.content
+                if isinstance(content, list):
+                    content = str(content[0]) if content else ""
+
+                # Check for usage metadata on final chunk
+                usage_metadata = getattr(chunk, "usage_metadata", None)
+                if usage_metadata:
+                    prompt_tokens = usage_metadata.get("input_tokens")
+                    completion_tokens = usage_metadata.get("output_tokens")
+                    total_tokens = usage_metadata.get("total_tokens")
+
+                yield StreamChunk(
+                    content=content,
+                    done=False,
+                )
+
+            # Final chunk with done=True and usage stats
+            yield StreamChunk(
+                content="",
+                done=True,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+
+        except Exception as e:
+            raise ProviderError(f"OpenAI streaming failed: {e}") from e
+
+    async def check_availability(self) -> bool:
+        """Check if OpenAI API is reachable with valid credentials."""
+        try:
+            # Use a minimal models list call to verify connectivity
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=self._api_key, base_url=self._base_url)
+            await client.models.list()
+            return True
+        except Exception as e:
+            logger.debug(f"OpenAI availability check failed: {e}")
+            return False
+
+    async def list_models(self) -> list[str]:
+        """List models available from OpenAI."""
+        try:
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=self._api_key, base_url=self._base_url)
+            models = await client.models.list()
+            return [model.id for model in models.data if "gpt" in model.id.lower()]
+        except Exception as e:
+            logger.debug(f"Failed to list OpenAI models: {e}")
+            return []
+
+    async def close(self) -> None:
+        """No persistent connections to close for OpenAI."""
+        pass

--- a/src/questfoundry/runtime/session/__init__.py
+++ b/src/questfoundry/runtime/session/__init__.py
@@ -1,0 +1,16 @@
+"""
+Session management for agent interactions.
+
+Sessions track conversations with the system, managing turns and state.
+"""
+
+from questfoundry.runtime.session.session import Session, SessionStatus
+from questfoundry.runtime.session.turn import TokenUsage, Turn, TurnStatus
+
+__all__ = [
+    "Session",
+    "SessionStatus",
+    "Turn",
+    "TurnStatus",
+    "TokenUsage",
+]

--- a/src/questfoundry/runtime/session/session.py
+++ b/src/questfoundry/runtime/session/session.py
@@ -1,0 +1,326 @@
+"""
+Session management for agent interactions.
+
+A Session represents a conversation with the system, tracking all turns
+and managing state persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.runtime.session.turn import TokenUsage, Turn, TurnStatus
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.storage import Project
+
+
+class SessionStatus(str, Enum):
+    """Status of a session."""
+
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+@dataclass
+class Session:
+    """
+    A session with the system.
+
+    Manages conversation state and persists to project database.
+    """
+
+    id: str
+    project_id: str
+    entry_agent: str
+    started_at: datetime = field(default_factory=datetime.now)
+    ended_at: datetime | None = None
+    status: SessionStatus = SessionStatus.ACTIVE
+    turns: list[Turn] = field(default_factory=list)
+    _project: Project | None = field(default=None, repr=False)
+
+    @classmethod
+    def create(
+        cls,
+        project: Project,
+        entry_agent: str,
+        session_id: str | None = None,
+    ) -> Session:
+        """
+        Create a new session.
+
+        Args:
+            project: The project for this session
+            entry_agent: ID of the entry agent
+            session_id: Optional session ID (generated if not provided)
+
+        Returns:
+            The created Session, persisted to database
+        """
+        session = cls(
+            id=session_id or str(uuid.uuid4()),
+            project_id=project.info.id if project.info else project.path.name,
+            entry_agent=entry_agent,
+            _project=project,
+        )
+        session._persist_session()
+        return session
+
+    @classmethod
+    def load(cls, project: Project, session_id: str) -> Session | None:
+        """
+        Load an existing session from the database.
+
+        Args:
+            project: The project containing the session
+            session_id: Session ID to load
+
+        Returns:
+            The Session or None if not found
+        """
+        conn = project._get_connection()
+
+        # Load session
+        row = conn.execute(
+            "SELECT * FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        session = cls(
+            id=row["id"],
+            project_id=project.info.id if project.info else project.path.name,
+            entry_agent=row["entry_agent"],
+            started_at=datetime.fromisoformat(row["started_at"]),
+            ended_at=datetime.fromisoformat(row["ended_at"]) if row["ended_at"] else None,
+            status=SessionStatus(row["status"]),
+            _project=project,
+        )
+
+        # Load turns
+        turn_rows = conn.execute(
+            """
+            SELECT id, session_id, turn_number, agent_id, input, output,
+                   started_at, ended_at, token_usage
+            FROM turns
+            WHERE session_id = ?
+            ORDER BY turn_number
+            """,
+            (session_id,),
+        ).fetchall()
+
+        for turn_row in turn_rows:
+            usage = None
+            if turn_row["token_usage"]:
+                usage_data = json.loads(turn_row["token_usage"])
+                usage = TokenUsage.from_dict(usage_data)
+
+            turn = Turn(
+                db_id=turn_row["id"],
+                turn_number=turn_row["turn_number"],
+                agent_id=turn_row["agent_id"],
+                session_id=turn_row["session_id"],
+                input=turn_row["input"],
+                output=turn_row["output"],
+                started_at=datetime.fromisoformat(turn_row["started_at"]),
+                ended_at=(
+                    datetime.fromisoformat(turn_row["ended_at"]) if turn_row["ended_at"] else None
+                ),
+                usage=usage,
+                status=TurnStatus.COMPLETED if turn_row["output"] else TurnStatus.PENDING,
+            )
+            session.turns.append(turn)
+
+        return session
+
+    def _persist_session(self) -> None:
+        """Persist session to database."""
+        if self._project is None:
+            return
+
+        conn = self._project._get_connection()
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO sessions (id, started_at, ended_at, entry_agent, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                self.id,
+                self.started_at.isoformat(),
+                self.ended_at.isoformat() if self.ended_at else None,
+                self.entry_agent,
+                self.status.value,
+            ),
+        )
+        conn.commit()
+
+    def start_turn(self, agent_id: str, user_input: str | None = None) -> Turn:
+        """
+        Start a new turn in the session.
+
+        Args:
+            agent_id: ID of the agent handling this turn
+            user_input: User input for this turn
+
+        Returns:
+            The created Turn
+        """
+        turn_number = len(self.turns) + 1
+
+        turn = Turn(
+            turn_number=turn_number,
+            agent_id=agent_id,
+            session_id=self.id,
+            input=user_input,
+            status=TurnStatus.STREAMING,
+        )
+        self.turns.append(turn)
+
+        # Persist to database
+        if self._project:
+            conn = self._project._get_connection()
+            cursor = conn.execute(
+                """
+                INSERT INTO turns (session_id, turn_number, agent_id, input, started_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    self.id,
+                    turn_number,
+                    agent_id,
+                    user_input,
+                    turn.started_at.isoformat(),
+                ),
+            )
+            turn.db_id = cursor.lastrowid
+            conn.commit()
+
+        return turn
+
+    def complete_turn(
+        self,
+        turn: Turn,
+        output: str,
+        usage: TokenUsage | None = None,
+    ) -> None:
+        """
+        Complete a turn with output.
+
+        Args:
+            turn: The turn to complete
+            output: The agent's output
+            usage: Optional token usage stats
+        """
+        turn.complete(output, usage)
+
+        # Persist to database
+        if self._project and turn.db_id:
+            conn = self._project._get_connection()
+            conn.execute(
+                """
+                UPDATE turns
+                SET output = ?, ended_at = ?, token_usage = ?
+                WHERE id = ?
+                """,
+                (
+                    output,
+                    turn.ended_at.isoformat() if turn.ended_at else None,
+                    json.dumps(usage.to_dict()) if usage else None,
+                    turn.db_id,
+                ),
+            )
+            conn.commit()
+
+    def error_turn(self, turn: Turn, error_message: str) -> None:
+        """
+        Mark a turn as errored.
+
+        Args:
+            turn: The turn that errored
+            error_message: Error description
+        """
+        turn.error(error_message)
+
+        # Persist to database
+        if self._project and turn.db_id:
+            conn = self._project._get_connection()
+            conn.execute(
+                """
+                UPDATE turns
+                SET output = ?, ended_at = ?
+                WHERE id = ?
+                """,
+                (
+                    error_message,
+                    turn.ended_at.isoformat() if turn.ended_at else None,
+                    turn.db_id,
+                ),
+            )
+            conn.commit()
+
+    def complete(self) -> None:
+        """Mark session as completed."""
+        self.status = SessionStatus.COMPLETED
+        self.ended_at = datetime.now()
+        self._persist_session()
+
+    def error(self) -> None:
+        """Mark session as errored."""
+        self.status = SessionStatus.ERROR
+        self.ended_at = datetime.now()
+        self._persist_session()
+
+    @property
+    def current_turn(self) -> Turn | None:
+        """Get the current (latest) turn."""
+        if not self.turns:
+            return None
+        return self.turns[-1]
+
+    @property
+    def turn_count(self) -> int:
+        """Number of turns in this session."""
+        return len(self.turns)
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens used across all turns."""
+        total = 0
+        for turn in self.turns:
+            if turn.usage and turn.usage.total_tokens:
+                total += turn.usage.total_tokens
+        return total
+
+    def get_history(self) -> list[dict[str, str]]:
+        """
+        Get conversation history for context.
+
+        Returns list of {role, content} dicts for LLM context.
+        """
+        history: list[dict[str, str]] = []
+        for turn in self.turns:
+            if turn.input:
+                history.append({"role": "user", "content": turn.input})
+            if turn.output and turn.status == TurnStatus.COMPLETED:
+                history.append({"role": "assistant", "content": turn.output})
+        return history
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "entry_agent": self.entry_agent,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "status": self.status.value,
+            "turns": [t.to_dict() for t in self.turns],
+        }

--- a/src/questfoundry/runtime/session/session.py
+++ b/src/questfoundry/runtime/session/session.py
@@ -109,7 +109,7 @@ class Session:
         turn_rows = conn.execute(
             """
             SELECT id, session_id, turn_number, agent_id, input, output,
-                   started_at, ended_at, token_usage
+                   started_at, ended_at, token_usage, status
             FROM turns
             WHERE session_id = ?
             ORDER BY turn_number
@@ -123,6 +123,13 @@ class Session:
                 usage_data = json.loads(turn_row["token_usage"])
                 usage = TokenUsage.from_dict(usage_data)
 
+            # Load status from DB, fallback to guessing for backwards compatibility
+            status_str = turn_row["status"] if turn_row["status"] else None
+            if status_str:
+                status = TurnStatus(status_str)
+            else:
+                status = TurnStatus.COMPLETED if turn_row["output"] else TurnStatus.PENDING
+
             turn = Turn(
                 db_id=turn_row["id"],
                 turn_number=turn_row["turn_number"],
@@ -135,7 +142,7 @@ class Session:
                     datetime.fromisoformat(turn_row["ended_at"]) if turn_row["ended_at"] else None
                 ),
                 usage=usage,
-                status=TurnStatus.COMPLETED if turn_row["output"] else TurnStatus.PENDING,
+                status=status,
             )
             session.turns.append(turn)
 
@@ -189,8 +196,8 @@ class Session:
             conn = self._project._get_connection()
             cursor = conn.execute(
                 """
-                INSERT INTO turns (session_id, turn_number, agent_id, input, started_at)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO turns (session_id, turn_number, agent_id, input, started_at, status)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 (
                     self.id,
@@ -198,6 +205,7 @@ class Session:
                     agent_id,
                     user_input,
                     turn.started_at.isoformat(),
+                    turn.status.value,
                 ),
             )
             turn.db_id = cursor.lastrowid
@@ -227,13 +235,14 @@ class Session:
             conn.execute(
                 """
                 UPDATE turns
-                SET output = ?, ended_at = ?, token_usage = ?
+                SET output = ?, ended_at = ?, token_usage = ?, status = ?
                 WHERE id = ?
                 """,
                 (
                     output,
                     turn.ended_at.isoformat() if turn.ended_at else None,
                     json.dumps(usage.to_dict()) if usage else None,
+                    turn.status.value,
                     turn.db_id,
                 ),
             )
@@ -255,12 +264,13 @@ class Session:
             conn.execute(
                 """
                 UPDATE turns
-                SET output = ?, ended_at = ?
+                SET output = ?, ended_at = ?, status = ?
                 WHERE id = ?
                 """,
                 (
                     error_message,
                     turn.ended_at.isoformat() if turn.ended_at else None,
+                    turn.status.value,
                     turn.db_id,
                 ),
             )

--- a/src/questfoundry/runtime/session/turn.py
+++ b/src/questfoundry/runtime/session/turn.py
@@ -1,0 +1,131 @@
+"""
+Turn tracking for agent interactions.
+
+A Turn represents a single agent interaction within a session.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+class TurnStatus(str, Enum):
+    """Status of a turn."""
+
+    PENDING = "pending"
+    STREAMING = "streaming"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+@dataclass
+class TokenUsage:
+    """Token usage for a turn."""
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    def to_dict(self) -> dict[str, int | None]:
+        """Convert to dictionary for JSON storage."""
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TokenUsage:
+        """Create from dictionary."""
+        return cls(
+            prompt_tokens=data.get("prompt_tokens"),
+            completion_tokens=data.get("completion_tokens"),
+            total_tokens=data.get("total_tokens"),
+        )
+
+
+@dataclass
+class Turn:
+    """
+    A single turn in a session.
+
+    Represents one agent invocation with input, output, and metadata.
+    """
+
+    turn_number: int
+    agent_id: str
+    session_id: str
+    input: str | None = None
+    output: str | None = None
+    started_at: datetime = field(default_factory=datetime.now)
+    ended_at: datetime | None = None
+    usage: TokenUsage | None = None
+    status: TurnStatus = TurnStatus.PENDING
+    db_id: int | None = None  # SQLite row ID
+
+    def start(self) -> None:
+        """Mark turn as started/streaming."""
+        self.status = TurnStatus.STREAMING
+        self.started_at = datetime.now()
+
+    def complete(
+        self,
+        output: str,
+        usage: TokenUsage | None = None,
+    ) -> None:
+        """Mark turn as completed with output."""
+        self.output = output
+        self.ended_at = datetime.now()
+        self.usage = usage
+        self.status = TurnStatus.COMPLETED
+
+    def error(self, error_message: str) -> None:
+        """Mark turn as errored."""
+        self.output = error_message
+        self.ended_at = datetime.now()
+        self.status = TurnStatus.ERROR
+
+    @property
+    def duration_ms(self) -> float | None:
+        """Calculate duration in milliseconds."""
+        if self.ended_at is None:
+            return None
+        delta = self.ended_at - self.started_at
+        return delta.total_seconds() * 1000
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for storage."""
+        return {
+            "turn_number": self.turn_number,
+            "agent_id": self.agent_id,
+            "session_id": self.session_id,
+            "input": self.input,
+            "output": self.output,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "usage": self.usage.to_dict() if self.usage else None,
+            "status": self.status.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Turn:
+        """Create from dictionary."""
+        usage = None
+        if data.get("usage"):
+            usage = TokenUsage.from_dict(data["usage"])
+
+        return cls(
+            turn_number=data["turn_number"],
+            agent_id=data["agent_id"],
+            session_id=data["session_id"],
+            input=data.get("input"),
+            output=data.get("output"),
+            started_at=datetime.fromisoformat(data["started_at"]),
+            ended_at=datetime.fromisoformat(data["ended_at"]) if data.get("ended_at") else None,
+            usage=usage,
+            status=TurnStatus(data.get("status", "pending")),
+            db_id=data.get("db_id"),
+        )

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -246,6 +246,7 @@ class Project:
                 started_at TEXT NOT NULL,
                 ended_at TEXT,
                 token_usage JSON,
+                status TEXT DEFAULT 'pending',
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
 

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the QuestFoundry CLI."""

--- a/tests/cli/test_ask.py
+++ b/tests/cli/test_ask.py
@@ -1,0 +1,351 @@
+"""Tests for the CLI ask command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from questfoundry.cli import app
+from questfoundry.runtime.domain import LoadError, LoadResult
+from questfoundry.runtime.models.base import Agent, Studio
+from questfoundry.runtime.providers import StreamChunk
+from questfoundry.runtime.storage import Project
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_studio() -> Studio:
+    """Create a mock studio with agents."""
+    return Studio(
+        id="test_studio",
+        name="Test Studio",
+        agents=[
+            Agent(
+                id="showrunner",
+                name="Showrunner",
+                description="The orchestrator",
+                archetypes=["orchestrator"],
+                is_entry_agent=True,
+            ),
+            Agent(
+                id="lorekeeper",
+                name="Lorekeeper",
+                description="Keeper of canon",
+                archetypes=["curator"],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def test_project(tmp_path: Path) -> Project:
+    """Create a test project."""
+    project_path = tmp_path / "projects" / "test-project"
+    project = Project.create(
+        path=project_path,
+        name="Test Project",
+        studio_id="test_studio",
+    )
+    yield project
+    project.close()
+
+
+class TestAskCommandHelp:
+    """Tests for ask command help and structure."""
+
+    def test_ask_help(self) -> None:
+        """ask --help displays usage."""
+        result = runner.invoke(app, ["ask", "--help"])
+        assert result.exit_code == 0
+        assert "Interactive session or single-shot query" in result.stdout
+
+    def test_ask_auto_creates_default_project(self, tmp_path: Path) -> None:
+        """ask without project auto-creates default project."""
+        load_result = LoadResult(
+            studio=None, errors=[LoadError(path="domain-v4", message="test", severity="error")]
+        )
+
+        with (
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                ["ask", "--projects-dir", str(tmp_path / "projects")],
+            )
+
+            # Should have created default project
+            assert (
+                "Creating default project" in result.stdout
+                or "Created default project" in result.stdout
+            )
+
+
+class TestAskProjectErrors:
+    """Tests for project-related errors."""
+
+    def test_ask_project_not_found(self, tmp_path: Path) -> None:
+        """ask exits with error when project not found."""
+        result = runner.invoke(
+            app,
+            [
+                "ask",
+                "nonexistent",
+                "Hello",
+                "--projects-dir",
+                str(tmp_path / "projects"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Project not found" in result.stdout
+
+
+class TestAskDomainErrors:
+    """Tests for domain-related errors."""
+
+    def test_ask_domain_load_failure(self, test_project: Project) -> None:
+        """ask exits with error when domain fails to load."""
+        failed_result = LoadResult(
+            studio=None,
+            errors=[
+                LoadError(
+                    path="domain-v4",
+                    message="Invalid domain",
+                    severity="error",
+                )
+            ],
+        )
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+        ):
+            mock_load.return_value = failed_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "Hello",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "Failed to load domain" in result.stdout
+
+
+class TestAskAgentErrors:
+    """Tests for agent-related errors."""
+
+    def test_ask_agent_not_found(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask exits with error when specified agent not found."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=True)
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "Hello",
+                    "--entry-agent",
+                    "nonexistent_agent",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "Agent not found" in result.stdout
+
+
+class TestAskProviderErrors:
+    """Tests for provider-related errors."""
+
+    def test_ask_provider_unavailable(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask exits with error when provider unavailable."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=False)
+        mock_provider.host = "http://localhost:11434"
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "Hello",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "Ollama not available" in result.stdout
+
+
+class TestAskSingleShot:
+    """Tests for single-shot mode."""
+
+    def test_ask_single_shot_success(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask in single-shot mode streams response."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=True)
+        mock_provider.close = AsyncMock()
+
+        # Mock streaming response
+        async def mock_stream(*_args, **_kwargs):
+            yield StreamChunk(content="Hello")
+            yield StreamChunk(content=" there!")
+            yield StreamChunk(content="", done=True, total_tokens=50)
+
+        mock_provider.stream = mock_stream
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "Hello, who are you?",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+            )
+
+            # Check it ran successfully (or at least didn't exit with project/domain errors)
+            # Note: Rich Live rendering may not work perfectly in test runner
+            assert "Project not found" not in result.stdout
+            assert "Failed to load domain" not in result.stdout
+
+    def test_ask_single_shot_with_agent(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask single-shot with specific agent."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=True)
+        mock_provider.close = AsyncMock()
+
+        async def mock_stream(*_args, **_kwargs):
+            yield StreamChunk(content="I am the Lorekeeper")
+            yield StreamChunk(content="", done=True, total_tokens=50)
+
+        mock_provider.stream = mock_stream
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "Who are you?",
+                    "--entry-agent",
+                    "lorekeeper",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+            )
+
+            # Verify the non-entry agent was accepted
+            assert "Agent not found" not in result.stdout
+
+
+class TestAskREPL:
+    """Tests for REPL mode."""
+
+    def test_ask_repl_exit(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask REPL mode can be exited with 'exit'."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=True)
+        mock_provider.close = AsyncMock()
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            # Simulate user typing 'exit'
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+                input="exit\n",
+            )
+
+            # REPL should have shown the header and ended cleanly
+            assert "Interactive Session" in result.stdout or "Session ended" in result.stdout
+
+    def test_ask_repl_quit(self, test_project: Project, mock_studio: Studio) -> None:
+        """ask REPL mode can be exited with 'quit'."""
+        load_result = LoadResult(studio=mock_studio)
+
+        mock_provider = MagicMock()
+        mock_provider.check_availability = AsyncMock(return_value=True)
+        mock_provider.close = AsyncMock()
+
+        with (
+            patch("questfoundry.runtime.storage.Project.open", return_value=test_project),
+            patch("questfoundry.runtime.load_studio", new_callable=AsyncMock) as mock_load,
+            patch("questfoundry.runtime.providers.OllamaProvider", return_value=mock_provider),
+        ):
+            mock_load.return_value = load_result
+
+            result = runner.invoke(
+                app,
+                [
+                    "ask",
+                    "test-project",
+                    "--projects-dir",
+                    str(test_project.path.parent),
+                ],
+                input="quit\n",
+            )
+
+            assert "Session ended" in result.stdout

--- a/tests/runtime/agent/__init__.py
+++ b/tests/runtime/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for agent runtime."""

--- a/tests/runtime/agent/test_context.py
+++ b/tests/runtime/agent/test_context.py
@@ -1,0 +1,229 @@
+"""Tests for ContextBuilder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from questfoundry.runtime.agent import AgentContext, ContextBuilder, build_context
+from questfoundry.runtime.models.base import Agent, KnowledgeRequirements, Studio
+
+
+@pytest.fixture
+def basic_agent() -> Agent:
+    """Create a basic agent for testing."""
+    return Agent(
+        id="test_agent",
+        name="Test Agent",
+        archetypes=["creator"],
+    )
+
+
+@pytest.fixture
+def agent_with_knowledge() -> Agent:
+    """Create an agent with knowledge requirements."""
+    return Agent(
+        id="showrunner",
+        name="Showrunner",
+        archetypes=["orchestrator"],
+        knowledge_requirements=KnowledgeRequirements(
+            constitution=True,
+            must_know=["spoiler_hygiene"],
+            role_specific=["showrunner_ops"],
+        ),
+    )
+
+
+@pytest.fixture
+def basic_studio() -> Studio:
+    """Create a basic studio for testing."""
+    return Studio(
+        id="test_studio",
+        name="Test Studio",
+    )
+
+
+@pytest.fixture
+def domain_with_knowledge(tmp_path: Path) -> Path:
+    """Create a mock domain with knowledge files."""
+    # Create directory structure
+    knowledge_dir = tmp_path / "knowledge"
+    must_know_dir = knowledge_dir / "must_know"
+    role_specific_dir = knowledge_dir / "role_specific"
+    governance_dir = tmp_path / "governance"
+
+    must_know_dir.mkdir(parents=True)
+    role_specific_dir.mkdir(parents=True)
+    governance_dir.mkdir(parents=True)
+
+    # Create constitution
+    constitution = {
+        "preamble": "This is the test constitution preamble.",
+        "principles": [
+            {"id": "p1", "statement": "Always be helpful."},
+            {"id": "p2", "statement": "Never reveal secrets."},
+        ],
+    }
+    (governance_dir / "constitution.json").write_text(json.dumps(constitution))
+
+    # Create must_know entry
+    spoiler_entry = {
+        "id": "spoiler_hygiene",
+        "name": "Spoiler Hygiene",
+        "layer": "must_know",
+        "summary": "Keep secrets secret.",
+        "content": {
+            "type": "inline",
+            "text": "Player-facing content must never reveal secrets.",
+        },
+    }
+    (must_know_dir / "spoiler_hygiene.json").write_text(json.dumps(spoiler_entry))
+
+    # Create role_specific entry
+    ops_entry = {
+        "id": "showrunner_ops",
+        "name": "Showrunner Operations",
+        "layer": "role_specific",
+        "summary": "How to coordinate agents.",
+        "content": {
+            "type": "inline",
+            "text": "Detailed operations guide for the showrunner.",
+        },
+    }
+    (role_specific_dir / "showrunner_ops.json").write_text(json.dumps(ops_entry))
+
+    return tmp_path
+
+
+class TestAgentContext:
+    """Tests for AgentContext dataclass."""
+
+    def test_create_empty_context(self) -> None:
+        """AgentContext can be created empty."""
+        ctx = AgentContext()
+        assert ctx.constitution_text is None
+        assert ctx.must_know_entries == []
+        assert ctx.role_specific_menu == []
+        assert ctx.total_tokens == 0
+
+    def test_total_tokens(self) -> None:
+        """total_tokens sums all components."""
+        ctx = AgentContext(
+            constitution_tokens=100,
+            must_know_tokens=50,
+            menu_tokens=25,
+        )
+        assert ctx.total_tokens == 175
+
+
+class TestContextBuilder:
+    """Tests for ContextBuilder class."""
+
+    def test_build_empty_requirements(self, basic_agent: Agent, basic_studio: Studio) -> None:
+        """Building context for agent without requirements returns empty."""
+        builder = ContextBuilder()
+        ctx = builder.build(basic_agent, basic_studio)
+
+        assert ctx.constitution_text is None
+        assert ctx.must_know_entries == []
+        assert ctx.role_specific_menu == []
+
+    def test_build_with_constitution(
+        self,
+        agent_with_knowledge: Agent,
+        basic_studio: Studio,
+        domain_with_knowledge: Path,
+    ) -> None:
+        """Constitution is loaded when required."""
+        builder = ContextBuilder(domain_path=domain_with_knowledge)
+        ctx = builder.build(agent_with_knowledge, basic_studio)
+
+        assert ctx.constitution_text is not None
+        assert "test constitution preamble" in ctx.constitution_text
+        assert "Always be helpful" in ctx.constitution_text
+
+    def test_build_with_must_know(
+        self,
+        agent_with_knowledge: Agent,
+        basic_studio: Studio,
+        domain_with_knowledge: Path,
+    ) -> None:
+        """Must-know entries are loaded."""
+        builder = ContextBuilder(domain_path=domain_with_knowledge)
+        ctx = builder.build(agent_with_knowledge, basic_studio)
+
+        assert len(ctx.must_know_entries) == 1
+        entry = ctx.must_know_entries[0]
+        assert entry["id"] == "spoiler_hygiene"
+        assert entry["name"] == "Spoiler Hygiene"
+        assert "never reveal secrets" in entry["content"]
+
+    def test_build_with_role_specific(
+        self,
+        agent_with_knowledge: Agent,
+        basic_studio: Studio,
+        domain_with_knowledge: Path,
+    ) -> None:
+        """Role-specific entries are added to menu."""
+        builder = ContextBuilder(domain_path=domain_with_knowledge)
+        ctx = builder.build(agent_with_knowledge, basic_studio)
+
+        assert len(ctx.role_specific_menu) == 1
+        menu_item = ctx.role_specific_menu[0]
+        assert menu_item["id"] == "showrunner_ops"
+        assert menu_item["name"] == "Showrunner Operations"
+        assert "coordinate agents" in menu_item["summary"]
+
+    def test_token_estimates(
+        self,
+        agent_with_knowledge: Agent,
+        basic_studio: Studio,
+        domain_with_knowledge: Path,
+    ) -> None:
+        """Token estimates are calculated."""
+        builder = ContextBuilder(domain_path=domain_with_knowledge)
+        ctx = builder.build(agent_with_knowledge, basic_studio)
+
+        assert ctx.constitution_tokens > 0
+        assert ctx.must_know_tokens > 0
+        assert ctx.total_tokens > 0
+
+    def test_missing_knowledge_entry(
+        self, basic_studio: Studio, domain_with_knowledge: Path
+    ) -> None:
+        """Missing knowledge entries are silently skipped."""
+        agent = Agent(
+            id="test",
+            name="Test",
+            knowledge_requirements=KnowledgeRequirements(
+                must_know=["nonexistent_entry"],
+            ),
+        )
+
+        builder = ContextBuilder(domain_path=domain_with_knowledge)
+        ctx = builder.build(agent, basic_studio)
+
+        assert ctx.must_know_entries == []
+
+
+class TestBuildContextConvenience:
+    """Tests for build_context convenience function."""
+
+    def test_build_context_function(
+        self,
+        agent_with_knowledge: Agent,
+        basic_studio: Studio,
+        domain_with_knowledge: Path,
+    ) -> None:
+        """build_context function works correctly."""
+        ctx = build_context(
+            agent=agent_with_knowledge,
+            studio=basic_studio,
+            domain_path=domain_with_knowledge,
+        )
+
+        assert isinstance(ctx, AgentContext)
+        assert ctx.constitution_text is not None
+        assert len(ctx.must_know_entries) == 1

--- a/tests/runtime/agent/test_prompt.py
+++ b/tests/runtime/agent/test_prompt.py
@@ -1,0 +1,229 @@
+"""Tests for PromptBuilder."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.runtime.agent import BuiltPrompt, PromptBuilder, PromptSection, build_prompt
+from questfoundry.runtime.models.base import Agent, Capability, Constraint, KnowledgeRequirements
+
+
+@pytest.fixture
+def basic_agent() -> Agent:
+    """Create a basic agent for testing."""
+    return Agent(
+        id="test_agent",
+        name="Test Agent",
+        description="A test agent for unit tests.",
+        archetypes=["creator", "validator"],
+    )
+
+
+@pytest.fixture
+def full_agent() -> Agent:
+    """Create a fully configured agent."""
+    return Agent(
+        id="showrunner",
+        name="Showrunner",
+        description="The orchestrator who coordinates all agents.",
+        archetypes=["orchestrator"],
+        capabilities=[
+            Capability(
+                id="delegate_all",
+                name="Delegate to All",
+                description="Can delegate to any agent",
+                category="delegation",
+            ),
+            Capability(
+                id="read_stores",
+                name="Read All Stores",
+                description="Can read from any store",
+                category="store_access",
+            ),
+        ],
+        constraints=[
+            Constraint(
+                id="no_override",
+                name="Never Override",
+                rule="Never override Gatekeeper decisions.",
+                severity="critical",
+            ),
+            Constraint(
+                id="delegate_prose",
+                name="Delegate Prose",
+                rule="Delegate prose writing to Scene Smith.",
+                severity="warning",
+            ),
+        ],
+        knowledge_requirements=KnowledgeRequirements(
+            constitution=True,
+            must_know=["spoiler_hygiene"],
+            role_specific=["showrunner_ops"],
+        ),
+    )
+
+
+class TestPromptSection:
+    """Tests for PromptSection dataclass."""
+
+    def test_create_section(self) -> None:
+        """Section can be created with name and content."""
+        section = PromptSection(name="test", content="Test content")
+        assert section.name == "test"
+        assert section.content == "Test content"
+        assert section.priority == 0
+
+    def test_create_section_with_priority(self) -> None:
+        """Section can have custom priority."""
+        section = PromptSection(name="important", content="Important!", priority=100)
+        assert section.priority == 100
+
+
+class TestBuiltPrompt:
+    """Tests for BuiltPrompt dataclass."""
+
+    def test_built_prompt_has_attributes(self) -> None:
+        """BuiltPrompt has required attributes."""
+        prompt = BuiltPrompt(
+            text="Test prompt",
+            sections=[PromptSection(name="test", content="content")],
+            token_estimate=100,
+        )
+        assert prompt.text == "Test prompt"
+        assert len(prompt.sections) == 1
+        assert prompt.token_estimate == 100
+
+
+class TestPromptBuilder:
+    """Tests for PromptBuilder class."""
+
+    def test_add_section(self) -> None:
+        """Sections can be added."""
+        builder = PromptBuilder()
+        builder.add_section("test", "Test content", priority=50)
+
+        assert len(builder._sections) == 1
+        assert builder._sections[0].name == "test"
+        assert builder._sections[0].priority == 50
+
+    def test_reset_clears_sections(self) -> None:
+        """reset() clears all sections."""
+        builder = PromptBuilder()
+        builder.add_section("test1", "Content 1")
+        builder.add_section("test2", "Content 2")
+
+        builder.reset()
+
+        assert len(builder._sections) == 0
+
+    def test_build_basic_agent(self, basic_agent: Agent) -> None:
+        """Building prompt for basic agent includes identity."""
+        builder = PromptBuilder()
+        result = builder.build_for_agent(basic_agent)
+
+        assert "Test Agent" in result.text
+        assert "test agent for unit tests" in result.text
+        assert "creator, validator" in result.text
+
+    def test_build_with_constitution(self, basic_agent: Agent) -> None:
+        """Constitution is included when provided."""
+        builder = PromptBuilder()
+        constitution = "Always be helpful. Never reveal secrets."
+
+        result = builder.build_for_agent(
+            basic_agent,
+            constitution_text=constitution,
+        )
+
+        assert "Constitution" in result.text
+        assert "Always be helpful" in result.text
+
+    def test_build_with_must_know(self, basic_agent: Agent) -> None:
+        """Must-know entries are included when provided."""
+        builder = PromptBuilder()
+        must_know = [
+            {"id": "entry1", "name": "Important Knowledge", "content": "This is critical info."},
+        ]
+
+        result = builder.build_for_agent(
+            basic_agent,
+            must_know_entries=must_know,
+        )
+
+        assert "Critical Knowledge" in result.text
+        assert "Important Knowledge" in result.text
+        assert "critical info" in result.text
+
+    def test_build_with_constraints(self, full_agent: Agent) -> None:
+        """Constraints are formatted correctly."""
+        builder = PromptBuilder()
+        result = builder.build_for_agent(full_agent)
+
+        assert "Constraints" in result.text
+        assert "Critical (Never Violate)" in result.text
+        assert "Never override Gatekeeper" in result.text
+        assert "Guidelines" in result.text
+        assert "Delegate prose" in result.text
+
+    def test_build_with_capabilities(self, full_agent: Agent) -> None:
+        """Capabilities are formatted correctly."""
+        builder = PromptBuilder()
+        result = builder.build_for_agent(full_agent)
+
+        assert "Capabilities" in result.text
+        assert "Delegation" in result.text
+        assert "delegate to any agent" in result.text
+
+    def test_build_with_knowledge_menu(self, basic_agent: Agent) -> None:
+        """Knowledge menu is included when provided."""
+        builder = PromptBuilder()
+        menu = [
+            {"id": "ops_guide", "name": "Operations Guide", "summary": "How to run things."},
+        ]
+
+        result = builder.build_for_agent(
+            basic_agent,
+            role_specific_menu=menu,
+        )
+
+        assert "Available Knowledge" in result.text
+        assert "Operations Guide" in result.text
+        assert "ops_guide" in result.text
+
+    def test_sections_sorted_by_priority(self, full_agent: Agent) -> None:
+        """Sections are sorted by priority (descending)."""
+        builder = PromptBuilder()
+        result = builder.build_for_agent(
+            full_agent,
+            constitution_text="Constitution text",
+        )
+
+        # Identity should come before constitution (higher priority)
+        identity_pos = result.text.find("Showrunner")
+        const_pos = result.text.find("Constitution")
+
+        assert identity_pos < const_pos
+
+    def test_token_estimate(self, basic_agent: Agent) -> None:
+        """Token estimate is calculated."""
+        builder = PromptBuilder()
+        result = builder.build_for_agent(basic_agent)
+
+        # Should be roughly len(text) / 4
+        expected = len(result.text) // 4
+        assert result.token_estimate == expected
+
+
+class TestBuildPromptConvenience:
+    """Tests for build_prompt convenience function."""
+
+    def test_build_prompt_function(self, basic_agent: Agent) -> None:
+        """build_prompt function works correctly."""
+        result = build_prompt(
+            agent=basic_agent,
+            constitution_text="Test constitution",
+        )
+
+        assert isinstance(result, BuiltPrompt)
+        assert "Test Agent" in result.text
+        assert "Test constitution" in result.text

--- a/tests/runtime/agent/test_runtime.py
+++ b/tests/runtime/agent/test_runtime.py
@@ -1,0 +1,352 @@
+"""Tests for AgentRuntime."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.runtime.agent import AgentRuntime
+from questfoundry.runtime.models.base import Agent, Studio
+from questfoundry.runtime.providers import (
+    ContextOverflowError,
+    LLMMessage,
+    LLMResponse,
+    OllamaProvider,
+    StreamChunk,
+)
+from questfoundry.runtime.session import Session
+from questfoundry.runtime.storage import Project
+
+
+@pytest.fixture
+def mock_provider() -> MagicMock:
+    """Create a mock LLM provider."""
+    provider = MagicMock(spec=OllamaProvider)
+    provider.name = "mock"
+    return provider
+
+
+@pytest.fixture
+def basic_studio() -> Studio:
+    """Create a basic studio with agents."""
+    return Studio(
+        id="test_studio",
+        name="Test Studio",
+        agents=[
+            Agent(
+                id="showrunner",
+                name="Showrunner",
+                description="The orchestrator",
+                archetypes=["orchestrator"],
+                is_entry_agent=True,
+            ),
+            Agent(
+                id="lorekeeper",
+                name="Lorekeeper",
+                description="Keeper of canon",
+                archetypes=["curator"],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def project(tmp_path) -> Project:
+    """Create a test project."""
+    project_path = tmp_path / "test_project"
+    project = Project.create(
+        path=project_path,
+        name="Test Project",
+        studio_id="test_studio",
+    )
+    yield project
+    project.close()
+
+
+@pytest.fixture
+def session(project: Project) -> Session:
+    """Create a test session."""
+    return Session.create(project=project, entry_agent="showrunner")
+
+
+class TestAgentRuntimeBasics:
+    """Tests for AgentRuntime initialization and basic operations."""
+
+    def test_create_runtime(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """AgentRuntime can be created."""
+        runtime = AgentRuntime(
+            provider=mock_provider,
+            studio=basic_studio,
+            model="qwen3:8b",
+        )
+
+        assert runtime._provider == mock_provider
+        assert runtime._studio == basic_studio
+        assert runtime._model == "qwen3:8b"
+
+    def test_get_agent(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """get_agent finds agents by ID."""
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+        assert agent.id == "showrunner"
+        assert agent.name == "Showrunner"
+
+    def test_get_agent_not_found(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """get_agent returns None for unknown ID."""
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+
+        agent = runtime.get_agent("nonexistent")
+        assert agent is None
+
+    def test_get_entry_agent(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """get_entry_agent finds first entry agent."""
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+
+        agent = runtime.get_entry_agent()
+        assert agent is not None
+        assert agent.id == "showrunner"
+        assert agent.is_entry_agent is True
+
+
+class TestBuildMessages:
+    """Tests for message building."""
+
+    def test_build_messages_basic(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """build_messages creates system and user messages."""
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        messages = runtime.build_messages(agent, "Hello!")
+
+        assert len(messages) == 2
+        assert messages[0].role == "system"
+        assert "Showrunner" in messages[0].content
+        assert messages[1].role == "user"
+        assert messages[1].content == "Hello!"
+
+    def test_build_messages_with_history(
+        self, mock_provider: MagicMock, basic_studio: Studio
+    ) -> None:
+        """build_messages includes conversation history."""
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        history = [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "First response"},
+        ]
+
+        messages = runtime.build_messages(agent, "Second message", history=history)
+
+        assert len(messages) == 4
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert messages[1].content == "First message"
+        assert messages[2].role == "assistant"
+        assert messages[3].role == "user"
+        assert messages[3].content == "Second message"
+
+
+class TestContextValidation:
+    """Tests for context size validation."""
+
+    def test_validate_within_limit(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """Validation passes when within limit."""
+        runtime = AgentRuntime(
+            provider=mock_provider,
+            studio=basic_studio,
+            context_limit=10000,
+        )
+
+        messages = [
+            LLMMessage(role="system", content="Short prompt"),
+            LLMMessage(role="user", content="Hello"),
+        ]
+
+        # Should not raise
+        runtime.validate_context_size(messages)
+
+    def test_validate_exceeds_limit(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """Validation raises when exceeding limit."""
+        runtime = AgentRuntime(
+            provider=mock_provider,
+            studio=basic_studio,
+            context_limit=10,  # Very small limit
+        )
+
+        messages = [
+            LLMMessage(role="system", content="A" * 1000),  # Way over limit
+        ]
+
+        with pytest.raises(ContextOverflowError, match="exceeds"):
+            runtime.validate_context_size(messages)
+
+    def test_validate_no_limit(self, mock_provider: MagicMock, basic_studio: Studio) -> None:
+        """Validation is skipped when no limit set."""
+        runtime = AgentRuntime(
+            provider=mock_provider,
+            studio=basic_studio,
+            context_limit=None,
+        )
+
+        messages = [
+            LLMMessage(role="system", content="A" * 100000),
+        ]
+
+        # Should not raise even with huge message
+        runtime.validate_context_size(messages)
+
+
+class TestAgentActivation:
+    """Tests for agent activation."""
+
+    @pytest.mark.asyncio
+    async def test_activate_success(
+        self,
+        mock_provider: MagicMock,
+        basic_studio: Studio,
+        session: Session,
+    ) -> None:
+        """activate() invokes provider and returns result."""
+        mock_response = LLMResponse(
+            content="Hello! I am the Showrunner.",
+            model="qwen3:8b",
+            provider="mock",
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+        )
+        mock_provider.invoke = AsyncMock(return_value=mock_response)
+
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        result = await runtime.activate(agent, "Hello!", session)
+
+        assert result.content == "Hello! I am the Showrunner."
+        assert result.agent_id == "showrunner"
+        assert result.turn is not None
+        assert result.usage is not None
+        assert result.usage.total_tokens == 120
+
+    @pytest.mark.asyncio
+    async def test_activate_creates_turn(
+        self,
+        mock_provider: MagicMock,
+        basic_studio: Studio,
+        session: Session,
+    ) -> None:
+        """activate() creates and completes a turn."""
+        mock_response = LLMResponse(
+            content="Response",
+            model="qwen3:8b",
+            provider="mock",
+        )
+        mock_provider.invoke = AsyncMock(return_value=mock_response)
+
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        assert session.turn_count == 0
+
+        await runtime.activate(agent, "Input", session)
+
+        assert session.turn_count == 1
+        turn = session.turns[0]
+        assert turn.input == "Input"
+        assert turn.output == "Response"
+
+    @pytest.mark.asyncio
+    async def test_activate_context_overflow(
+        self,
+        mock_provider: MagicMock,
+        basic_studio: Studio,
+        session: Session,
+    ) -> None:
+        """activate() raises on context overflow."""
+        runtime = AgentRuntime(
+            provider=mock_provider,
+            studio=basic_studio,
+            context_limit=10,  # Very small
+        )
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        with pytest.raises(ContextOverflowError):
+            await runtime.activate(agent, "Hello!", session)
+
+        # Turn should be marked as error
+        assert session.turn_count == 1
+        assert "exceeds" in (session.turns[0].output or "")
+
+
+class TestAgentActivationStreaming:
+    """Tests for streaming agent activation."""
+
+    @pytest.mark.asyncio
+    async def test_activate_streaming(
+        self,
+        mock_provider: MagicMock,
+        basic_studio: Studio,
+        session: Session,
+    ) -> None:
+        """activate_streaming yields chunks and completes turn."""
+
+        async def mock_stream(*_args, **_kwargs):
+            yield StreamChunk(content="Hello")
+            yield StreamChunk(content=" world")
+            yield StreamChunk(content="!", done=True, total_tokens=50)
+
+        mock_provider.stream = mock_stream
+
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        chunks = []
+        async for chunk in runtime.activate_streaming(agent, "Hi", session):
+            chunks.append(chunk)
+
+        assert len(chunks) == 3
+        assert chunks[0].content == "Hello"
+        assert chunks[1].content == " world"
+        assert chunks[2].done is True
+
+        # Turn should be completed
+        assert session.turn_count == 1
+        turn = session.turns[0]
+        assert turn.output == "Hello world!"
+
+    @pytest.mark.asyncio
+    async def test_activate_streaming_error(
+        self,
+        mock_provider: MagicMock,
+        basic_studio: Studio,
+        session: Session,
+    ) -> None:
+        """activate_streaming handles errors properly."""
+
+        async def mock_stream_error(*_args, **_kwargs):
+            yield StreamChunk(content="Start")
+            raise RuntimeError("Stream failed")
+
+        mock_provider.stream = mock_stream_error
+
+        runtime = AgentRuntime(provider=mock_provider, studio=basic_studio)
+        agent = runtime.get_agent("showrunner")
+        assert agent is not None
+
+        with pytest.raises(RuntimeError, match="Stream failed"):
+            async for _chunk in runtime.activate_streaming(agent, "Hi", session):
+                pass
+
+        # Turn should be marked as error
+        assert session.turn_count == 1
+        assert "Stream failed" in (session.turns[0].output or "")

--- a/tests/runtime/providers/__init__.py
+++ b/tests/runtime/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for LLM providers."""

--- a/tests/runtime/providers/test_base.py
+++ b/tests/runtime/providers/test_base.py
@@ -1,0 +1,157 @@
+"""Tests for base provider types and interfaces."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.runtime.providers import (
+    ContextOverflowError,
+    InvokeOptions,
+    LLMMessage,
+    LLMResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+
+
+class TestLLMMessage:
+    """Tests for LLMMessage dataclass."""
+
+    def test_create_system_message(self) -> None:
+        """System messages have role='system'."""
+        msg = LLMMessage(role="system", content="You are a helpful assistant.")
+        assert msg.role == "system"
+        assert msg.content == "You are a helpful assistant."
+
+    def test_create_user_message(self) -> None:
+        """User messages have role='user'."""
+        msg = LLMMessage(role="user", content="Hello!")
+        assert msg.role == "user"
+        assert msg.content == "Hello!"
+
+    def test_create_assistant_message(self) -> None:
+        """Assistant messages have role='assistant'."""
+        msg = LLMMessage(role="assistant", content="Hi there!")
+        assert msg.role == "assistant"
+        assert msg.content == "Hi there!"
+
+
+class TestLLMResponse:
+    """Tests for LLMResponse dataclass."""
+
+    def test_create_minimal_response(self) -> None:
+        """Response requires content, model, and provider."""
+        response = LLMResponse(
+            content="Hello!",
+            model="qwen3:8b",
+            provider="ollama",
+        )
+        assert response.content == "Hello!"
+        assert response.model == "qwen3:8b"
+        assert response.provider == "ollama"
+        assert response.prompt_tokens is None
+        assert response.completion_tokens is None
+        assert response.total_tokens is None
+        assert response.duration_ms is None
+        assert response.raw is None
+
+    def test_create_full_response(self) -> None:
+        """Response can include all metadata."""
+        response = LLMResponse(
+            content="Hello!",
+            model="qwen3:8b",
+            provider="ollama",
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            duration_ms=1234.5,
+            raw={"debug": "data"},
+        )
+        assert response.prompt_tokens == 100
+        assert response.completion_tokens == 50
+        assert response.total_tokens == 150
+        assert response.duration_ms == 1234.5
+        assert response.raw == {"debug": "data"}
+
+
+class TestStreamChunk:
+    """Tests for StreamChunk dataclass."""
+
+    def test_create_content_chunk(self) -> None:
+        """Content chunks have text and done=False."""
+        chunk = StreamChunk(content="Hello")
+        assert chunk.content == "Hello"
+        assert chunk.done is False
+        assert chunk.prompt_tokens is None
+
+    def test_create_final_chunk(self) -> None:
+        """Final chunk has done=True and optional usage stats."""
+        chunk = StreamChunk(
+            content="",
+            done=True,
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+        )
+        assert chunk.content == ""
+        assert chunk.done is True
+        assert chunk.prompt_tokens == 100
+        assert chunk.completion_tokens == 50
+        assert chunk.total_tokens == 150
+
+
+class TestInvokeOptions:
+    """Tests for InvokeOptions dataclass."""
+
+    def test_default_options(self) -> None:
+        """Options have sensible defaults."""
+        options = InvokeOptions()
+        assert options.temperature == 0.7
+        assert options.max_tokens is None
+        assert options.stop_sequences == []
+        assert options.timeout_seconds == 120.0
+
+    def test_custom_options(self) -> None:
+        """Options can be customized."""
+        options = InvokeOptions(
+            temperature=0.3,
+            max_tokens=1000,
+            stop_sequences=["###", "END"],
+            timeout_seconds=60.0,
+        )
+        assert options.temperature == 0.3
+        assert options.max_tokens == 1000
+        assert options.stop_sequences == ["###", "END"]
+        assert options.timeout_seconds == 60.0
+
+
+class TestExceptions:
+    """Tests for provider exceptions."""
+
+    def test_provider_error_hierarchy(self) -> None:
+        """All provider errors inherit from ProviderError."""
+        assert issubclass(ProviderUnavailableError, ProviderError)
+        assert issubclass(ProviderConfigError, ProviderError)
+        assert issubclass(ContextOverflowError, ProviderError)
+
+    def test_provider_error(self) -> None:
+        """ProviderError can be raised with message."""
+        with pytest.raises(ProviderError, match="Test error"):
+            raise ProviderError("Test error")
+
+    def test_provider_unavailable_error(self) -> None:
+        """ProviderUnavailableError for connectivity issues."""
+        with pytest.raises(ProviderUnavailableError, match="not available"):
+            raise ProviderUnavailableError("Ollama not available at localhost")
+
+    def test_provider_config_error(self) -> None:
+        """ProviderConfigError for configuration issues."""
+        with pytest.raises(ProviderConfigError, match="Missing API key"):
+            raise ProviderConfigError("Missing API key for OpenAI")
+
+    def test_context_overflow_error(self) -> None:
+        """ContextOverflowError for prompt size issues."""
+        with pytest.raises(ContextOverflowError, match="exceeds"):
+            raise ContextOverflowError("Prompt (50000 tokens) exceeds context (32768)")

--- a/tests/runtime/providers/test_ollama.py
+++ b/tests/runtime/providers/test_ollama.py
@@ -1,0 +1,385 @@
+"""Tests for Ollama provider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from questfoundry.runtime.providers import (
+    InvokeOptions,
+    LLMMessage,
+    ProviderError,
+    ProviderUnavailableError,
+    StreamChunk,
+)
+from questfoundry.runtime.providers.ollama import OllamaProvider
+
+
+class TestOllamaProviderBasics:
+    """Tests for OllamaProvider basic functionality."""
+
+    def test_provider_name(self) -> None:
+        """Provider has correct name."""
+        provider = OllamaProvider()
+        assert provider.name == "ollama"
+
+    def test_default_host(self) -> None:
+        """Default host is localhost:11434."""
+        provider = OllamaProvider()
+        assert provider.host == "http://localhost:11434"
+
+    def test_custom_host(self) -> None:
+        """Host can be customized."""
+        provider = OllamaProvider(host="http://192.168.1.100:11434")
+        assert provider.host == "http://192.168.1.100:11434"
+
+    def test_host_trailing_slash_stripped(self) -> None:
+        """Trailing slash is stripped from host."""
+        provider = OllamaProvider(host="http://localhost:11434/")
+        assert provider.host == "http://localhost:11434"
+
+
+class TestOllamaProviderAvailability:
+    """Tests for OllamaProvider availability checks."""
+
+    @pytest.mark.asyncio
+    async def test_check_availability_success(self) -> None:
+        """Returns True when Ollama is reachable."""
+        provider = OllamaProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            result = await provider.check_availability()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_check_availability_failure(self) -> None:
+        """Returns False when Ollama is not reachable."""
+        provider = OllamaProvider()
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_get_client.return_value = mock_client
+
+            result = await provider.check_availability()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_check_availability_non_200(self) -> None:
+        """Returns False when Ollama returns non-200."""
+        provider = OllamaProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            result = await provider.check_availability()
+            assert result is False
+
+
+class TestOllamaProviderListModels:
+    """Tests for OllamaProvider model listing."""
+
+    @pytest.mark.asyncio
+    async def test_list_models_success(self) -> None:
+        """Returns model list when Ollama is available."""
+        provider = OllamaProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": [
+                {"name": "qwen3:8b"},
+                {"name": "llama3.2:3b"},
+            ]
+        }
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            models = await provider.list_models()
+            assert models == ["qwen3:8b", "llama3.2:3b"]
+
+    @pytest.mark.asyncio
+    async def test_list_models_empty(self) -> None:
+        """Returns empty list when no models installed."""
+        provider = OllamaProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": []}
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            models = await provider.list_models()
+            assert models == []
+
+    @pytest.mark.asyncio
+    async def test_list_models_error(self) -> None:
+        """Returns empty list on error."""
+        provider = OllamaProvider()
+
+        with patch.object(provider, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_get_client.return_value = mock_client
+
+            models = await provider.list_models()
+            assert models == []
+
+
+class TestOllamaProviderInvoke:
+    """Tests for OllamaProvider invoke method."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_unavailable(self) -> None:
+        """Raises ProviderUnavailableError when Ollama is down."""
+        provider = OllamaProvider()
+
+        with (
+            patch.object(provider, "check_availability", return_value=False),
+            pytest.raises(ProviderUnavailableError, match="not available"),
+        ):
+            await provider.invoke(
+                messages=[LLMMessage(role="user", content="Hello")],
+                model="qwen3:8b",
+            )
+
+    @pytest.mark.asyncio
+    async def test_invoke_success(self) -> None:
+        """Returns response on successful invocation."""
+        provider = OllamaProvider()
+
+        # Mock langchain response
+        mock_response = MagicMock()
+        mock_response.content = "Hello! How can I help you?"
+        mock_response.usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+
+        with (
+            patch.object(provider, "check_availability", return_value=True),
+            patch("questfoundry.runtime.providers.ollama.ChatOllama") as mock_chat,
+        ):
+            mock_llm = AsyncMock()
+            mock_llm.ainvoke.return_value = mock_response
+            mock_chat.return_value = mock_llm
+
+            response = await provider.invoke(
+                messages=[
+                    LLMMessage(role="system", content="Be helpful."),
+                    LLMMessage(role="user", content="Hello"),
+                ],
+                model="qwen3:8b",
+            )
+
+            assert response.content == "Hello! How can I help you?"
+            assert response.model == "qwen3:8b"
+            assert response.provider == "ollama"
+            assert response.prompt_tokens == 10
+            assert response.completion_tokens == 5
+            assert response.total_tokens == 15
+            assert response.duration_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_options(self) -> None:
+        """Options are passed to ChatOllama."""
+        provider = OllamaProvider()
+
+        mock_response = MagicMock()
+        mock_response.content = "Response"
+        mock_response.usage_metadata = None
+
+        with (
+            patch.object(provider, "check_availability", return_value=True),
+            patch("questfoundry.runtime.providers.ollama.ChatOllama") as mock_chat,
+        ):
+            mock_llm = AsyncMock()
+            mock_llm.ainvoke.return_value = mock_response
+            mock_chat.return_value = mock_llm
+
+            await provider.invoke(
+                messages=[LLMMessage(role="user", content="Hello")],
+                model="qwen3:8b",
+                options=InvokeOptions(
+                    temperature=0.3,
+                    max_tokens=500,
+                    stop_sequences=["###"],
+                ),
+            )
+
+            # Verify ChatOllama was called with correct params
+            mock_chat.assert_called_once()
+            call_kwargs = mock_chat.call_args.kwargs
+            assert call_kwargs["temperature"] == 0.3
+            assert call_kwargs["num_predict"] == 500
+            assert call_kwargs["stop"] == ["###"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_timeout(self) -> None:
+        """Raises ProviderError on timeout."""
+        provider = OllamaProvider()
+
+        with (
+            patch.object(provider, "check_availability", return_value=True),
+            patch("questfoundry.runtime.providers.ollama.ChatOllama") as mock_chat,
+        ):
+            mock_llm = AsyncMock()
+            mock_llm.ainvoke.side_effect = TimeoutError()
+            mock_chat.return_value = mock_llm
+
+            with pytest.raises(ProviderError, match="timed out"):
+                await provider.invoke(
+                    messages=[LLMMessage(role="user", content="Hello")],
+                    model="qwen3:8b",
+                    options=InvokeOptions(timeout_seconds=1.0),
+                )
+
+
+class TestOllamaProviderStream:
+    """Tests for OllamaProvider stream method."""
+
+    @pytest.mark.asyncio
+    async def test_stream_unavailable(self) -> None:
+        """Raises ProviderUnavailableError when Ollama is down."""
+        provider = OllamaProvider()
+
+        with (
+            patch.object(provider, "check_availability", return_value=False),
+            pytest.raises(ProviderUnavailableError, match="not available"),
+        ):
+            async for _chunk in provider.stream(
+                messages=[LLMMessage(role="user", content="Hello")],
+                model="qwen3:8b",
+            ):
+                pass  # Should not reach here
+
+    @pytest.mark.asyncio
+    async def test_stream_success(self) -> None:
+        """Yields chunks and final done chunk."""
+        provider = OllamaProvider()
+
+        # Create mock chunks
+        chunk1 = MagicMock()
+        chunk1.content = "Hello"
+        chunk1.usage_metadata = None
+
+        chunk2 = MagicMock()
+        chunk2.content = " world"
+        chunk2.usage_metadata = None
+
+        chunk3 = MagicMock()
+        chunk3.content = "!"
+        chunk3.usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "total_tokens": 13,
+        }
+
+        async def mock_astream(_messages: list) -> AsyncMock:  # type: ignore[misc]
+            for chunk in [chunk1, chunk2, chunk3]:
+                yield chunk
+
+        with (
+            patch.object(provider, "check_availability", return_value=True),
+            patch("questfoundry.runtime.providers.ollama.ChatOllama") as mock_chat,
+        ):
+            mock_llm = MagicMock()
+            mock_llm.astream = mock_astream
+            mock_chat.return_value = mock_llm
+
+            chunks: list[StreamChunk] = []
+            async for chunk in provider.stream(
+                messages=[LLMMessage(role="user", content="Hello")],
+                model="qwen3:8b",
+            ):
+                chunks.append(chunk)
+
+            # Should have 4 chunks: 3 content + 1 final
+            assert len(chunks) == 4
+
+            # Content chunks
+            assert chunks[0].content == "Hello"
+            assert chunks[0].done is False
+            assert chunks[1].content == " world"
+            assert chunks[1].done is False
+            assert chunks[2].content == "!"
+            assert chunks[2].done is False
+
+            # Final chunk with usage
+            assert chunks[3].content == ""
+            assert chunks[3].done is True
+            assert chunks[3].prompt_tokens == 10
+            assert chunks[3].completion_tokens == 3
+            assert chunks[3].total_tokens == 13
+
+    @pytest.mark.asyncio
+    async def test_stream_error(self) -> None:
+        """Raises ProviderError on streaming failure."""
+        provider = OllamaProvider()
+
+        async def mock_astream(_messages: list) -> AsyncMock:  # type: ignore[misc]
+            raise Exception("Stream error")
+            yield  # Make it a generator  # noqa: B033
+
+        with (
+            patch.object(provider, "check_availability", return_value=True),
+            patch("questfoundry.runtime.providers.ollama.ChatOllama") as mock_chat,
+        ):
+            mock_llm = MagicMock()
+            mock_llm.astream = mock_astream
+            mock_chat.return_value = mock_llm
+
+            with pytest.raises(ProviderError, match="streaming failed"):
+                async for _chunk in provider.stream(
+                    messages=[LLMMessage(role="user", content="Hello")],
+                    model="qwen3:8b",
+                ):
+                    pass
+
+
+class TestOllamaProviderClose:
+    """Tests for OllamaProvider cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_client(self) -> None:
+        """close() releases HTTP client."""
+        provider = OllamaProvider()
+
+        # Simulate a client being created
+        mock_client = AsyncMock()
+        provider._client = mock_client
+
+        await provider.close()
+
+        mock_client.aclose.assert_called_once()
+        assert provider._client is None
+
+    @pytest.mark.asyncio
+    async def test_close_no_client(self) -> None:
+        """close() is safe to call without client."""
+        provider = OllamaProvider()
+        assert provider._client is None
+
+        # Should not raise
+        await provider.close()
+        assert provider._client is None

--- a/tests/runtime/session/__init__.py
+++ b/tests/runtime/session/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for session management."""

--- a/tests/runtime/session/test_session.py
+++ b/tests/runtime/session/test_session.py
@@ -1,0 +1,331 @@
+"""Tests for Session management."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.runtime.session import Session, SessionStatus, TokenUsage, TurnStatus
+from questfoundry.runtime.storage import Project
+
+
+@pytest.fixture
+def project(tmp_path):
+    """Create a temporary project for testing."""
+    project_path = tmp_path / "test_project"
+    project = Project.create(
+        path=project_path,
+        name="Test Project",
+        description="A test project",
+        studio_id="questfoundry",
+    )
+    yield project
+    project.close()
+
+
+class TestSessionStatus:
+    """Tests for SessionStatus enum."""
+
+    def test_status_values(self) -> None:
+        """SessionStatus has expected values."""
+        assert SessionStatus.ACTIVE.value == "active"
+        assert SessionStatus.COMPLETED.value == "completed"
+        assert SessionStatus.ERROR.value == "error"
+
+
+class TestSessionCreation:
+    """Tests for Session creation."""
+
+    def test_create_session(self, project: Project) -> None:
+        """Session can be created with required fields."""
+        session = Session.create(
+            project=project,
+            entry_agent="showrunner",
+        )
+
+        assert session.id is not None
+        assert session.project_id == "test_project"
+        assert session.entry_agent == "showrunner"
+        assert session.status == SessionStatus.ACTIVE
+        assert session.turns == []
+
+    def test_create_session_with_id(self, project: Project) -> None:
+        """Session can be created with custom ID."""
+        session = Session.create(
+            project=project,
+            entry_agent="showrunner",
+            session_id="custom-session-123",
+        )
+
+        assert session.id == "custom-session-123"
+
+    def test_create_session_persists(self, project: Project) -> None:
+        """Session is persisted to database on creation."""
+        session = Session.create(
+            project=project,
+            entry_agent="showrunner",
+        )
+
+        # Check database
+        conn = project._get_connection()
+        row = conn.execute(
+            "SELECT * FROM sessions WHERE id = ?",
+            (session.id,),
+        ).fetchone()
+
+        assert row is not None
+        assert row["entry_agent"] == "showrunner"
+        assert row["status"] == "active"
+
+
+class TestSessionLoad:
+    """Tests for loading sessions."""
+
+    def test_load_existing_session(self, project: Project) -> None:
+        """Existing session can be loaded."""
+        # Create a session
+        original = Session.create(
+            project=project,
+            entry_agent="showrunner",
+        )
+
+        # Load it back
+        loaded = Session.load(project, original.id)
+
+        assert loaded is not None
+        assert loaded.id == original.id
+        assert loaded.entry_agent == "showrunner"
+        assert loaded.status == SessionStatus.ACTIVE
+
+    def test_load_nonexistent_session(self, project: Project) -> None:
+        """Loading nonexistent session returns None."""
+        result = Session.load(project, "nonexistent-id")
+        assert result is None
+
+    def test_load_session_with_turns(self, project: Project) -> None:
+        """Session loads its turns."""
+        session = Session.create(
+            project=project,
+            entry_agent="showrunner",
+        )
+
+        # Add some turns
+        turn1 = session.start_turn("showrunner", "Hello")
+        session.complete_turn(turn1, "Hi there!")
+
+        turn2 = session.start_turn("showrunner", "How are you?")
+        session.complete_turn(turn2, "I'm great!")
+
+        # Load and verify
+        loaded = Session.load(project, session.id)
+
+        assert loaded is not None
+        assert len(loaded.turns) == 2
+        assert loaded.turns[0].input == "Hello"
+        assert loaded.turns[0].output == "Hi there!"
+        assert loaded.turns[1].input == "How are you?"
+
+
+class TestSessionTurns:
+    """Tests for Session turn management."""
+
+    def test_start_turn(self, project: Project) -> None:
+        """Session can start a new turn."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn = session.start_turn("showrunner", "Hello!")
+
+        assert turn.turn_number == 1
+        assert turn.agent_id == "showrunner"
+        assert turn.input == "Hello!"
+        assert turn.status == TurnStatus.STREAMING
+        assert len(session.turns) == 1
+
+    def test_start_multiple_turns(self, project: Project) -> None:
+        """Multiple turns are numbered sequentially."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn1 = session.start_turn("showrunner", "First")
+        session.complete_turn(turn1, "Response 1")
+
+        turn2 = session.start_turn("lorekeeper", "Second")
+
+        assert turn1.turn_number == 1
+        assert turn2.turn_number == 2
+        assert len(session.turns) == 2
+
+    def test_complete_turn(self, project: Project) -> None:
+        """Turn can be completed with output."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn = session.start_turn("showrunner", "Hello")
+        usage = TokenUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        session.complete_turn(turn, "Hi!", usage)
+
+        assert turn.output == "Hi!"
+        assert turn.status == TurnStatus.COMPLETED
+        assert turn.usage == usage
+
+    def test_complete_turn_persists(self, project: Project) -> None:
+        """Completed turn is persisted to database."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn = session.start_turn("showrunner", "Hello")
+        session.complete_turn(turn, "Hi!")
+
+        # Check database
+        conn = project._get_connection()
+        row = conn.execute(
+            "SELECT * FROM turns WHERE id = ?",
+            (turn.db_id,),
+        ).fetchone()
+
+        assert row is not None
+        assert row["output"] == "Hi!"
+        assert row["ended_at"] is not None
+
+    def test_error_turn(self, project: Project) -> None:
+        """Turn can be marked as errored."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn = session.start_turn("showrunner", "Hello")
+        session.error_turn(turn, "Connection failed")
+
+        assert turn.output == "Connection failed"
+        assert turn.status == TurnStatus.ERROR
+
+    def test_current_turn(self, project: Project) -> None:
+        """current_turn returns the latest turn."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        assert session.current_turn is None
+
+        turn1 = session.start_turn("showrunner", "First")
+        assert session.current_turn == turn1
+
+        session.complete_turn(turn1, "Response")
+        turn2 = session.start_turn("showrunner", "Second")
+        assert session.current_turn == turn2
+
+
+class TestSessionCompletion:
+    """Tests for Session completion."""
+
+    def test_complete_session(self, project: Project) -> None:
+        """Session can be completed."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        session.complete()
+
+        assert session.status == SessionStatus.COMPLETED
+        assert session.ended_at is not None
+
+    def test_error_session(self, project: Project) -> None:
+        """Session can be marked as errored."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        session.error()
+
+        assert session.status == SessionStatus.ERROR
+        assert session.ended_at is not None
+
+
+class TestSessionStats:
+    """Tests for Session statistics."""
+
+    def test_turn_count(self, project: Project) -> None:
+        """turn_count returns number of turns."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        assert session.turn_count == 0
+
+        turn1 = session.start_turn("showrunner", "First")
+        assert session.turn_count == 1
+
+        session.complete_turn(turn1, "Response")
+        session.start_turn("showrunner", "Second")
+        assert session.turn_count == 2
+
+    def test_total_tokens(self, project: Project) -> None:
+        """total_tokens sums usage across turns."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        assert session.total_tokens == 0
+
+        turn1 = session.start_turn("showrunner", "First")
+        session.complete_turn(turn1, "Response", TokenUsage(total_tokens=100))
+
+        turn2 = session.start_turn("showrunner", "Second")
+        session.complete_turn(turn2, "Response", TokenUsage(total_tokens=50))
+
+        assert session.total_tokens == 150
+
+
+class TestSessionHistory:
+    """Tests for conversation history."""
+
+    def test_get_history_empty(self, project: Project) -> None:
+        """Empty session returns empty history."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        history = session.get_history()
+        assert history == []
+
+    def test_get_history_with_turns(self, project: Project) -> None:
+        """History includes completed turns."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn1 = session.start_turn("showrunner", "Hello")
+        session.complete_turn(turn1, "Hi!")
+
+        turn2 = session.start_turn("showrunner", "How are you?")
+        session.complete_turn(turn2, "Great!")
+
+        history = session.get_history()
+
+        assert len(history) == 4
+        assert history[0] == {"role": "user", "content": "Hello"}
+        assert history[1] == {"role": "assistant", "content": "Hi!"}
+        assert history[2] == {"role": "user", "content": "How are you?"}
+        assert history[3] == {"role": "assistant", "content": "Great!"}
+
+    def test_get_history_excludes_incomplete(self, project: Project) -> None:
+        """History excludes incomplete turns."""
+        session = Session.create(project=project, entry_agent="showrunner")
+
+        turn1 = session.start_turn("showrunner", "Hello")
+        session.complete_turn(turn1, "Hi!")
+
+        # Start but don't complete turn 2
+        session.start_turn("showrunner", "How are you?")
+
+        history = session.get_history()
+
+        # Only turn 1 should be in history
+        assert len(history) == 3
+        assert history[0] == {"role": "user", "content": "Hello"}
+        assert history[1] == {"role": "assistant", "content": "Hi!"}
+        assert history[2] == {"role": "user", "content": "How are you?"}
+
+
+class TestSessionSerialization:
+    """Tests for Session serialization."""
+
+    def test_to_dict(self, project: Project) -> None:
+        """Session converts to dict correctly."""
+        session = Session.create(
+            project=project,
+            entry_agent="showrunner",
+            session_id="test-session",
+        )
+
+        turn = session.start_turn("showrunner", "Hello")
+        session.complete_turn(turn, "Hi!")
+
+        d = session.to_dict()
+
+        assert d["id"] == "test-session"
+        assert d["project_id"] == "test_project"
+        assert d["entry_agent"] == "showrunner"
+        assert d["status"] == "active"
+        assert len(d["turns"]) == 1
+        assert d["turns"][0]["input"] == "Hello"

--- a/tests/runtime/session/test_turn.py
+++ b/tests/runtime/session/test_turn.py
@@ -1,0 +1,210 @@
+"""Tests for Turn tracking."""
+
+from __future__ import annotations
+
+from questfoundry.runtime.session import TokenUsage, Turn, TurnStatus
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage dataclass."""
+
+    def test_create_empty_usage(self) -> None:
+        """TokenUsage can be created with no values."""
+        usage = TokenUsage()
+        assert usage.prompt_tokens is None
+        assert usage.completion_tokens is None
+        assert usage.total_tokens is None
+
+    def test_create_full_usage(self) -> None:
+        """TokenUsage can be created with all values."""
+        usage = TokenUsage(
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+        )
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 150
+
+    def test_to_dict(self) -> None:
+        """TokenUsage converts to dict correctly."""
+        usage = TokenUsage(prompt_tokens=100, completion_tokens=50)
+        d = usage.to_dict()
+        assert d == {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": None,
+        }
+
+    def test_from_dict(self) -> None:
+        """TokenUsage can be created from dict."""
+        data = {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        }
+        usage = TokenUsage.from_dict(data)
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 50
+        assert usage.total_tokens == 150
+
+
+class TestTurnStatus:
+    """Tests for TurnStatus enum."""
+
+    def test_status_values(self) -> None:
+        """TurnStatus has expected values."""
+        assert TurnStatus.PENDING.value == "pending"
+        assert TurnStatus.STREAMING.value == "streaming"
+        assert TurnStatus.COMPLETED.value == "completed"
+        assert TurnStatus.ERROR.value == "error"
+
+    def test_status_from_string(self) -> None:
+        """TurnStatus can be created from string."""
+        assert TurnStatus("pending") == TurnStatus.PENDING
+        assert TurnStatus("streaming") == TurnStatus.STREAMING
+
+
+class TestTurn:
+    """Tests for Turn class."""
+
+    def test_create_turn(self) -> None:
+        """Turn can be created with required fields."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+        )
+        assert turn.turn_number == 1
+        assert turn.agent_id == "showrunner"
+        assert turn.session_id == "session-123"
+        assert turn.input is None
+        assert turn.output is None
+        assert turn.status == TurnStatus.PENDING
+        assert turn.usage is None
+
+    def test_create_turn_with_input(self) -> None:
+        """Turn can be created with user input."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+            input="Hello, who are you?",
+        )
+        assert turn.input == "Hello, who are you?"
+
+    def test_turn_start(self) -> None:
+        """start() marks turn as streaming."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+        )
+        assert turn.status == TurnStatus.PENDING
+
+        turn.start()
+        assert turn.status == TurnStatus.STREAMING
+
+    def test_turn_complete(self) -> None:
+        """complete() marks turn with output and status."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+            input="Hello",
+        )
+        turn.start()
+
+        usage = TokenUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        turn.complete("Hello! I am the Showrunner.", usage)
+
+        assert turn.output == "Hello! I am the Showrunner."
+        assert turn.status == TurnStatus.COMPLETED
+        assert turn.ended_at is not None
+        assert turn.usage == usage
+
+    def test_turn_error(self) -> None:
+        """error() marks turn with error message."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+        )
+        turn.start()
+
+        turn.error("Connection timeout")
+
+        assert turn.output == "Connection timeout"
+        assert turn.status == TurnStatus.ERROR
+        assert turn.ended_at is not None
+
+    def test_turn_duration_not_completed(self) -> None:
+        """duration_ms is None before completion."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+        )
+        assert turn.duration_ms is None
+
+    def test_turn_duration_completed(self) -> None:
+        """duration_ms is calculated after completion."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+        )
+        turn.start()
+        turn.complete("Response")
+
+        assert turn.duration_ms is not None
+        assert turn.duration_ms >= 0
+
+    def test_turn_to_dict(self) -> None:
+        """Turn converts to dict correctly."""
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="session-123",
+            input="Hello",
+        )
+        turn.start()
+        turn.complete("Hi!", TokenUsage(prompt_tokens=10, completion_tokens=5))
+
+        d = turn.to_dict()
+        assert d["turn_number"] == 1
+        assert d["agent_id"] == "showrunner"
+        assert d["session_id"] == "session-123"
+        assert d["input"] == "Hello"
+        assert d["output"] == "Hi!"
+        assert d["status"] == "completed"
+        assert d["usage"]["prompt_tokens"] == 10
+        assert "started_at" in d
+        assert "ended_at" in d
+
+    def test_turn_from_dict(self) -> None:
+        """Turn can be created from dict."""
+        data = {
+            "turn_number": 2,
+            "agent_id": "lorekeeper",
+            "session_id": "session-456",
+            "input": "Tell me about the world",
+            "output": "This is a magical world...",
+            "started_at": "2024-12-14T10:00:00",
+            "ended_at": "2024-12-14T10:00:05",
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 100,
+                "total_tokens": 150,
+            },
+            "status": "completed",
+        }
+        turn = Turn.from_dict(data)
+
+        assert turn.turn_number == 2
+        assert turn.agent_id == "lorekeeper"
+        assert turn.input == "Tell me about the world"
+        assert turn.output == "This is a magical world..."
+        assert turn.status == TurnStatus.COMPLETED
+        assert turn.usage is not None
+        assert turn.usage.total_tokens == 150


### PR DESCRIPTION
## Summary

Implements the full Phase 1 single-agent execution pipeline:

- **LLM Providers**: Abstract base class with Ollama implementation supporting streaming
- **Session Management**: Sessions and turns with SQLite persistence
- **Agent Runtime**: ContextBuilder (knowledge injection), PromptBuilder, AgentRuntime
- **CLI `qf ask`**: Interactive REPL mode and single-shot query mode

### Key Features

- Streaming LLM responses with Rich Live rendering
- Knowledge injection from domain (constitution, must_know, role_specific)
- Context size validation (hard error on overflow - no silent truncation)
- Auto-creation of default project for frictionless UX
- Verbose logging flags (`-v`/`-vv`/`-vvv`) for debugging

### Usage

```bash
# Interactive REPL (auto-creates default project)
qf ask

# Single-shot query
qf ask "Hello, who are you?"

# With specific project
qf ask my_story "Tell me about this world"

# With verbose logging
qf ask -vvv "Debug this"
```

### Test Coverage

197 tests passing (110 new for Phase 1):

| Component | Tests |
|-----------|-------|
| Providers (base + ollama + streaming) | 33 |
| Session management | 36 |
| PromptBuilder | 14 |
| ContextBuilder | 10 |
| AgentRuntime | 13 |
| CLI `qf ask` | 10 |

## Test plan

- [x] All 197 tests pass (`uv run pytest tests/ -v`)
- [x] Pre-commit hooks pass (ruff, mypy, markdownlint)
- [x] Manual verification of `qf ask` in REPL mode
- [x] Manual verification of `qf ask "prompt"` single-shot mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)