### PR TITLE
feat(runtime): optimize prompts using v3 patterns

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,7 @@ Architecture and design documentation for the v4 runtime cleanroom rebuild.
 | [PHASE1_SINGLE_AGENT.md](PHASE1_SINGLE_AGENT.md) | LLM providers, sessions, agent runtime | #145 | Complete |
 | [PHASE2_TOOL_EXECUTION.md](PHASE2_TOOL_EXECUTION.md) | Tool infrastructure, registry, capability filtering | #146 | Complete |
 | [PHASE3_DELEGATION_MESSAGING.md](PHASE3_DELEGATION_MESSAGING.md) | Async messaging, delegation, playbook tracking | #147 | Complete |
+| [TOOL_CALLING_FIXES.md](TOOL_CALLING_FIXES.md) | Streaming tool calls, conversation flow fixes | — | Reference |
 
 ## Master Tracking
 

--- a/docs/design/TOOL_CALLING_FIXES.md
+++ b/docs/design/TOOL_CALLING_FIXES.md
@@ -1,0 +1,128 @@
+# Tool Calling Fixes (December 2025)
+
+## Overview
+
+This document captures fixes made to the V4 runtime tool calling system and identifies a gap that Phase 4 (Storage & Lifecycle) will address.
+
+## Issues Fixed
+
+### 1. Streaming Tool Call Arguments
+
+**Problem**: When using LangChain's streaming mode, tool call arguments arrived as empty `{}`.
+
+**Root Cause**: LangChain streaming sends tool call arguments as JSON string fragments via `tool_call_chunks`, not as parsed objects in `tool_calls`. The providers were only checking `tool_calls`.
+
+**Fix**: Both OpenAI and Ollama providers now accumulate `tool_call_chunks` by index and parse the JSON at stream end:
+
+```python
+# Track tool call chunks by index
+tool_call_builders: dict[int, dict[str, str]] = {}
+
+async for chunk in llm.astream(messages):
+    tool_call_chunks = getattr(chunk, "tool_call_chunks", None)
+    if tool_call_chunks:
+        for tcc in tool_call_chunks:
+            idx = tcc.get("index", 0)
+            if idx not in tool_call_builders:
+                tool_call_builders[idx] = {"id": "", "name": "", "args_json": ""}
+            builder = tool_call_builders[idx]
+            if tcc.get("id"):
+                builder["id"] = tcc["id"]
+            if tcc.get("name"):
+                builder["name"] = tcc["name"]
+            if tcc.get("args"):
+                builder["args_json"] += tcc["args"]  # Accumulate JSON fragments
+
+# Parse accumulated tool calls at end
+for builder in tool_call_builders.values():
+    args = json.loads(builder["args_json"]) if builder["args_json"] else {}
+    final_tool_calls.append(ToolCallRequest(id=builder["id"], name=builder["name"], arguments=args))
+```
+
+**Files Changed**:
+- `src/questfoundry/runtime/providers/openai.py`
+- `src/questfoundry/runtime/providers/ollama.py`
+
+### 2. Tool Call Conversation Flow Loop
+
+**Problem**: Models would loop calling the same tool repeatedly, ignoring tool results.
+
+**Root Cause**: LangChain requires `AIMessage` objects to have `tool_calls` attached so it can associate subsequent `ToolMessage` results. The V4 runtime's intermediate `LLMMessage` format didn't preserve `tool_calls`, breaking this association.
+
+**Fix**:
+1. Added `tool_calls` field to `LLMMessage` dataclass
+2. Updated message conversion to preserve `tool_calls` on `AIMessage`
+3. Updated runtime to store `tool_calls` on assistant messages
+
+**Files Changed**:
+- `src/questfoundry/runtime/providers/base.py` - Added `tool_calls` field
+- `src/questfoundry/runtime/providers/openai.py` - Preserve in conversion
+- `src/questfoundry/runtime/providers/ollama.py` - Preserve in conversion
+- `src/questfoundry/runtime/agent/runtime.py` - Store on messages
+
+### 3. CLI Non-Streaming Option
+
+**Problem**: Streaming mode is unreliable with some models (especially Ollama/qwen3:8b).
+
+**Fix**: Added `--no-stream` CLI option to disable streaming output.
+
+```bash
+uv run qf ask --no-stream -p ollama "create a story"
+```
+
+**Files Changed**:
+- `src/questfoundry/cli.py` - Added `--no-stream` flag and `_invoke_response()` function
+
+## Gap Identified: Artifact Persistence
+
+### Current State
+
+Agents like `scene_smith` have capabilities to create artifacts:
+- `create_sections` - "Create and update section prose"
+- `write_workspace` - "Can write draft sections"
+
+However, there is **no tool to actually save artifacts**. The model generates content in its response text, then tries to validate non-existent artifacts.
+
+### Observed Behavior
+
+From OpenAI test logs:
+```
+tool_call_start: validate_artifact, args: {artifact_id: "scene_1", artifact_type_id: "section"}
+tool_call_complete: success=false, error="No artifact data provided or found"
+```
+
+The model:
+1. Generates section content in its response
+2. Tries to validate `artifact_id="scene_1"`
+3. Fails because nothing was ever saved
+
+### Resolution
+
+This gap will be addressed by **Phase 4: Storage & Lifecycle** (Issue #148), which includes:
+- Store Manager with CRUD operations
+- Artifact Storage with schema validation on write
+- Lifecycle state management (draft -> review -> approved -> cold)
+
+### Workaround (Not Recommended)
+
+The `validate_artifact` tool supports inline `artifact_data`:
+```json
+validate_artifact(artifact_type_id="section", artifact_data={...content...})
+```
+
+However, this is awkward (massive JSON in tool calls) and doesn't provide persistence.
+
+## Test Results
+
+| Provider | Streaming | Non-Streaming |
+|----------|-----------|---------------|
+| OpenAI (gpt-4o) | Works | Works |
+| Ollama (qwen3:8b) | Flaky | Works |
+
+**Recommendation**: Use `--no-stream` with Ollama until streaming reliability improves.
+
+## Related Issues
+
+- #143 - V4 Runtime Cleanroom Rebuild (master tracking)
+- #147 - Phase 3: Delegation & Messaging (tool call flow)
+- #148 - Phase 4: Storage & Lifecycle (artifact persistence)

--- a/docs/design/TOOL_CALLING_FIXES.md
+++ b/docs/design/TOOL_CALLING_FIXES.md
@@ -40,6 +40,7 @@ for builder in tool_call_builders.values():
 ```
 
 **Files Changed**:
+
 - `src/questfoundry/runtime/providers/openai.py`
 - `src/questfoundry/runtime/providers/ollama.py`
 
@@ -50,11 +51,13 @@ for builder in tool_call_builders.values():
 **Root Cause**: LangChain requires `AIMessage` objects to have `tool_calls` attached so it can associate subsequent `ToolMessage` results. The V4 runtime's intermediate `LLMMessage` format didn't preserve `tool_calls`, breaking this association.
 
 **Fix**:
+
 1. Added `tool_calls` field to `LLMMessage` dataclass
 2. Updated message conversion to preserve `tool_calls` on `AIMessage`
 3. Updated runtime to store `tool_calls` on assistant messages
 
 **Files Changed**:
+
 - `src/questfoundry/runtime/providers/base.py` - Added `tool_calls` field
 - `src/questfoundry/runtime/providers/openai.py` - Preserve in conversion
 - `src/questfoundry/runtime/providers/ollama.py` - Preserve in conversion
@@ -71,6 +74,7 @@ uv run qf ask --no-stream -p ollama "create a story"
 ```
 
 **Files Changed**:
+
 - `src/questfoundry/cli.py` - Added `--no-stream` flag and `_invoke_response()` function
 
 ## Gap Identified: Artifact Persistence
@@ -78,6 +82,7 @@ uv run qf ask --no-stream -p ollama "create a story"
 ### Current State
 
 Agents like `scene_smith` have capabilities to create artifacts:
+
 - `create_sections` - "Create and update section prose"
 - `write_workspace` - "Can write draft sections"
 
@@ -86,12 +91,14 @@ However, there is **no tool to actually save artifacts**. The model generates co
 ### Observed Behavior
 
 From OpenAI test logs:
-```
+
+```text
 tool_call_start: validate_artifact, args: {artifact_id: "scene_1", artifact_type_id: "section"}
 tool_call_complete: success=false, error="No artifact data provided or found"
 ```
 
 The model:
+
 1. Generates section content in its response
 2. Tries to validate `artifact_id="scene_1"`
 3. Fails because nothing was ever saved
@@ -99,6 +106,7 @@ The model:
 ### Resolution
 
 This gap will be addressed by **Phase 4: Storage & Lifecycle** (Issue #148), which includes:
+
 - Store Manager with CRUD operations
 - Artifact Storage with schema validation on write
 - Lifecycle state management (draft -> review -> approved -> cold)
@@ -106,6 +114,7 @@ This gap will be addressed by **Phase 4: Storage & Lifecycle** (Issue #148), whi
 ### Workaround (Not Recommended)
 
 The `validate_artifact` tool supports inline `artifact_data`:
+
 ```json
 validate_artifact(artifact_type_id="section", artifact_data={...content...})
 ```

--- a/domain-v4/agents/art_director.json
+++ b/domain-v4/agents/art_director.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "art_director",
   "name": "Art Director",
+  "summary": "Plans visual assets and references",
   "description": "Plans visual content: decides WHAT to illustrate, WHERE, and WHY. Creates Art Plans for all worthy scenes (planning is cheap). Sets priorities for budget-constrained generation. Maintains Reference Sheets for visual consistency of recurring elements (characters, locations, objects). Consults Style Lead for visual language guidance. Does NOT generate images—that's handled by tools when budget allows.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/audio_director.json
+++ b/domain-v4/agents/audio_director.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "audio_director",
   "name": "Audio Director",
+  "summary": "Plans audio assets and soundscapes",
   "description": "Plans audio experiences for the interactive fiction: ambient soundscapes, spot effects, and musical cues. Decides WHAT to sound and WHY, leaving generation details to the generate_audio tool. Maintains audio coherence through cuesheets. Remember: planning is cheap (LLM tokens), generation is expensive (API costs)—plan all worthy moments, generate selectively.",
 
   "archetypes": ["author"],

--- a/domain-v4/agents/book_binder.json
+++ b/domain-v4/agents/book_binder.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "book_binder",
   "name": "Book Binder",
+  "summary": "Exports final content to static formats",
   "description": "Turns Canon snapshots into player-safe export views. Package, don't rewrite. Assembles bundles (MD/HTML/EPUB/PDF), stamps front matter with snapshot ID and options, ensures navigation integrity, and maintains view logs. If text changes are needed, routes upstream - never edits in the binding step.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/codex_curator.json
+++ b/domain-v4/agents/codex_curator.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "codex_curator",
   "name": "Codex Curator",
+  "summary": "Creates player-safe glossary entries",
   "description": "Transforms canon into player-safe glossary entries. Reads the spoiler-level world bible and distills diegetic explanations that players can safely see. Every codex entry must feel like something an in-world scholar would write—no meta-knowledge, no fourth-wall breaks, no spoilers. Gatekeeper validates entries for leaks before publishing.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/gatekeeper.json
+++ b/domain-v4/agents/gatekeeper.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "gatekeeper",
   "name": "Gatekeeper",
+  "summary": "Validates quality against 8 quality bars",
   "description": "The book's bouncer, not its ghostwriter. Keeps checks lightweight and specific, protects player surfaces, and unblocks creators with pinpoint fixes. Enforces the 8 quality bars: Integrity, Reachability, Nonlinearity, Gateways, Style, Determinism, Presentation, Accessibility.",
 
   "archetypes": ["validator"],

--- a/domain-v4/agents/lore_weaver.json
+++ b/domain-v4/agents/lore_weaver.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "lore_weaver",
   "name": "Lore Weaver",
+  "summary": "Creates canon packs and world truth",
   "description": "Builds and maintains the canon—the spoiler-level world bible. Creates causes behind events, secret histories, faction motivations, metaphysical rules, and timeline anchors. Works from Showrunner briefs and Researcher findings. Canon Packs are portable lore containers shareable across multiple books. Codex Curator derives player-safe entries from this truth.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/player_narrator.json
+++ b/domain-v4/agents/player_narrator.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "player_narrator",
   "name": "Player-Narrator",
+  "summary": "Performs interactive fiction to live players",
   "description": "The dynamic export path: narrates interactive fiction to a live player. Performs authored content, presents choices, and handles player responses. Has agency to improvise color and handle off-script moments gracefully, but never contradicts canon or invents world state. When players stray from authored paths, acknowledges their intent and gently guides them back. Enforces all gates diegetically—the player should never see behind the curtain.",
 
   "archetypes": ["performer"],

--- a/domain-v4/agents/plotwright.json
+++ b/domain-v4/agents/plotwright.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "plotwright",
   "name": "Plotwright",
+  "summary": "Designs narrative structure and section briefs",
   "description": "Sketches the playground, not the paragraphs. Thinks in hubs, loops, gateways, and keystones. Makes choices contrastive, returns meaningful, and gates diegetic. Creates Section Briefs that Scene Smith can draft without guessing. Primary agent for Story Spark loop.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/researcher.json
+++ b/domain-v4/agents/researcher.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "researcher",
   "name": "Researcher",
+  "summary": "Verifies plausibility and real-world facts",
   "description": "Context-preserving fact service. Corroborates claims, estimates uncertainty, and returns concise memos so creative agents can stay focused on their work. Absorbs web-browsing context cost on behalf of callers. Provides posture (corroborated/plausible/disputed/uncorroborated) and player-safe neutral phrasing.",
 
   "archetypes": ["researcher"],

--- a/domain-v4/agents/scene_smith.json
+++ b/domain-v4/agents/scene_smith.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "scene_smith",
   "name": "Scene Smith",
+  "summary": "Writes prose sections with dialogue and choices",
   "description": "Shows the world, hides the gears. Writes clean beats and contrastive choices from Plotwright briefs. Keeps phrasing in register and enforces gates diegetically. Files hooks when fixes need structure or canon. Primary agent for Scene Weave loop.",
 
   "archetypes": ["creator"],

--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "showrunner",
   "name": "Showrunner",
+  "summary": "Orchestrates workflows, delegates to specialists",
   "description": "The orchestrator who activates roles, sets scope, and owns stabilization cadence. Keeps momentum high and changes small. Wakes only the roles needed for each TU, runs focused loops, and makes the next step obvious. Protects player surfaces by routing debates through the right neighbors.",
 
   "archetypes": ["orchestrator"],

--- a/domain-v4/agents/style_lead.json
+++ b/domain-v4/agents/style_lead.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/agent.schema.json",
   "id": "style_lead",
   "name": "Style Lead",
+  "summary": "Ensures voice and aesthetic consistency",
   "description": "Owns unified style across prose, visual, and audio surfaces. Keeps voice, register, visual language, and motifs coherent. Nudge, don't strangle: preserve creators' intent while making everything sing together. Reviews prose for voice drift, Art Plans for visual consistency, and surfaces for player safety. Produces Style Guide and Style Addenda with exemplars.",
 
   "archetypes": ["validator"],

--- a/domain-v4/artifact-types/art_plan.json
+++ b/domain-v4/artifact-types/art_plan.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "art_plan",
   "name": "Art Plan",
+  "summary": "Visual illustration planning document",
   "description": "Planning document for a single illustration slot. Specifies what to illustrate and why, leaving visual language details to the Style Guide. Planning is cheap—create Art Plans for ALL worthy scenes. Generation is selective based on priority and budget.",
   "category": "document",
 

--- a/domain-v4/artifact-types/audio_plan.json
+++ b/domain-v4/artifact-types/audio_plan.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "audio_plan",
   "name": "Audio Plan",
+  "summary": "Audio cue planning document",
   "description": "Planning document for a single audio cue. Specifies what to sound and why, leaving sonic aesthetic details to the Style Guide. Planning is cheap—create Audio Plans for ALL worthy moments. Generation is selective based on priority and budget.",
   "category": "document",
 

--- a/domain-v4/artifact-types/build_manifest.json
+++ b/domain-v4/artifact-types/build_manifest.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "build_manifest",
   "name": "Build Manifest",
+  "summary": "Machine-readable export build record",
   "description": "Machine-readable record of an export build. Contains full configuration, integrity report, output file references, and determinism data. This is the internal counterpart to View Log - it contains everything needed to reproduce or debug a build, but is NOT player-safe.",
   "category": "manifest",
 

--- a/domain-v4/artifact-types/canon_pack.json
+++ b/domain-v4/artifact-types/canon_pack.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "canon_pack",
   "name": "Canon Pack",
+  "summary": "World truth for internal use",
   "description": "Portable container of world truth. Holds spoiler-level lore: causes, timelines, secrets, faction motivations, metaphysical rules. Canon Packs can be shared across multiple books using the same world. Creative agents consult canon; players never see it. Lore Weaver is the exclusive producer.",
   "category": "reference",
 

--- a/domain-v4/artifact-types/codex_entry.json
+++ b/domain-v4/artifact-types/codex_entry.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "codex_entry",
   "name": "Codex Entry",
+  "summary": "Player-safe glossary entry",
   "description": "Player-safe glossary entry. Diegetic explanation of a term, entity, place, or concept that players can read without spoilers. Written as an in-world scholar would write it. Derived from canon by Codex Curator, validated by Gatekeeper for spoiler leaks.",
   "category": "reference",
 

--- a/domain-v4/artifact-types/cuelist.json
+++ b/domain-v4/artifact-types/cuelist.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "cuelist",
   "name": "Cuelist",
+  "summary": "Index of Audio Plans for a scope",
   "description": "Index of Audio Plans for a scope (chapter, act, or book). Tracks priorities, statuses, cue types, and budget allocation. Audio Director creates cuelists to manage audio coverage. Each entry references a full Audio Plan.",
   "category": "manifest",
 

--- a/domain-v4/artifact-types/gatecheck_report.json
+++ b/domain-v4/artifact-types/gatecheck_report.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "gatecheck_report",
   "name": "Gatecheck Report",
+  "summary": "Quality validation results",
   "description": "Gatekeeper's formal assessment of a TU or View against the 8 quality bars. Names each bar status (green/yellow/red), cites the smallest viable fix, and routes to the correct owner. Examples must be player-safe; never paste Hot content.",
   "category": "feedback",
 

--- a/domain-v4/artifact-types/hook_card.json
+++ b/domain-v4/artifact-types/hook_card.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "hook_card",
   "name": "Hook Card",
+  "summary": "Captured idea for triage",
   "description": "A small, traceable follow-up capturing a new need or uncertainty without derailing current work. Hooks are classified, routed to the correct owner, and developed through loops. The player-safe summary is clean; spoilers live in hot_details only.",
   "category": "record",
 

--- a/domain-v4/artifact-types/reference_sheet.json
+++ b/domain-v4/artifact-types/reference_sheet.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "reference_sheet",
   "name": "Reference Sheet",
+  "summary": "Visual reference for recurring elements",
   "description": "Visual reference for recurring elements: characters, locations, or objects. Ensures visual consistency across illustrations. Art Director maintains these; generate_image tool consults them for consistency.",
   "category": "reference",
 

--- a/domain-v4/artifact-types/research_memo.json
+++ b/domain-v4/artifact-types/research_memo.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "research_memo",
   "name": "Research Memo",
+  "summary": "Factual findings from Researcher",
   "description": "Concise factual findings from Researcher. Contains question, short answer, citations, posture (certainty level), and optional neutral phrasing for surfaces. Memos are decision-ready summaries, not exhaustive dumps. They remain in Hot as reference documents and are not exported to players.",
   "category": "document",
 

--- a/domain-v4/artifact-types/section.json
+++ b/domain-v4/artifact-types/section.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "section",
   "name": "Section",
+  "summary": "Interactive story section with choices",
   "description": "A complete unit of narrative prose ending in one or more player-facing choices. Sections are the atomic reading units of the manuscript, written by Scene Smith from Section Briefs. In Cold state, sections are player-safe and ready for export.",
   "category": "document",
 

--- a/domain-v4/artifact-types/section_brief.json
+++ b/domain-v4/artifact-types/section_brief.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "section_brief",
   "name": "Section Brief",
+  "summary": "Structure spec for scene_smith",
   "description": "Writing instructions from Plotwright to Scene Smith for drafting a specific section. Defines goal, beats, choice intents, and expected outcomes. Section Briefs are the bridge between Story Spark (structure) and Scene Weave (prose). They remain in Hot as working documents and are not exported to players.",
   "category": "document",
 

--- a/domain-v4/artifact-types/shotlist.json
+++ b/domain-v4/artifact-types/shotlist.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "shotlist",
   "name": "Shotlist",
+  "summary": "Index of Art Plans for a scope",
   "description": "Index of Art Plans for a scope (chapter, act, or book). Tracks priorities, statuses, and budget allocation. Art Director creates shotlists to manage illustration coverage. Each entry references a full Art Plan.",
   "category": "manifest",
 

--- a/domain-v4/artifact-types/style_addendum.json
+++ b/domain-v4/artifact-types/style_addendum.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "style_addendum",
   "name": "Style Addendum",
+  "summary": "Targeted style guidance with exemplars",
   "description": "Targeted style guidance from Style Lead. Contains exemplars, edit patterns, and specific notes for maintaining voice consistency, diegetic gate phrasing, and contrastive choice labels. Style Addenda guide validation rather than prescribe exact text.",
   "category": "guidance",
 

--- a/domain-v4/artifact-types/style_guide.json
+++ b/domain-v4/artifact-types/style_guide.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "style_guide",
   "name": "Style Guide",
+  "summary": "Unified prose, visual, and audio aesthetics",
   "description": "Unified style guide covering prose, visual, and audio aesthetics. Created and maintained by Style Lead. Defines voice, register, visual language, motif palette, and audio signature. All creative agents consult this for consistency. Style Addenda provide targeted clarifications for specific patterns.",
   "category": "guidance",
 

--- a/domain-v4/artifact-types/view_log.json
+++ b/domain-v4/artifact-types/view_log.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/artifact-type.schema.json",
   "id": "view_log",
   "name": "View Log",
+  "summary": "Export version history",
   "description": "Append-only log of export views generated from Canon snapshots. Each entry documents what was exported, when, from which snapshot, and with what options. Player-safe: can be included in exports to show version history without revealing internal details.",
   "category": "record",
 

--- a/domain-v4/playbooks/art_planning.json
+++ b/domain-v4/playbooks/art_planning.json
@@ -3,6 +3,7 @@
   "id": "art_planning",
   "name": "Art Planning",
   "version": "1.0.0",
+  "summary": "Plan visual assets for narrative scope",
   "purpose": "Plan visual content for a narrative scope. Create Art Plans for all worthy scenes (planning is cheap), organize into Shotlists with priorities, maintain Reference Sheets for consistency. Generation is separate and budget-constrained.",
 
   "description": "Art Planning is the visual content loop. Art Director decides WHAT to illustrate and WHY—not HOW. The philosophy: plan everything worth illustrating (cheap), generate selectively based on budget (expensive). Reference Sheets ensure recurring elements (characters, locations, objects) stay visually consistent. Style Lead validates visual language alignment. Generation happens via the generate_image tool when budget and priorities align.",

--- a/domain-v4/playbooks/audio_planning.json
+++ b/domain-v4/playbooks/audio_planning.json
@@ -3,6 +3,7 @@
   "id": "audio_planning",
   "name": "Audio Planning",
   "version": "1.0.0",
+  "summary": "Plan audio assets for narrative scope",
   "purpose": "Plan audio content for a narrative scope. Create Audio Plans for all worthy moments (planning is cheap), organize into Cuelists with priorities, maintain Reference Sheets for sonic consistency. Generation is separate and budget-constrained.",
 
   "description": "Audio Planning is the audio content loop. Audio Director decides WHAT to sound and WHY—not HOW. The philosophy: plan everything worth sounding (cheap), generate selectively based on budget (expensive). Reference Sheets ensure recurring sonic elements (leitmotifs, location ambients) stay consistent. Style Lead validates audio aesthetic alignment. Generation happens via the generate_audio tool when budget and priorities align.",

--- a/domain-v4/playbooks/binding_run.json
+++ b/domain-v4/playbooks/binding_run.json
@@ -3,6 +3,7 @@
   "id": "binding_run",
   "name": "Binding Run",
   "version": "1.0.0",
+  "summary": "Export approved content to distributable formats",
   "purpose": "Assemble a player-safe export view from a Canon snapshot. Package manuscript, codex, and optional assets without leaking spoilers or internal plumbing.",
 
   "description": "Binding Run is the export loop. Book Binder packages what exists—no rewrites, no content changes. The focus is on integrity (all links resolve), presentation safety (no internals leak), and clear provenance (snapshot ID and options stamped). If issues are found, they're routed upstream via hooks. The output is a distributable bundle plus view log and build manifest.",

--- a/domain-v4/playbooks/hook_harvest.json
+++ b/domain-v4/playbooks/hook_harvest.json
@@ -3,6 +3,7 @@
   "id": "hook_harvest",
   "name": "Hook Harvest",
   "version": "1.0.0",
+  "summary": "Triage hooks: accept, defer, or reject",
   "purpose": "Collect, cluster, and triage hooks from creative work. Decide what advances now, what defers, and what gets rejected. Fast ideas, safe canon.",
 
   "description": "Hook Harvest is the triage loop. Showrunner sweeps up newly proposed hooks from Story Spark, Scene Weave, and other creative bursts. The goal is to remove duplicates, cluster related ideas, annotate with uncertainty and dependencies, and make clear decisions: accepted (with next loop), deferred (with wake condition), or rejected (with reason). This loop maintains velocity by keeping the hook backlog clean.",

--- a/domain-v4/playbooks/lore_deepening.json
+++ b/domain-v4/playbooks/lore_deepening.json
@@ -3,6 +3,7 @@
   "id": "lore_deepening",
   "name": "Lore Deepening",
   "version": "1.0.0",
+  "summary": "Build canon and player-safe codex entries",
   "purpose": "Expand the world bible (canon) and derive player-safe glossary entries (codex). Build the lore that creative agents need, then surface what players can safely see.",
 
   "description": "Lore Deepening builds depth: the causes behind events, the secrets factions hide, the rules of the metaphysics. Lore Weaver creates Canon Packs—portable containers of world truth. Codex Curator then distills player-safe entries from that truth. Style Lead ensures codex entries maintain diegetic voice. Gatekeeper validates that no spoilers leak into the codex.",

--- a/domain-v4/playbooks/scene_weave.json
+++ b/domain-v4/playbooks/scene_weave.json
@@ -3,6 +3,7 @@
   "id": "scene_weave",
   "name": "Scene Weave",
   "version": "1.0.0",
+  "summary": "Transform briefs into prose with choices",
   "purpose": "Transform Section Briefs into full prose Sections with dialogue, sensory detail, and contrastive choices. Voice first, structure assumed stable.",
 
   "description": "Scene Weave is the prose loop. Scene Smith fills structural shells from Story Spark with dialogue and sensory detail. The structure is assumed stable—this loop does not change topology, only inhabits it. The focus is on voice, aesthetic quality, contrastive choices, and diegetic gate phrasing. Hooks generated here are scene-level (traits, tells, props) rather than structural.",

--- a/domain-v4/playbooks/story_spark.json
+++ b/domain-v4/playbooks/story_spark.json
@@ -3,6 +3,7 @@
   "id": "story_spark",
   "name": "Story Spark",
   "version": "1.0.0",
+  "summary": "Design story structure and produce Section Briefs",
   "purpose": "Design or reshape narrative topology (hubs, loops, gateways, codewords) and produce Section Briefs for Scene Weave. Structure first, prose second.",
 
   "description": "Story Spark is the structure loop. Plotwright sketches the playground—not the paragraphs. The focus is on meaningful nonlinearity: hubs that fan out, loops that return with difference, gateways that gate diegetically. The output is Section Briefs that Scene Smith can draft without guessing intent. This loop explicitly does NOT write prose; it hands off structural shells to Scene Weave.",

--- a/domain-v4/studio.json
+++ b/domain-v4/studio.json
@@ -82,7 +82,10 @@
     "tools/generate_image.json",
     "tools/generate_audio.json",
     "tools/consult_corpus.json",
-    "tools/request_clarification.json"
+    "tools/request_clarification.json",
+    "tools/list_artifact_types.json",
+    "tools/list_stores.json",
+    "tools/list_agents.json"
   ],
 
   "quality_criteria": [
@@ -112,8 +115,8 @@
   },
 
   "metadata": {
-    "wave": 6,
+    "wave": 7,
     "status": "complete",
-    "notes": "Wave 6: Added Player-Narrator agent (dynamic export path). PN is a performer/consumer, not an author—narrates interactive fiction to live players with agency to improvise color while never contradicting canon. No playbooks (reactive to player input, not workflow-driven). Removed Translator from original plan (localization is out of scope for now). Studio definition complete: 12 agents, 11 tools, 16 artifact types, 2 asset types, 7 playbooks."
+    "notes": "Wave 7: Added list_* tools for explicit discovery (list_artifact_types, list_stores, list_agents). V3 pattern: compact menus in prompt with consult tools for full details. Studio definition: 12 agents, 15 tools, 16 artifact types, 2 asset types, 7 playbooks."
   }
 }

--- a/domain-v4/tools/consult_playbook.json
+++ b/domain-v4/tools/consult_playbook.json
@@ -2,16 +2,17 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "consult_playbook",
   "name": "Consult Playbook",
-  "description": "Retrieve full details for a playbook/workflow. Returns the sequence of phases and steps, which agents handle each step, input/output artifacts, completion criteria, and quality checkpoints. Use this to understand how to orchestrate a workflow.\n\nPattern: menu+consult - prompt includes summary menu, this tool provides full details on demand.",
+  "description": "Retrieve full details for a playbook/workflow. REQUIRED: You MUST provide the playbook_id parameter (e.g., 'story_spark'). Returns the sequence of phases and steps, which agents handle each step, input/output artifacts, completion criteria, and quality checkpoints. Use this to understand how to orchestrate a workflow.",
 
   "input_schema": {
     "type": "object",
     "properties": {
       "playbook_id": {
         "type": "string",
-        "description": "The ID of the playbook to retrieve (e.g., 'story_spark', 'scene_weave'). If omitted, lists all available playbooks."
+        "description": "The ID of the playbook to retrieve (e.g., 'story_spark', 'scene_weave'). See prompt for available playbook IDs."
       }
-    }
+    },
+    "required": ["playbook_id"]
   },
 
   "output_schema": {
@@ -60,8 +61,10 @@
       }
     },
     {
-      "description": "List all available playbooks",
-      "input": {}
+      "description": "Get full details for the Scene Weave workflow",
+      "input": {
+        "playbook_id": "scene_weave"
+      }
     }
   ]
 }

--- a/domain-v4/tools/list_agents.json
+++ b/domain-v4/tools/list_agents.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "list_agents",
+  "name": "List Agents",
+  "description": "List all agents available for delegation. Use this to discover what specialist agents exist and their archetypes before delegating work. Returns a compact list with id, name, archetypes, and brief description.",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "agents": {
+        "type": "array",
+        "description": "List of agents with id, name, archetypes, description"
+      },
+      "count": {
+        "type": "integer",
+        "description": "Number of agents"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Discover available agents for delegation",
+      "input": {},
+      "output": {
+        "agents": [
+          {"id": "plotwright", "name": "Plotwright", "archetypes": ["architect"], "description": "Designs story topology and structure"},
+          {"id": "scene_smith", "name": "Scene Smith", "archetypes": ["author", "creator"], "description": "Transforms skeleton scenes into engaging prose"}
+        ],
+        "count": 2
+      }
+    }
+  ]
+}

--- a/domain-v4/tools/list_artifact_types.json
+++ b/domain-v4/tools/list_artifact_types.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "list_artifact_types",
+  "name": "List Artifact Types",
+  "description": "List all available artifact types with brief descriptions. Use this to discover what artifact types exist before consulting their full schemas. Returns a compact list with id, name, category, and brief description for each type.",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "artifact_types": {
+        "type": "array",
+        "description": "List of artifact types with id, name, category, description"
+      },
+      "count": {
+        "type": "integer",
+        "description": "Number of artifact types"
+      },
+      "hint": {
+        "type": "string",
+        "description": "Hint for next action"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Discover available artifact types",
+      "input": {},
+      "output": {
+        "artifact_types": [
+          {"id": "section", "name": "Section", "category": "narrative", "description": "Story section with prose, choices, and gates"},
+          {"id": "section_brief", "name": "Section Brief", "category": "planning", "description": "Structural outline before prose writing"}
+        ],
+        "count": 2,
+        "hint": "Use consult_schema(artifact_type_id) for full field definitions."
+      }
+    }
+  ]
+}

--- a/domain-v4/tools/list_stores.json
+++ b/domain-v4/tools/list_stores.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "list_stores",
+  "name": "List Stores",
+  "description": "List all available stores with their semantics and descriptions. Use this to discover what stores exist and understand their access patterns (hot, cold, versioned, ephemeral).",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "stores": {
+        "type": "array",
+        "description": "List of stores with id, name, semantics, description"
+      },
+      "count": {
+        "type": "integer",
+        "description": "Number of stores"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Discover available stores",
+      "input": {},
+      "output": {
+        "stores": [
+          {"id": "workspace", "name": "Workspace", "semantics": "hot", "description": "Working memory for drafts and in-progress work"},
+          {"id": "canon", "name": "Canon Store", "semantics": "cold", "description": "Permanent storage for approved artifacts"}
+        ],
+        "count": 2
+      }
+    }
+  ]
+}

--- a/meta/schemas/core/_definitions.schema.json
+++ b/meta/schemas/core/_definitions.schema.json
@@ -26,6 +26,12 @@
       "description": "A brief explanation of purpose or function"
     },
 
+    "summary": {
+      "type": "string",
+      "maxLength": 100,
+      "description": "A concise one-line summary for compact display in menus and prompts"
+    },
+
     "markdown_text": {
       "type": "string",
       "description": "Longer-form text content, may contain markdown formatting"

--- a/meta/schemas/core/agent.schema.json
+++ b/meta/schemas/core/agent.schema.json
@@ -23,6 +23,11 @@
       "description": "What this agent does and why it exists"
     },
 
+    "summary": {
+      "$ref": "_definitions.schema.json#/$defs/summary",
+      "description": "Concise one-liner for delegation menus. Use description for full explanation."
+    },
+
     "archetypes": {
       "type": "array",
       "items": {

--- a/meta/schemas/core/artifact-type.schema.json
+++ b/meta/schemas/core/artifact-type.schema.json
@@ -23,6 +23,11 @@
       "description": "What this artifact represents and when it is used"
     },
 
+    "summary": {
+      "$ref": "_definitions.schema.json#/$defs/summary",
+      "description": "Concise one-liner for artifact type menus. Use description for full explanation."
+    },
+
     "category": {
       "type": "string",
       "enum": [

--- a/meta/schemas/core/playbook.schema.json
+++ b/meta/schemas/core/playbook.schema.json
@@ -24,6 +24,11 @@
       "description": "What this playbook accomplishes. Used by orchestrator to select appropriate playbook."
     },
 
+    "summary": {
+      "$ref": "_definitions.schema.json#/$defs/summary",
+      "description": "Concise one-liner for prompt menus. Use purpose for full explanation."
+    },
+
     "description": {
       "$ref": "_definitions.schema.json#/$defs/markdown_text",
       "description": "Detailed description of when and how to use this playbook"

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from questfoundry.runtime.messaging import AsyncMessageBroker
     from questfoundry.runtime.models import Agent, Studio
     from questfoundry.runtime.observability import EventLogger, TracingManager
-    from questfoundry.runtime.providers import OllamaProvider
+    from questfoundry.runtime.providers import LLMProvider, OllamaProvider
     from questfoundry.runtime.session import Session
     from questfoundry.runtime.storage import Project
 from rich.console import Console
@@ -382,6 +382,13 @@ def ask(
             help="Enable/disable interactive mode (default: auto-detect TTY)",
         ),
     ] = None,
+    stream: Annotated[
+        bool,
+        typer.Option(
+            "--stream/--no-stream",
+            help="Enable/disable streaming output (default: streaming enabled)",
+        ),
+    ] = True,
     verbose: Annotated[  # noqa: ARG001 - callback sets global _verbosity
         int,
         typer.Option(
@@ -414,6 +421,7 @@ def ask(
                 model,
                 log,
                 is_interactive,
+                stream,
             )
         )
     else:
@@ -464,7 +472,7 @@ async def _setup_runtime(
     AgentRuntime,
     Agent,
     Session,
-    OllamaProvider,
+    LLMProvider,
     EventLogger | None,
     Path | None,
     AsyncMessageBroker,
@@ -523,17 +531,35 @@ async def _setup_runtime(
         project.close()
         raise typer.Exit(1)
 
-    host: str = provider_config.host or "http://localhost:11434"
     model_to_use: str = model or provider_config.default_model or "qwen3:8b"
 
-    # Create provider
-    logger.debug(f"Connecting to {selected_provider} at {host}")
-    provider = OllamaProvider(host=host)
+    # Create provider based on type
+    from questfoundry.runtime.providers import OpenAIProvider
+
+    provider: OllamaProvider | OpenAIProvider
+    if selected_provider == "openai":
+        logger.debug("Connecting to OpenAI API")
+        try:
+            provider = OpenAIProvider()
+        except Exception as e:
+            console.print(f"[red]✗ OpenAI provider error: {e}[/red]")
+            project.close()
+            raise typer.Exit(1) from None
+    else:
+        # Default to Ollama for ollama or any other provider
+        host: str = provider_config.host or "http://localhost:11434"
+        logger.debug(f"Connecting to {selected_provider} at {host}")
+        provider = OllamaProvider(host=host)
 
     # Check provider availability
     if not await provider.check_availability():
-        console.print(f"[red]✗ {selected_provider} not available at {host}[/red]")
-        console.print("[dim]Start Ollama with: ollama serve[/dim]")
+        if selected_provider == "openai":
+            console.print("[red]✗ OpenAI API not available[/red]")
+            console.print("[dim]Check OPENAI_API_KEY environment variable[/dim]")
+        else:
+            host = provider_config.host or "http://localhost:11434"
+            console.print(f"[red]✗ {selected_provider} not available at {host}[/red]")
+            console.print("[dim]Start Ollama with: ollama serve[/dim]")
         project.close()
         raise typer.Exit(1)
 
@@ -698,6 +724,84 @@ async def _stream_response(
     return full_content
 
 
+async def _invoke_response(
+    runtime: AgentRuntime,
+    agent: Agent,
+    user_input: str,
+    session: Session,
+    process_delegations: bool = True,
+) -> str:
+    """Invoke agent without streaming (single response)."""
+    import time
+
+    logger = logging.getLogger("questfoundry.cli")
+
+    start_time = time.time()
+
+    # Show prompt at -vvv
+    if _verbosity >= 3:
+        context = runtime.build_context(agent)
+        messages = runtime.build_messages(agent, user_input, context)
+        console.print()
+        console.print("[dim]─── Prompt ───[/dim]")
+        for msg in messages:
+            role_color = {"system": "yellow", "user": "green", "assistant": "blue"}.get(
+                msg.role, "white"
+            )
+            console.print(f"[{role_color}]{msg.role}:[/{role_color}]")
+            content = msg.content
+            if msg.role == "system" and len(content) > 2000:
+                content = content[:2000] + f"\n... ({len(msg.content)} chars total)"
+            console.print(f"[dim]{content}[/dim]")
+            console.print()
+        console.print("[dim]─── Response ───[/dim]")
+
+    # Non-streaming activation
+    result = await runtime.activate(agent, user_input, session)
+    full_content = result.content
+
+    # Print the response
+    console.print(full_content)
+
+    duration_ms = (time.time() - start_time) * 1000
+
+    # Show token usage at -v+
+    if _verbosity >= 1 and result.usage:
+        tokens_info = []
+        if result.usage.prompt_tokens:
+            tokens_info.append(f"prompt: {result.usage.prompt_tokens}")
+        if result.usage.completion_tokens:
+            tokens_info.append(f"completion: {result.usage.completion_tokens}")
+        if result.usage.total_tokens:
+            tokens_info.append(f"total: {result.usage.total_tokens}")
+        if tokens_info:
+            console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
+
+    # Show timing at -vv+
+    if _verbosity >= 2:
+        console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
+        logger.debug(f"Response generated in {duration_ms:.0f}ms")
+
+    # Process any pending delegations
+    if process_delegations:
+        delegation_results = await runtime.process_pending_delegations(session)
+        if delegation_results:
+            console.print()
+            console.print(f"[dim]── Processed {len(delegation_results)} delegation(s) ──[/dim]")
+            for dr in delegation_results:
+                status = "[green]✓[/green]" if dr.get("success") else "[red]✗[/red]"
+                to_agent = dr.get("to_agent", "unknown")
+                task_preview = dr.get("task", "")[:40]
+                console.print(f"  {status} {to_agent}: {task_preview}...")
+                if dr.get("success") and _verbosity >= 2:
+                    response_preview = str(dr.get("result", ""))[:200]
+                    console.print(f"    [dim]{response_preview}...[/dim]")
+                elif not dr.get("success"):
+                    console.print(f"    [red]{dr.get('error', 'Unknown error')}[/red]")
+
+    return full_content
+
+
 async def _handle_clarification_requests(
     broker: AsyncMessageBroker,
 ) -> list[dict[str, Any]]:
@@ -846,6 +950,7 @@ async def _ask_single(
     model: str | None,
     log: bool = False,
     interactive: bool = True,
+    stream: bool = True,
 ) -> None:
     """Execute a single-shot query."""
     from questfoundry.runtime.providers import ContextOverflowError, ProviderError
@@ -872,6 +977,9 @@ async def _ask_single(
         interactive,
     )
 
+    # Select response function based on streaming preference
+    respond = _stream_response if stream else _invoke_response
+
     # Wrap execution in LangSmith session tracing
     with (
         tracing_manager.session(session.id, agent.id, project_id)
@@ -880,7 +988,7 @@ async def _ask_single(
     ):
         try:
             console.print(f"[dim]{agent.name}:[/dim]")
-            await _stream_response(runtime, agent, prompt, session)
+            await respond(runtime, agent, prompt, session)
             console.print()
 
             # Handle clarification requests in a loop
@@ -901,7 +1009,7 @@ async def _ask_single(
 
                     # Build a context message for the agent with the clarification response
                     context_msg = f"[Customer response to your question: {answer}]"
-                    await _stream_response(runtime, agent, context_msg, session)
+                    await respond(runtime, agent, context_msg, session)
                     console.print()
 
         except ContextOverflowError as e:

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -105,8 +105,8 @@ class PromptBuilder:
         # Priority ordering: actionable content first, reference material later
         # Higher priority = appears earlier in prompt
         #
-        # Identity & Delegation (who you are, who to work with):
-        #   identity (100), agents (95), behavioral (92)
+        # Identity & Behavior (who you are, how to behave):
+        #   identity (100), behavioral (98), agents (95)
         # Actionable (what to do NOW):
         #   tools (90), playbooks (85)
         # Operational (how to behave):
@@ -127,7 +127,7 @@ class PromptBuilder:
         # V3 pattern: This was critical for keeping models on track
         archetypes = [a.value if hasattr(a, "value") else str(a) for a in (agent.archetypes or [])]
         behavioral = self._build_behavioral_guidance(archetypes)
-        self.add_section("behavioral", behavioral, priority=92)
+        self.add_section("behavioral", behavioral, priority=98)
 
         # 4. Available Tools (actionable - how to act)
         if tool_schemas:
@@ -287,7 +287,8 @@ class PromptBuilder:
 
         for pb in playbooks:
             name = pb.get("name", pb.get("id", "Unknown"))
-            purpose = (pb.get("purpose", "") or "")[:80]
+            # Use summary (preferred) or fall back to purpose
+            purpose = pb.get("summary") or pb.get("purpose", "")
             pb_id = pb.get("id", "")
             lines.append(f"- **{name}** (`{pb_id}`): {purpose}")
 
@@ -313,8 +314,9 @@ class PromptBuilder:
             name = ag.get("name", ag.get("id", "Unknown"))
             archetypes = ag.get("archetypes", [])
             archetypes_str = ", ".join(archetypes[:2]) if archetypes else "general"
+            # Use summary (preferred) or fall back to first specialty
             specialties = ag.get("specialties", [])
-            spec = specialties[0][:40] if specialties else ""
+            spec = ag.get("summary") or (specialties[0] if specialties else "")
             lines.append(f"| {name} | {archetypes_str} | {spec} |")
 
         lines.append("")
@@ -339,7 +341,8 @@ class PromptBuilder:
 
         for tool in tool_schemas:
             name = tool.get("name", "unknown")
-            desc = (tool.get("description", "") or "").split("\n")[0][:80]
+            # Use first line of description (no truncation - keep domain data short instead)
+            desc = (tool.get("description", "") or "").split("\n")[0]
             lines.append(f"- **{name}**: {desc}")
 
         return "\n".join(lines)
@@ -410,15 +413,42 @@ class PromptBuilder:
         if "orchestrator" in archetypes_lower:
             lines.extend(
                 [
+                    "## CRITICAL: First Action Must Be consult_playbook",
+                    "",
+                    "**Your VERY FIRST action must be to call the consult_playbook tool** with",
+                    "playbook_id='story_spark' to understand the workflow for new story requests.",
+                    "",
+                    "Example tool call:",
+                    "```",
+                    "consult_playbook(playbook_id='story_spark')",
+                    "```",
+                    "",
+                    "This will tell you:",
+                    "- What workflow steps are recommended",
+                    "- Which roles to delegate to and in what order",
+                    "- What quality gates apply",
+                    "",
+                    "## Workflow Pattern",
+                    "",
+                    "1. User request arrives",
+                    "2. IMMEDIATELY call consult_playbook with playbook_id='story_spark'",
+                    "3. Follow the playbook's steps (typically: plotwright -> scene_smith)",
+                    "4. Pass artifact IDs between delegations",
+                    "5. Delegate to gatekeeper for quality validation",
+                    "",
+                    "## Output Format",
+                    "",
                     "Your responses should consist of:",
-                    "1. **Tool calls** - delegate, consult_playbook, terminate",
+                    "1. **Tool calls** - consult_playbook, delegate",
                     "2. **Brief status updates** - 1-2 sentences",
                     "",
-                    "DO NOT write narrative content. Delegate creative work.",
+                    "**NEVER generate story content yourself.** If your response contains more",
+                    "than 2-3 sentences that aren't a tool call, you're doing it wrong.",
+                    "",
+                    "## Anti-Pattern Reminder",
                     "",
                     "WRONG: The detective entered the dimly lit room, her footsteps echoing...",
-                    "CORRECT: I'll delegate scene writing to the appropriate specialist.",
-                    "         [delegate(to_agent='scene_smith', task='Write entrance scene')]",
+                    "RIGHT: [makes consult_playbook tool call with playbook_id='story_spark']",
                 ]
             )
         elif any(a in archetypes_lower for a in ["creator", "author", "writer"]):

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -105,8 +105,10 @@ class PromptBuilder:
         # Priority ordering: actionable content first, reference material later
         # Higher priority = appears earlier in prompt
         #
+        # Identity & Delegation (who you are, who to work with):
+        #   identity (100), agents (95), behavioral (92)
         # Actionable (what to do NOW):
-        #   identity (100), agents (95), tools (90), playbooks (85)
+        #   tools (90), playbooks (85)
         # Operational (how to behave):
         #   capabilities (80), constraints (75)
         # Reference (background knowledge):
@@ -121,48 +123,54 @@ class PromptBuilder:
             agents_section = self._build_agents_section(agents_menu)
             self.add_section("agents", agents_section, priority=95)
 
-        # 3. Available Tools (actionable - how to act)
+        # 3. Behavioral Guidance (operational - WRONG/CORRECT examples by archetype)
+        # V3 pattern: This was critical for keeping models on track
+        archetypes = [a.value if hasattr(a, "value") else str(a) for a in (agent.archetypes or [])]
+        behavioral = self._build_behavioral_guidance(archetypes)
+        self.add_section("behavioral", behavioral, priority=92)
+
+        # 4. Available Tools (actionable - how to act)
         if tool_schemas:
             tools_section = self._build_tools_section(tool_schemas)
             self.add_section("tools", tools_section, priority=90)
 
-        # 4. Available Playbooks (actionable - workflow guidance)
+        # 5. Available Playbooks (actionable - workflow guidance)
         if playbooks_menu:
             playbooks_section = self._build_playbooks_section(playbooks_menu)
             self.add_section("playbooks", playbooks_section, priority=85)
 
-        # 5. Capabilities (operational - what you can do)
+        # 6. Capabilities (operational - what you can do)
         if agent.capabilities:
             capabilities = self._build_capabilities_section(agent)
             self.add_section("capabilities", capabilities, priority=80)
 
-        # 6. Constraints (operational - what not to do)
+        # 7. Constraints (operational - what not to do)
         if agent.constraints:
             constraints = self._build_constraints_section(agent)
             self.add_section("constraints", constraints, priority=75)
 
-        # 7. Constitution (reference - principles)
+        # 8. Constitution (reference - principles)
         if constitution_text:
             self.add_section(
                 "constitution", self._format_constitution(constitution_text), priority=65
             )
 
-        # 8. Must Know (reference - knowledge including operational guidelines)
+        # 9. Must Know (reference - knowledge including operational guidelines)
         if must_know_entries:
             must_know = self._build_must_know_section(must_know_entries)
             self.add_section("must_know", must_know, priority=60)
 
-        # 9. Store Access (reference - what stores you can read/write)
+        # 10. Store Access (reference - what stores you can read/write)
         if stores_menu:
             stores_section = self._build_stores_section(stores_menu)
             self.add_section("stores", stores_section, priority=55)
 
-        # 10. Artifact Types (reference - what types you can create)
+        # 11. Artifact Types (reference - what types you can create)
         if artifact_types_menu:
             artifact_types_section = self._build_artifact_types_section(artifact_types_menu)
             self.add_section("artifact_types", artifact_types_section, priority=50)
 
-        # 11. Available Knowledge Menu
+        # 12. Available Knowledge Menu
         if role_specific_menu:
             menu = self._build_knowledge_menu(role_specific_menu)
             self.add_section("knowledge_menu", menu, priority=45)
@@ -266,196 +274,209 @@ class PromptBuilder:
         return "\n".join(lines)
 
     def _build_playbooks_section(self, playbooks: list[dict[str, Any]]) -> str:
-        """Build the available playbooks menu.
+        """Build compact playbooks menu.
 
         Args:
             playbooks: List of playbook menu items with id, name, purpose, triggers, workflow
 
         Returns:
-            Formatted playbooks section for the prompt
+            Compact formatted playbooks section for the prompt
         """
         lines = ["## Available Playbooks\n"]
-        lines.append(
-            "These are the production workflows available in this studio. "
-            "Choose the appropriate playbook based on the task at hand:\n"
-        )
+        lines.append("Use `consult_playbook(id)` to get full workflow steps and outputs.\n")
 
         for pb in playbooks:
             name = pb.get("name", pb.get("id", "Unknown"))
-            purpose = pb.get("purpose", "")
-            triggers = pb.get("triggers", [])
-            workflow = pb.get("workflow", "")
+            purpose = (pb.get("purpose", "") or "")[:80]
             pb_id = pb.get("id", "")
-
-            lines.append(f"### {name} (`{pb_id}`)")
-            lines.append(f"{purpose}\n")
-
-            # Include workflow summary showing delegation sequence
-            if workflow:
-                lines.append(f"**Workflow:** {workflow}\n")
-
-            if triggers:
-                lines.append("**When to use:**")
-                for trigger in triggers:
-                    if trigger:
-                        lines.append(f"- {trigger}")
-                lines.append("")
+            lines.append(f"- **{name}** (`{pb_id}`): {purpose}")
 
         return "\n".join(lines)
 
     def _build_agents_section(self, agents: list[dict[str, Any]]) -> str:
-        """Build the delegation agents section.
+        """Build compact delegation agents table.
 
-        This is a CRITICAL section for orchestrators. It tells them WHO they can
-        delegate to and provides explicit instructions about delegation behavior.
+        V3 pattern: Compact table format instead of full descriptions.
+        Details available via list_agents() or consulting agent charters.
 
         Args:
             agents: List of agent menu items with id, name, description, archetypes, specialties
 
         Returns:
-            Formatted agents section for the prompt
+            Compact formatted agents section for the prompt
         """
-        lines = ["## Orchestrator Output Guidelines\n"]
-
-        # CRITICAL: Output format guidance (from v3 architecture)
-        lines.append(
-            "**Your responses should primarily consist of:**\n"
-            "1. **Tool calls** - `delegate`, `consult_schema`, `terminate`\n"
-            "2. **Brief status updates** - 1-2 sentences explaining what you're doing\n\n"
-            "**DO NOT** write paragraphs of narrative content. If you find yourself writing "
-            "story prose, character descriptions, or scene details, **STOP** and delegate "
-            "to the appropriate specialist agent instead.\n"
-        )
-
-        lines.append("\n## Delegation Protocol\n")
-
-        # Delegation instructions
-        lines.append(
-            "As an orchestrator, you coordinate work by DELEGATING tasks to specialist agents. "
-            "You do NOT perform specialist work yourself.\n\n"
-            "- When a task requires creating content (stories, sections, prose): delegate to creators\n"
-            "- When a task requires validation or quality checks: delegate to validators\n"
-            "- When a task requires research or fact-checking: delegate to researchers\n"
-            "- When a task requires managing knowledge or documentation: delegate to curators\n\n"
-            "Use the `delegate` tool to assign work. Always specify:\n"
-            "1. `to_agent`: The agent ID to delegate to\n"
-            "2. `task`: Clear description of what needs to be done\n"
-            "3. `expected_outputs`: What artifacts should be produced\n"
-        )
-
-        lines.append("\n## Available Agents\n")
+        lines = ["## Available Agents for Delegation\n"]
+        lines.append("| Agent | Archetype | Specialty |")
+        lines.append("|-------|-----------|-----------|")
 
         for ag in agents:
             name = ag.get("name", ag.get("id", "Unknown"))
-            ag_id = ag.get("id", "")
-            description = ag.get("description", "")
             archetypes = ag.get("archetypes", [])
+            archetypes_str = ", ".join(archetypes[:2]) if archetypes else "general"
             specialties = ag.get("specialties", [])
+            spec = specialties[0][:40] if specialties else ""
+            lines.append(f"| {name} | {archetypes_str} | {spec} |")
 
-            archetypes_str = ", ".join(archetypes) if archetypes else "general"
-            lines.append(f"### {name} (`{ag_id}`) - {archetypes_str}")
-            lines.append(f"{description}\n")
-
-            if specialties:
-                lines.append("**Specialties:**")
-                for spec in specialties[:3]:  # Limit to avoid bloat
-                    lines.append(f"- {spec}")
-                lines.append("")
+        lines.append("")
+        lines.append("Use `delegate(to_agent, task, expected_outputs)` to assign work.")
 
         return "\n".join(lines)
 
     def _build_tools_section(self, tool_schemas: list[dict[str, Any]]) -> str:
-        """Build the available tools section.
+        """Build compact tools list.
+
+        V3 pattern: Name + first line of description only.
+        LangChain already provides full parameter schemas to the model.
 
         Args:
             tool_schemas: List of tool schemas in LangChain format
                           Each has: name, description, parameters
 
         Returns:
-            Formatted tools section for the prompt
+            Compact formatted tools section for the prompt
         """
-        lines = ["## Available Tools\n"]
-        lines.append("You have access to the following tools. Use them to accomplish your tasks:\n")
+        lines = ["## Your Tools\n"]
 
         for tool in tool_schemas:
             name = tool.get("name", "unknown")
-            description = tool.get("description", "No description")
-            parameters = tool.get("parameters", {})
-
-            lines.append(f"### {name}")
-            lines.append(f"{description}\n")
-
-            # Format parameters if present
-            properties = parameters.get("properties", {})
-            required = parameters.get("required", [])
-
-            if properties:
-                lines.append("**Parameters:**")
-                for param_name, param_info in properties.items():
-                    param_type = param_info.get("type", "any")
-                    param_desc = param_info.get("description", "")
-                    is_required = param_name in required
-                    req_marker = " (required)" if is_required else ""
-                    lines.append(f"- `{param_name}` ({param_type}){req_marker}: {param_desc}")
-                lines.append("")
-
-        lines.append(
-            "To use a tool, specify a function call with the tool name and required parameters."
-        )
+            desc = (tool.get("description", "") or "").split("\n")[0][:80]
+            lines.append(f"- **{name}**: {desc}")
 
         return "\n".join(lines)
 
     def _build_stores_section(self, stores: list[dict[str, Any]]) -> str:
-        """Build the store access section.
+        """Build compact stores menu.
+
+        V3 pattern: Compact list with semantics and access level.
 
         Args:
             stores: List of store menu items with id, name, description, semantics, access
 
         Returns:
-            Formatted stores section for the prompt
+            Compact formatted stores section for the prompt
         """
         lines = ["## Your Store Access\n"]
-        lines.append("You can access the following stores:\n")
 
         for store in stores:
             name = store.get("name", store.get("id", "Unknown"))
-            store_id = store.get("id", "")
-            description = store.get("description", "")
             semantics = store.get("semantics", "unknown")
             access = store.get("access", "read")
-
-            lines.append(f"- **{name}** (`{store_id}`): {access} access, {semantics} storage")
-            if description:
-                lines.append(f"  {description}")
+            lines.append(f"- **{name}**: {access} ({semantics})")
 
         return "\n".join(lines)
 
     def _build_artifact_types_section(self, artifact_types: list[dict[str, Any]]) -> str:
-        """Build the artifact types section.
+        """Build compact artifact types menu.
+
+        V3 pattern: Compact list with consult hint for full schemas.
+        Types are already role-specific (filtered in context.py).
 
         Args:
             artifact_types: List of artifact type menu items with id, name, description, category, actions
 
         Returns:
-            Formatted artifact types section for the prompt
+            Compact formatted artifact types section for the prompt
         """
-        lines = ["## Artifact Types You Can Work With\n"]
-        lines.append(
-            "You can create, read, or update the following artifact types. "
-            "Use `consult_schema` to get full field definitions before creating artifacts:\n"
-        )
+        lines = ["## Artifact Types\n"]
+        lines.append("Use `consult_schema(id)` for full field definitions.\n")
 
         for at in artifact_types:
             name = at.get("name", at.get("id", "Unknown"))
             at_id = at.get("id", "")
-            description = at.get("description", "")
             category = at.get("category", "document")
             actions = at.get("actions", ["read"])
-
             actions_str = ", ".join(actions)
             lines.append(f"- **{name}** (`{at_id}`): [{actions_str}] ({category})")
-            if description:
-                lines.append(f"  {description}")
+
+        return "\n".join(lines)
+
+    def _build_behavioral_guidance(self, archetypes: list[str]) -> str:
+        """Build archetype-specific behavioral guidance with WRONG/CORRECT examples.
+
+        V3 pattern: Explicit examples of what NOT to do and what TO do.
+        This was critical for keeping models on track.
+
+        Args:
+            archetypes: List of archetype strings for the agent
+
+        Returns:
+            Formatted behavioral guidance section
+        """
+        lines = ["## Output Guidelines\n"]
+
+        # Normalize archetypes to lowercase for matching
+        archetypes_lower = [a.lower() for a in archetypes]
+
+        if "orchestrator" in archetypes_lower:
+            lines.extend(
+                [
+                    "Your responses should consist of:",
+                    "1. **Tool calls** - delegate, consult_playbook, terminate",
+                    "2. **Brief status updates** - 1-2 sentences",
+                    "",
+                    "DO NOT write narrative content. Delegate creative work.",
+                    "",
+                    "WRONG: The detective entered the dimly lit room, her footsteps echoing...",
+                    "CORRECT: I'll delegate scene writing to the appropriate specialist.",
+                    "         [delegate(to_agent='scene_smith', task='Write entrance scene')]",
+                ]
+            )
+        elif any(a in archetypes_lower for a in ["creator", "author", "writer"]):
+            lines.extend(
+                [
+                    "CRITICAL: Write artifacts to storage BEFORE returning.",
+                    "",
+                    "WRONG: Returning without persisting work",
+                    "CORRECT: write_artifact(key='scene_1', value={...}) THEN return_to_sr(...)",
+                    "",
+                    "Always call write_artifact for each piece of content you create,",
+                    "then return_to_sr with the list of artifact IDs.",
+                ]
+            )
+        elif any(a in archetypes_lower for a in ["validator", "auditor", "guardian"]):
+            lines.extend(
+                [
+                    "CRITICAL: Read artifacts before approving.",
+                    "",
+                    "WRONG: Approving without inspection",
+                    "CORRECT: read_artifact('scene_1') -> check criteria -> report findings",
+                    "",
+                    "Always read each artifact, evaluate against quality criteria,",
+                    "then return with detailed validation results.",
+                ]
+            )
+        elif any(a in archetypes_lower for a in ["architect", "planner", "designer"]):
+            lines.extend(
+                [
+                    "CRITICAL: Design structure, leave content empty for creators.",
+                    "",
+                    "WRONG: Writing prose content in structural artifacts",
+                    "CORRECT: Create skeleton with content='' for creators to fill",
+                    "",
+                    "Your role is topology - the 'bones' that prose hangs on.",
+                    "Scene Smith fills the actual prose content.",
+                ]
+            )
+        elif any(a in archetypes_lower for a in ["librarian", "curator", "archivist"]):
+            lines.extend(
+                [
+                    "CRITICAL: List existing artifacts before promoting.",
+                    "",
+                    "WRONG: Promoting only what was explicitly mentioned",
+                    "CORRECT: list_hot_store_keys() -> promote ALL matching artifacts",
+                    "",
+                    "Always discover what exists, then process everything.",
+                ]
+            )
+        else:
+            # Generic guidance for any role
+            lines.extend(
+                [
+                    "1. Read relevant artifacts before acting",
+                    "2. Persist your work with write_artifact before returning",
+                    "3. Return with status, artifacts list, and recommendation",
+                ]
+            )
 
         return "\n".join(lines)
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -640,14 +640,26 @@ class AgentRuntime:
                 if stop_tool:
                     logger.info("Stop tool '%s' called, ending activation", stop_tool)
                     stop_reason = stop_tool
-                    # Still add the messages for context
-                    messages.append(LLMMessage(role="assistant", content=response.content or ""))
+                    # Still add the messages for context - include tool_calls for proper conversation flow
+                    messages.append(
+                        LLMMessage(
+                            role="assistant",
+                            content=response.content or "",
+                            tool_calls=response.tool_calls,
+                        )
+                    )
                     tool_messages = self._tool_results_to_messages(tool_calls, tool_results)
                     messages.extend(tool_messages)
                     break
 
-                # Add assistant message with tool calls (empty content)
-                messages.append(LLMMessage(role="assistant", content=response.content or ""))
+                # Add assistant message with tool calls for proper LangChain conversation flow
+                messages.append(
+                    LLMMessage(
+                        role="assistant",
+                        content=response.content or "",
+                        tool_calls=response.tool_calls,
+                    )
+                )
 
                 # Add tool result messages
                 tool_messages = self._tool_results_to_messages(tool_calls, tool_results)
@@ -865,16 +877,28 @@ class AgentRuntime:
                     stop_tool, _ = self._check_for_stop_tool(tool_results)
                     if stop_tool:
                         logger.info("Stop tool '%s' called, ending streaming", stop_tool)
-                        # Add messages for completeness
-                        messages.append(LLMMessage(role="assistant", content=iteration_content))
+                        # Add messages for completeness - include tool_calls for proper conversation flow
+                        messages.append(
+                            LLMMessage(
+                                role="assistant",
+                                content=iteration_content,
+                                tool_calls=pending_tool_calls,
+                            )
+                        )
                         tool_messages = self._tool_results_to_messages(
                             pending_tool_calls, tool_results
                         )
                         messages.extend(tool_messages)
                         break
 
-                    # Add assistant message and tool results
-                    messages.append(LLMMessage(role="assistant", content=iteration_content))
+                    # Add assistant message with tool calls for proper LangChain conversation flow
+                    messages.append(
+                        LLMMessage(
+                            role="assistant",
+                            content=iteration_content,
+                            tool_calls=pending_tool_calls,
+                        )
+                    )
                     tool_messages = self._tool_results_to_messages(pending_tool_calls, tool_results)
                     messages.extend(tool_messages)
 

--- a/src/questfoundry/runtime/providers/base.py
+++ b/src/questfoundry/runtime/providers/base.py
@@ -53,6 +53,7 @@ class LLMMessage:
     content: str
     tool_call_id: str | None = None  # For tool result messages
     name: str | None = None  # Tool name for tool result messages
+    tool_calls: list[ToolCallRequest] | None = None  # For assistant messages with tool calls
 
 
 @dataclass
@@ -200,5 +201,14 @@ class LLMProvider(ABC):
 
         Returns:
             List of model identifiers
+        """
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """
+        Clean up provider resources.
+
+        Should be called when the provider is no longer needed.
         """
         ...

--- a/src/questfoundry/runtime/providers/ollama.py
+++ b/src/questfoundry/runtime/providers/ollama.py
@@ -77,7 +77,15 @@ class OllamaProvider(LLMProvider):
             elif msg.role == "user":
                 langchain_messages.append(HumanMessage(content=msg.content))
             elif msg.role == "assistant":
-                langchain_messages.append(AIMessage(content=msg.content))
+                # Include tool_calls on AIMessage if present
+                if msg.tool_calls:
+                    tool_calls = [
+                        {"id": tc.id, "name": tc.name, "args": tc.arguments}
+                        for tc in msg.tool_calls
+                    ]
+                    langchain_messages.append(AIMessage(content=msg.content, tool_calls=tool_calls))
+                else:
+                    langchain_messages.append(AIMessage(content=msg.content))
             elif msg.role == "tool":
                 # Tool result message
                 langchain_messages.append(
@@ -234,7 +242,9 @@ class OllamaProvider(LLMProvider):
             prompt_tokens: int | None = None
             completion_tokens: int | None = None
             total_tokens: int | None = None
-            accumulated_tool_calls: list[ToolCallRequest] = []
+            # Track tool call chunks by index to accumulate incrementally
+            # Key: index, Value: {"id": str, "name": str, "args_json": str}
+            tool_call_builders: dict[int, dict[str, str]] = {}
 
             async for chunk in llm.astream(langchain_messages, config=config):
                 # Extract content from chunk
@@ -249,24 +259,56 @@ class OllamaProvider(LLMProvider):
                     completion_tokens = usage_metadata.get("output_tokens")
                     total_tokens = usage_metadata.get("total_tokens")
 
-                # Accumulate tool calls from streaming chunks
-                chunk_tool_calls = self._parse_tool_calls(chunk)
-                if chunk_tool_calls:
-                    accumulated_tool_calls.extend(chunk_tool_calls)
+                # Accumulate tool call chunks (args come as JSON string fragments)
+                tool_call_chunks = getattr(chunk, "tool_call_chunks", None)
+                if tool_call_chunks:
+                    for tcc in tool_call_chunks:
+                        idx = tcc.get("index", 0)
+                        if idx not in tool_call_builders:
+                            tool_call_builders[idx] = {"id": "", "name": "", "args_json": ""}
+
+                        builder = tool_call_builders[idx]
+                        if tcc.get("id"):
+                            builder["id"] = tcc["id"]
+                        if tcc.get("name"):
+                            builder["name"] = tcc["name"]
+                        if tcc.get("args"):
+                            builder["args_json"] += tcc["args"]
 
                 yield StreamChunk(
                     content=content,
                     done=False,
                 )
 
-            # Final chunk with done=True, usage stats, and accumulated tool calls
+            # Parse accumulated tool calls
+            import json
+
+            final_tool_calls = []
+            for _idx, builder in tool_call_builders.items():
+                if builder["name"] and builder["id"]:
+                    # Parse the accumulated JSON args
+                    try:
+                        args = json.loads(builder["args_json"]) if builder["args_json"] else {}
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to parse tool call args: {builder['args_json']}")
+                        args = {}
+
+                    final_tool_calls.append(
+                        ToolCallRequest(
+                            id=builder["id"],
+                            name=builder["name"],
+                            arguments=args,
+                        )
+                    )
+
+            # Final chunk with done=True, usage stats, and parsed tool calls
             yield StreamChunk(
                 content="",
                 done=True,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,
-                tool_calls=accumulated_tool_calls if accumulated_tool_calls else None,
+                tool_calls=final_tool_calls if final_tool_calls else None,
             )
 
         except Exception as e:

--- a/src/questfoundry/runtime/providers/openai.py
+++ b/src/questfoundry/runtime/providers/openai.py
@@ -7,6 +7,7 @@ Uses langchain-openai for communication with OpenAI API.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -22,6 +23,7 @@ from questfoundry.runtime.providers.base import (
     ProviderError,
     ProviderUnavailableError,
     StreamChunk,
+    ToolCallRequest,
 )
 
 logger = logging.getLogger(__name__)
@@ -75,7 +77,13 @@ class OpenAIProvider(LLMProvider):
 
     def _convert_messages(self, messages: list[LLMMessage]):  # type: ignore[no-untyped-def]
         """Convert LLMMessage to langchain format."""
-        from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+        from langchain_core.messages import (
+            AIMessage,
+            BaseMessage,
+            HumanMessage,
+            SystemMessage,
+            ToolMessage,
+        )
 
         langchain_messages: list[BaseMessage] = []
         for msg in messages:
@@ -84,9 +92,45 @@ class OpenAIProvider(LLMProvider):
             elif msg.role == "user":
                 langchain_messages.append(HumanMessage(content=msg.content))
             elif msg.role == "assistant":
-                langchain_messages.append(AIMessage(content=msg.content))
+                # Include tool_calls on AIMessage if present
+                if msg.tool_calls:
+                    tool_calls = [
+                        {"id": tc.id, "name": tc.name, "args": tc.arguments}
+                        for tc in msg.tool_calls
+                    ]
+                    langchain_messages.append(AIMessage(content=msg.content, tool_calls=tool_calls))
+                else:
+                    langchain_messages.append(AIMessage(content=msg.content))
+            elif msg.role == "tool":
+                # Tool result message
+                langchain_messages.append(
+                    ToolMessage(
+                        content=msg.content,
+                        tool_call_id=msg.tool_call_id or "",
+                        name=msg.name,
+                    )
+                )
 
         return langchain_messages
+
+    def _parse_tool_calls(self, response: Any) -> list[ToolCallRequest] | None:
+        """Parse tool calls from LangChain AIMessage response."""
+        tool_calls = getattr(response, "tool_calls", None)
+        if not tool_calls:
+            return None
+
+        result = []
+        for tc in tool_calls:
+            # Debug: log raw tool call data
+            logger.debug(f"Raw tool call: {tc}")
+            result.append(
+                ToolCallRequest(
+                    id=tc.get("id", ""),
+                    name=tc.get("name", ""),
+                    arguments=tc.get("args", {}),
+                )
+            )
+        return result if result else None
 
     async def invoke(
         self,
@@ -100,20 +144,24 @@ class OpenAIProvider(LLMProvider):
         Send messages to OpenAI and get a response.
 
         Uses langchain-openai for the actual invocation.
-        Note: tools parameter accepted but not yet implemented.
         """
-        # TODO: Implement tool support for OpenAI
-        _ = tools  # Acknowledge but not yet used
-        _ = callbacks  # Acknowledge but not yet used
         options = options or InvokeOptions()
 
         llm = self._get_llm(model, options)
+
+        # Bind tools if provided
+        if tools:
+            llm = llm.bind_tools(tools)
+
         langchain_messages = self._convert_messages(messages)
+
+        # Build config with callbacks for tracing
+        config = {"callbacks": callbacks} if callbacks else None
 
         start_time = time.time()
         try:
             response = await asyncio.wait_for(
-                llm.ainvoke(langchain_messages),
+                llm.ainvoke(langchain_messages, config=config),
                 timeout=options.timeout_seconds,
             )
         except TimeoutError as e:
@@ -142,6 +190,9 @@ class OpenAIProvider(LLMProvider):
         if isinstance(content, list):
             content = str(content[0]) if content else ""
 
+        # Parse tool calls from response
+        tool_calls = self._parse_tool_calls(response)
+
         return LLMResponse(
             content=content,
             model=model,
@@ -150,6 +201,7 @@ class OpenAIProvider(LLMProvider):
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
             duration_ms=duration_ms,
+            tool_calls=tool_calls,
             raw=response,
         )
 
@@ -165,22 +217,30 @@ class OpenAIProvider(LLMProvider):
         Stream response chunks from OpenAI.
 
         Uses langchain-openai's astream for streaming.
-        Note: tools parameter accepted but not yet implemented.
+        Supports tool binding when tools are provided.
         """
-        # TODO: Implement tool support for OpenAI
-        _ = tools  # Acknowledge but not yet used
-        _ = callbacks  # Acknowledge but not yet used
         options = options or InvokeOptions()
 
         llm = self._get_llm(model, options)
+
+        # Bind tools if provided
+        if tools:
+            llm = llm.bind_tools(tools)
+
         langchain_messages = self._convert_messages(messages)
+
+        # Build config with callbacks for tracing
+        config = {"callbacks": callbacks} if callbacks else None
 
         try:
             prompt_tokens: int | None = None
             completion_tokens: int | None = None
             total_tokens: int | None = None
+            # Track tool call chunks by index to accumulate incrementally
+            # Key: index, Value: {"id": str, "name": str, "args_json": str}
+            tool_call_builders: dict[int, dict[str, str]] = {}
 
-            async for chunk in llm.astream(langchain_messages):
+            async for chunk in llm.astream(langchain_messages, config=config):
                 content = chunk.content
                 if isinstance(content, list):
                     content = str(content[0]) if content else ""
@@ -192,18 +252,54 @@ class OpenAIProvider(LLMProvider):
                     completion_tokens = usage_metadata.get("output_tokens")
                     total_tokens = usage_metadata.get("total_tokens")
 
+                # Accumulate tool call chunks (args come as JSON string fragments)
+                tool_call_chunks = getattr(chunk, "tool_call_chunks", None)
+                if tool_call_chunks:
+                    for tcc in tool_call_chunks:
+                        idx = tcc.get("index", 0)
+                        if idx not in tool_call_builders:
+                            tool_call_builders[idx] = {"id": "", "name": "", "args_json": ""}
+
+                        builder = tool_call_builders[idx]
+                        if tcc.get("id"):
+                            builder["id"] = tcc["id"]
+                        if tcc.get("name"):
+                            builder["name"] = tcc["name"]
+                        if tcc.get("args"):
+                            builder["args_json"] += tcc["args"]
+
                 yield StreamChunk(
                     content=content,
                     done=False,
                 )
 
-            # Final chunk with done=True and usage stats
+            # Parse accumulated tool calls
+            final_tool_calls = []
+            for _idx, builder in tool_call_builders.items():
+                if builder["name"] and builder["id"]:
+                    # Parse the accumulated JSON args
+                    try:
+                        args = json.loads(builder["args_json"]) if builder["args_json"] else {}
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to parse tool call args: {builder['args_json']}")
+                        args = {}
+
+                    final_tool_calls.append(
+                        ToolCallRequest(
+                            id=builder["id"],
+                            name=builder["name"],
+                            arguments=args,
+                        )
+                    )
+
+            # Final chunk with done=True, usage stats, and parsed tool calls
             yield StreamChunk(
                 content="",
                 done=True,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,
+                tool_calls=final_tool_calls if final_tool_calls else None,
             )
 
         except Exception as e:

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -23,6 +23,9 @@ from questfoundry.runtime.tools import (
     consult_playbook,  # noqa: F401
     consult_schema,  # noqa: F401
     delegate,  # noqa: F401
+    list_agents,  # noqa: F401
+    list_artifact_types,  # noqa: F401
+    list_stores,  # noqa: F401
     request_clarification,  # noqa: F401
     search_workspace,  # noqa: F401
     stubs,  # noqa: F401

--- a/src/questfoundry/runtime/tools/consult_playbook.py
+++ b/src/questfoundry/runtime/tools/consult_playbook.py
@@ -34,13 +34,18 @@ class ConsultPlaybookTool(BaseTool):
         playbook_id = args.get("playbook_id")
 
         if not playbook_id:
-            # List available playbooks
+            # List available playbooks with directive message
             available = [pb.id for pb in self._context.studio.playbooks]
             return ToolResult(
                 success=True,
                 data={
-                    "message": "No playbook_id provided. Available playbooks:",
+                    "message": (
+                        "You called consult_playbook without specifying a playbook_id. "
+                        "For new story requests, call again with playbook_id='story_spark'. "
+                        "Available playbooks:"
+                    ),
                     "available_playbooks": available,
+                    "next_action": "Call consult_playbook(playbook_id='story_spark') for story creation workflow",
                 },
             )
 
@@ -61,6 +66,20 @@ class ConsultPlaybookTool(BaseTool):
 
         # Build detailed response
         result_data = self._format_playbook(playbook)
+
+        # Add clear next-action guidance
+        if playbook.entry_phase and playbook.phases:
+            entry_phase_data = playbook.phases.get(playbook.entry_phase, {})
+            steps = entry_phase_data.get("steps", {})
+            if steps:
+                first_step = list(steps.values())[0] if steps else {}
+                first_agent = first_step.get("specific_agent") or first_step.get("agent_archetype")
+                if first_agent:
+                    result_data["next_action"] = (
+                        f"Now delegate to '{first_agent}' to begin the workflow. "
+                        f"Use: delegate(to_agent='{first_agent}', task='...')"
+                    )
+
         return ToolResult(success=True, data=result_data)
 
     def _format_playbook(self, playbook: Playbook) -> dict[str, Any]:

--- a/src/questfoundry/runtime/tools/list_agents.py
+++ b/src/questfoundry/runtime/tools/list_agents.py
@@ -1,0 +1,47 @@
+"""
+List Agents tool implementation.
+
+Returns compact list of available agents for delegation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult
+from questfoundry.runtime.tools.registry import register_tool
+
+
+@register_tool("list_agents")
+class ListAgentsTool(BaseTool):
+    """
+    List all agents available for delegation.
+
+    Use this to discover what specialist agents exist and their capabilities.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute agent listing."""
+        _ = args  # No args needed for this tool
+
+        agents = []
+        for agent in self._context.studio.agents:
+            archetypes = [
+                a.value if hasattr(a, "value") else str(a) for a in (agent.archetypes or [])
+            ]
+            agents.append(
+                {
+                    "id": agent.id,
+                    "name": agent.name,
+                    "archetypes": archetypes,
+                    "description": (agent.description or "")[:80],
+                }
+            )
+
+        return ToolResult(
+            success=True,
+            data={
+                "agents": agents,
+                "count": len(agents),
+            },
+        )

--- a/src/questfoundry/runtime/tools/list_artifact_types.py
+++ b/src/questfoundry/runtime/tools/list_artifact_types.py
@@ -1,0 +1,47 @@
+"""
+List Artifact Types tool implementation.
+
+Returns compact list of available artifact types for discovery.
+Use consult_schema for full field definitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult
+from questfoundry.runtime.tools.registry import register_tool
+
+
+@register_tool("list_artifact_types")
+class ListArtifactTypesTool(BaseTool):
+    """
+    List all available artifact types with brief descriptions.
+
+    Use this to discover what artifact types exist.
+    Then call consult_schema(artifact_type_id) for full field definitions.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact type listing."""
+        _ = args  # No args needed for this tool
+
+        types = []
+        for at in self._context.studio.artifact_types:
+            types.append(
+                {
+                    "id": at.id,
+                    "name": at.name,
+                    "category": at.category or "document",
+                    "description": (at.description or "")[:80],
+                }
+            )
+
+        return ToolResult(
+            success=True,
+            data={
+                "artifact_types": types,
+                "count": len(types),
+                "hint": "Use consult_schema(artifact_type_id) for full field definitions.",
+            },
+        )

--- a/src/questfoundry/runtime/tools/list_stores.py
+++ b/src/questfoundry/runtime/tools/list_stores.py
@@ -1,0 +1,45 @@
+"""
+List Stores tool implementation.
+
+Returns compact list of available stores with semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult
+from questfoundry.runtime.tools.registry import register_tool
+
+
+@register_tool("list_stores")
+class ListStoresTool(BaseTool):
+    """
+    List all available stores with their semantics.
+
+    Use this to discover what stores exist and their access patterns.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute store listing."""
+        _ = args  # No args needed for this tool
+
+        stores = []
+        for store in self._context.studio.stores:
+            semantics = store.semantics.value if store.semantics else "unknown"
+            stores.append(
+                {
+                    "id": store.id,
+                    "name": store.name,
+                    "semantics": semantics,
+                    "description": (store.description or "")[:80],
+                }
+            )
+
+        return ToolResult(
+            success=True,
+            data={
+                "stores": stores,
+                "count": len(stores),
+            },
+        )

--- a/tests/runtime/domain/test_loader.py
+++ b/tests/runtime/domain/test_loader.py
@@ -130,7 +130,9 @@ class TestLoadStudio:
         result = await load_studio(domain_v4_path)
 
         assert result.success
-        assert len(result.studio.tools) == 12
+        assert (
+            len(result.studio.tools) == 15
+        )  # Updated: +3 list tools (list_artifact_types, list_stores, list_agents)
 
     async def test_load_studio_resolves_playbook_refs(self, domain_v4_path: Path):
         """load_studio resolves playbook file references."""


### PR DESCRIPTION
## Summary

Apply v3 prompt patterns that worked reliably with qwen3:8b, achieving ~70% prompt size reduction.

### Compact Section Builders
- `_build_agents_section`: table format instead of full descriptions
- `_build_tools_section`: name + 1-line description (LangChain provides schemas)
- `_build_playbooks_section`: menu with consult hint
- `_build_stores_section`: compact list with semantics
- `_build_artifact_types_section`: compact list with consult hint

### Behavioral Guidance by Archetype
- **orchestrator**: "DO NOT write narrative, delegate creative work"
- **creator/author**: "Write artifacts BEFORE returning"
- **validator/auditor**: "Read artifacts before approving"
- **architect/planner**: "Design structure, leave content empty"
- **librarian/curator**: "List existing artifacts before promoting"

### Discovery Tools (Option A from plan)
- `list_artifact_types`: discover available artifact types
- `list_stores`: discover available stores
- `list_agents`: discover available agents for delegation

## Results

| Agent | Before | After | Reduction |
|-------|--------|-------|-----------|
| Showrunner | ~25K chars | ~3.5K chars | ~86% |
| Scene Smith | - | ~1.9K chars | - |
| Gatekeeper | - | ~1.8K chars | - |

## Test plan

- [x] All 360 existing tests pass
- [x] Prompt sizes verified via measurement script
- [ ] Manual test with ollama to verify model behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)