### PR TITLE
feat(runtime): Phase 4 Storage & Lifecycle

### DIFF
--- a/docs/design/PHASE4_STORAGE_LIFECYCLE.md
+++ b/docs/design/PHASE4_STORAGE_LIFECYCLE.md
@@ -108,7 +108,13 @@ From `meta/schemas/core/artifact-type.schema.json`:
 3. Runtime responds:
    |-> "committed" - state changed
    |-> "rejected" - criteria failed, guidance provided
-   |-> "deferred" - needs orchestrator decision
+   |-> "deferred" - needs orchestrator decision (e.g., multi-agent approval)
+
+Note on "deferred": This result indicates that the transition cannot be
+immediately committed and requires external resolution. The orchestrator
+(Showrunner) is notified via a message to its inbox containing the pending
+transition details. Resolution occurs when the orchestrator or designated
+approver explicitly commits or rejects the transition.
 ```
 
 ### Gatekeeper's Role
@@ -252,6 +258,25 @@ class ExclusiveWriterEnforcer:
             asyncio.create_task(self._emit_nudge(broker, agent_id, store_id, designated))
 
         return ExclusiveWriterCheck(allowed=True, warning=warning, violation_logged=True)
+
+    async def _emit_nudge(
+        self,
+        broker: MessageBroker,
+        agent_id: str,
+        store_id: str,
+        designated: str,
+    ) -> None:
+        """Send workflow nudge to orchestrator about exclusive writer violation."""
+        await broker.send(
+            to_agent="showrunner",
+            message_type="workflow_nudge",
+            content={
+                "violation": "exclusive_writer",
+                "agent": agent_id,
+                "store": store_id,
+                "designated_producer": designated,
+            },
+        )
 ```
 
 ---
@@ -420,48 +445,58 @@ async def request_lifecycle_transition(
 
 ## 8. Store Semantics Enforcement
 
-Enforcement in `Project` methods:
+Enforcement happens at the **tool level** (`UpdateArtifactTool`, `DeleteArtifactTool`),
+not in `Project` methods. This keeps `Project` as a simple data access layer while
+tools handle policy enforcement.
 
 ```python
-class Project:
-    def __init__(self, path: Path, store_manager: StoreManager | None = None):
-        self._store_manager = store_manager
+class UpdateArtifactTool(BaseTool):
+    """Respects store semantics (blocks updates to cold/append_only stores)."""
 
-    def create_artifact(self, ..., store: str | None = None) -> dict[str, Any]:
-        """Create artifact - allowed for all semantics."""
-        # Existing implementation
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        # ... validation ...
 
-    def update_artifact(self, artifact_id: str, data: dict, ...) -> dict[str, Any] | None:
-        """Update artifact - blocked for cold/append_only stores."""
-        existing = self.get_artifact(artifact_id)
-        if existing and self._store_manager:
-            store = existing.get("_store")
-            if store:
-                store_def = self._store_manager.get_store(store)
-                if store_def and store_def.semantics in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY):
-                    raise StoreSemanticViolation(
-                        f"Cannot update artifact in {store_def.semantics} store '{store}'"
-                    )
-                if store_def and store_def.semantics == StoreSemantics.VERSIONED:
-                    self._save_version(artifact_id, existing)
-        # Continue with update
+        # Check store semantics
+        store_id = existing.get("_store")
+        if store_id and self._context.store_manager:
+            store = self._context.store_manager.get_store(store_id)
+            if store and not store.allows_updates():
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=(
+                        f"Cannot update artifact in {store.semantics.value} store '{store_id}'. "
+                        "Use request_lifecycle_transition to move it to an editable store first."
+                    ),
+                )
 
-    def delete_artifact(self, artifact_id: str) -> bool:
-        """Delete artifact - blocked for cold/append_only stores."""
-        existing = self.get_artifact(artifact_id)
-        if existing and self._store_manager:
-            store = existing.get("_store")
-            if store:
-                store_def = self._store_manager.get_store(store)
-                if store_def and store_def.semantics in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY):
-                    raise StoreSemanticViolation(
-                        f"Cannot delete artifact from {store_def.semantics} store '{store}'"
-                    )
-        # Continue with delete
+        # Continue with update via Project.update_artifact()
 
-    def _save_version(self, artifact_id: str, artifact: dict) -> None:
-        """Save artifact version to artifact_versions table."""
+
+class DeleteArtifactTool(BaseTool):
+    """Respects store semantics (blocks deletes from cold/append_only stores)."""
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        # ... validation ...
+
+        # Check store semantics
+        store_id = existing.get("_store")
+        if store_id and self._context.store_manager:
+            store = self._context.store_manager.get_store(store_id)
+            if store and not store.allows_deletes():
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=(
+                        f"Cannot delete artifact from {store.semantics.value} store '{store_id}'."
+                    ),
+                )
+
+        # Continue with delete via Project.delete_artifact()
 ```
+
+`Project` methods remain simple data operations. Version history for `versioned` stores
+is handled by `Project._save_version()` called from `update_artifact()`.
 
 ---
 
@@ -491,14 +526,16 @@ brief_opening       section_brief  draft    workspace  2024-12-16 09:15
 | Step | Files | Description |
 |------|-------|-------------|
 | 1 | `storage/store_manager.py` | StoreManager, load from domain |
-| 2 | `tools/save_artifact.py` | Agent tool to persist artifacts |
-| 3 | `storage/project.py` | Add semantics enforcement to update/delete |
+| 2 | `storage/project.py` | Version history support for versioned stores |
+| 3 | `tools/save_artifact.py` | SaveArtifact, UpdateArtifact, DeleteArtifact tools with semantics enforcement |
 | 4 | `storage/exclusive_writer.py` | ExclusiveWriterEnforcer with configurable policy |
-| 5 | `storage/artifact_lifecycle.py` | ArtifactLifecycle, LifecycleRegistry |
-| 6 | `tools/request_lifecycle_transition.py` | Transition request tool |
-| 7 | `storage/project.py` | Version history for versioned stores |
-| 8 | `tools/get_artifact.py`, `tools/list_artifacts.py` | Query tools |
-| 9 | `cli.py` | `qf artifacts` subcommand |
+| 5 | `storage/lifecycle.py` | ArtifactLifecycle, LifecycleManager |
+| 6 | `tools/lifecycle_transition.py` | Transition request and state query tools |
+| 7 | `tools/get_artifact.py`, `tools/list_artifacts.py` | Query tools |
+| 8 | `cli.py` | `qf artifacts` subcommand |
+
+Note: Store semantics enforcement (blocking updates/deletes on cold/append_only)
+happens at the tool level (step 3), not in Project methods.
 
 ---
 

--- a/docs/design/PHASE4_STORAGE_LIFECYCLE.md
+++ b/docs/design/PHASE4_STORAGE_LIFECYCLE.md
@@ -45,6 +45,7 @@ class StoreSemantics(str, Enum):
 ### Workflow Intent
 
 From store schema, `workflow_intent` provides:
+
 - `consumption_guidance`: Which agents should load this store into context
 - `production_guidance`: Who should produce data here (`all`, `specified`, `exclusive`)
 - `designated_producers`: For `exclusive` stores, the single owner agent
@@ -60,6 +61,7 @@ From store schema, `workflow_intent` provides:
 Each artifact type defines its own lifecycle in `domain-v4/artifact-types/*.json`:
 
 **Example: `section.json`**
+
 ```json
 {
   "lifecycle": {
@@ -112,6 +114,7 @@ From `meta/schemas/core/artifact-type.schema.json`:
 ### Gatekeeper's Role
 
 From `domain-v4/agents/gatekeeper.json`:
+
 - Has `block_cold_merge` capability: "Authority to block merges to Cold SoT when quality bars fail"
 - Writes `gatecheck_report` artifacts to workspace
 - Evaluates artifacts and requests `gatecheck → approved` or `gatecheck → draft`
@@ -502,6 +505,7 @@ brief_opening       section_brief  draft    workspace  2024-12-16 09:15
 ## 11. Test Strategy
 
 **Unit tests:**
+
 - `tests/runtime/storage/test_store_manager.py` - Load stores, resolve defaults
 - `tests/runtime/storage/test_exclusive_writer.py` - Policy enforcement
 - `tests/runtime/storage/test_artifact_lifecycle.py` - State machine, transitions
@@ -509,6 +513,7 @@ brief_opening       section_brief  draft    workspace  2024-12-16 09:15
 - `tests/runtime/tools/test_lifecycle_transition.py` - Transition flow
 
 **Integration tests:**
+
 - `test_artifact_creation_in_workspace`
 - `test_exclusive_writer_warning_on_canon_violation`
 - `test_lifecycle_transition_draft_to_review`

--- a/docs/design/PHASE4_STORAGE_LIFECYCLE.md
+++ b/docs/design/PHASE4_STORAGE_LIFECYCLE.md
@@ -1,0 +1,555 @@
+# Phase 4: Storage & Lifecycle
+
+> **Issue**: #148
+> **Status**: In Progress
+> **Parent**: #143 (V4 Runtime Cleanroom Rebuild)
+
+## Overview
+
+Implement the store system with lifecycle state management. Artifacts flow through states (draft → review → approved → cold) with validation at transitions. Agents persist artifacts via tools; the Runtime enforces store semantics and exclusive writer policies.
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Exclusive writer enforcement | Allow with warning (configurable) | "Open floor" principle; easy to switch to hard-block later |
+| Lifecycle transitions | Explicit tool calls only | Domain-aligned; agents must request transitions |
+| Transition approval | Gatekeeper has `block_cold_merge` capability | Domain defines who can approve; Runtime validates `requires_validation` |
+| Store semantics | Per-store enforcement | `cold` = no updates, `append_only` = no deletes, `versioned` = save history |
+| Version storage | SQLite `artifact_versions` table | Already exists in schema from Phase 0 |
+
+---
+
+## 1. Domain Model
+
+### Stores (from `domain-v4/stores/`)
+
+| Store | Semantics | Producer | Purpose |
+|-------|-----------|----------|---------|
+| `workspace` | mutable | all | Working drafts, WIP artifacts |
+| `canon` | cold | lore_weaver (exclusive) | Spoiler-level world truth |
+| `codex` | cold | codex_curator (exclusive) | Player-safe glossary |
+| `exports` | versioned | book_binder (exclusive) | Generated bundles |
+| `audit` | append_only | all | Traceability log |
+
+### Store Semantics (from `meta/schemas/core/store.schema.json`)
+
+```python
+class StoreSemantics(str, Enum):
+    MUTABLE = "mutable"        # Read/write, updates allowed
+    APPEND_ONLY = "append_only" # Write once, no updates/deletes
+    VERSIONED = "versioned"    # History preserved on every update
+    COLD = "cold"              # Optimized for reads, no updates after commit
+```
+
+### Workflow Intent
+
+From store schema, `workflow_intent` provides:
+- `consumption_guidance`: Which agents should load this store into context
+- `production_guidance`: Who should produce data here (`all`, `specified`, `exclusive`)
+- `designated_producers`: For `exclusive` stores, the single owner agent
+
+**Key insight**: This is for **attention/routing**, not access control. The Runtime never denies access; it nudges on deviation.
+
+---
+
+## 2. Lifecycle Model
+
+### Lifecycle States (per artifact type)
+
+Each artifact type defines its own lifecycle in `domain-v4/artifact-types/*.json`:
+
+**Example: `section.json`**
+```json
+{
+  "lifecycle": {
+    "states": [
+      {"id": "draft", "name": "Draft"},
+      {"id": "review", "name": "Review"},
+      {"id": "gatecheck", "name": "Gatecheck"},
+      {"id": "approved", "name": "Approved"},
+      {"id": "cold", "name": "Cold", "terminal": true}
+    ],
+    "initial_state": "draft",
+    "transitions": [
+      {"from": "draft", "to": "review"},
+      {"from": "review", "to": "draft"},
+      {"from": "review", "to": "gatecheck"},
+      {"from": "gatecheck", "to": "draft"},
+      {"from": "gatecheck", "to": "approved"},
+      {"from": "approved", "to": "cold",
+       "requires_validation": ["integrity", "reachability", "style", "presentation"]}
+    ]
+  }
+}
+```
+
+### Transition Control
+
+From `meta/schemas/core/artifact-type.schema.json`:
+
+- **`allowed_agents`**: Who can REQUEST the transition (empty = any)
+- **`requires_validation`**: Quality criteria that must pass before commit
+
+### Transition Flow
+
+```
+1. Agent calls `request_lifecycle_transition` tool
+   |-> from_state, to_state, artifact_id, justification
+
+2. Runtime validates:
+   |-> Current state matches from_state
+   |-> Transition exists in artifact type's lifecycle
+   |-> Agent is in allowed_agents (if specified)
+   |-> requires_validation criteria pass (if specified)
+
+3. Runtime responds:
+   |-> "committed" - state changed
+   |-> "rejected" - criteria failed, guidance provided
+   |-> "deferred" - needs orchestrator decision
+```
+
+### Gatekeeper's Role
+
+From `domain-v4/agents/gatekeeper.json`:
+- Has `block_cold_merge` capability: "Authority to block merges to Cold SoT when quality bars fail"
+- Writes `gatecheck_report` artifacts to workspace
+- Evaluates artifacts and requests `gatecheck → approved` or `gatecheck → draft`
+
+---
+
+## 3. Module Structure
+
+```
+src/questfoundry/runtime/
+├── storage/
+│   ├── __init__.py
+│   ├── project.py              # EXISTING: SQLite CRUD
+│   ├── store_manager.py        # NEW: Store registry, semantics enforcement
+│   ├── artifact_lifecycle.py   # NEW: State machine, transition validation
+│   └── exclusive_writer.py     # NEW: Exclusive writer policy
+│
+├── tools/
+│   ├── save_artifact.py        # NEW: Persist artifacts
+│   ├── get_artifact.py         # NEW: Retrieve artifacts
+│   ├── list_artifacts.py       # NEW: Query artifacts
+│   └── request_lifecycle_transition.py  # NEW: Request state changes
+│
+└── cli.py                      # MODIFY: Add artifacts subcommand
+```
+
+---
+
+## 4. StoreManager
+
+Central registry for store definitions:
+
+```python
+@dataclass
+class StoreDefinition:
+    id: str
+    name: str
+    description: str | None
+    semantics: StoreSemantics
+    artifact_types: list[str]
+    workflow_intent: WorkflowIntent | None
+    retention: RetentionPolicy | None
+
+@dataclass
+class WorkflowIntent:
+    consumption_guidance: str  # "all", "specified", "none"
+    production_guidance: str   # "all", "specified", "exclusive", "none"
+    designated_consumers: list[str]
+    designated_producers: list[str]
+
+class StoreManager:
+    def __init__(self, stores: dict[str, StoreDefinition]):
+        self._stores = stores
+
+    @classmethod
+    def from_domain(cls, domain_path: Path) -> StoreManager:
+        """Load store definitions from domain-v4/stores/*.json"""
+
+    def get_store(self, store_id: str) -> StoreDefinition | None:
+        """Get store by ID."""
+
+    def get_default_store(self, artifact_type: str) -> str | None:
+        """Get default store for artifact type."""
+
+    def validate_write(self, store_id: str, artifact_type: str) -> bool:
+        """Check if artifact type can be stored in this store."""
+
+    def get_exclusive_producer(self, store_id: str) -> str | None:
+        """Get exclusive producer agent ID, or None if not exclusive."""
+```
+
+---
+
+## 5. Exclusive Writer Policy
+
+Configurable enforcement for exclusive stores:
+
+```python
+class ExclusiveWriterPolicy(str, Enum):
+    ALLOW_WITH_WARNING = "warn"   # Log warning, allow write
+    HARD_BLOCK = "block"          # Raise error, deny write
+
+@dataclass
+class ExclusiveWriterCheck:
+    allowed: bool
+    warning: str | None = None
+    violation_logged: bool = False
+
+class ExclusiveWriterEnforcer:
+    def __init__(
+        self,
+        store_manager: StoreManager,
+        policy: ExclusiveWriterPolicy = ExclusiveWriterPolicy.ALLOW_WITH_WARNING
+    ):
+        self._store_manager = store_manager
+        self._policy = policy
+
+    def check_write(
+        self,
+        store_id: str,
+        agent_id: str,
+        broker: AsyncMessageBroker | None = None
+    ) -> ExclusiveWriterCheck:
+        """
+        Check if agent can write to store.
+
+        If store is exclusive and agent is not designated producer:
+        - ALLOW_WITH_WARNING: log warning, emit nudge, return allowed=True
+        - HARD_BLOCK: return allowed=False
+        """
+        store = self._store_manager.get_store(store_id)
+        if not store or not store.workflow_intent:
+            return ExclusiveWriterCheck(allowed=True)
+
+        if store.workflow_intent.production_guidance != "exclusive":
+            return ExclusiveWriterCheck(allowed=True)
+
+        designated = store.workflow_intent.designated_producers
+        if agent_id in designated:
+            return ExclusiveWriterCheck(allowed=True)
+
+        # Violation detected
+        warning = (
+            f"Workflow deviation: {agent_id} writing to {store_id} "
+            f"(exclusive to {designated})"
+        )
+
+        if self._policy == ExclusiveWriterPolicy.HARD_BLOCK:
+            return ExclusiveWriterCheck(allowed=False, warning=warning)
+
+        # ALLOW_WITH_WARNING: log and emit nudge
+        logger.warning(warning)
+        if broker:
+            # Emit nudge message asynchronously
+            asyncio.create_task(self._emit_nudge(broker, agent_id, store_id, designated))
+
+        return ExclusiveWriterCheck(allowed=True, warning=warning, violation_logged=True)
+```
+
+---
+
+## 6. ArtifactLifecycle
+
+State machine loaded from artifact type definitions:
+
+```python
+@dataclass
+class LifecycleState:
+    id: str
+    name: str
+    description: str | None = None
+    terminal: bool = False
+
+@dataclass
+class LifecycleTransition:
+    from_state: str
+    to_state: str
+    allowed_agents: list[str]  # Empty = any
+    requires_validation: list[str]  # Quality criteria IDs
+
+@dataclass
+class ArtifactLifecycle:
+    states: dict[str, LifecycleState]
+    initial_state: str
+    transitions: list[LifecycleTransition]
+
+    def get_valid_transitions(self, from_state: str) -> list[LifecycleTransition]:
+        """Get all valid transitions from a state."""
+
+    def can_transition(
+        self,
+        from_state: str,
+        to_state: str,
+        agent_id: str | None = None
+    ) -> tuple[bool, str | None]:
+        """
+        Check if transition is valid.
+        Returns (allowed, reason_if_not).
+        """
+
+    def get_requires_validation(self, from_state: str, to_state: str) -> list[str]:
+        """Get quality criteria required for this transition."""
+
+class LifecycleRegistry:
+    def __init__(self):
+        self._lifecycles: dict[str, ArtifactLifecycle] = {}
+
+    @classmethod
+    def from_domain(cls, domain_path: Path) -> LifecycleRegistry:
+        """Load lifecycle definitions from domain-v4/artifact-types/*.json"""
+
+    def get_lifecycle(self, artifact_type: str) -> ArtifactLifecycle | None:
+        """Get lifecycle for artifact type (None if no lifecycle defined)."""
+```
+
+---
+
+## 7. Tools
+
+### save_artifact
+
+```python
+@tool_registry.register("save_artifact")
+async def save_artifact(
+    artifact_type: str,
+    data: dict[str, Any],
+    artifact_id: str | None = None,
+    store: str | None = None,
+    ctx: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Save an artifact to a store.
+
+    Args:
+        artifact_type: Artifact type ID (e.g., "section", "canon_pack")
+        data: Artifact data (must match artifact type schema)
+        artifact_id: Optional ID (auto-generated if not provided)
+        store: Target store (uses artifact type's default_store if not provided)
+
+    Returns:
+        Created artifact with system fields (_id, _type, _version, etc.)
+    """
+    # 1. Resolve store (explicit > default_store > workspace)
+    # 2. Check exclusive writer policy
+    # 3. Validate artifact against schema
+    # 4. Get initial lifecycle state (if artifact type has lifecycle)
+    # 5. Persist via Project.create_artifact()
+    # 6. Return artifact with system fields
+```
+
+### get_artifact
+
+```python
+@tool_registry.register("get_artifact")
+async def get_artifact(
+    artifact_id: str,
+    ctx: ToolContext = None,
+) -> dict[str, Any] | None:
+    """
+    Retrieve an artifact by ID.
+
+    Returns:
+        Artifact with all fields, or None if not found
+    """
+```
+
+### list_artifacts
+
+```python
+@tool_registry.register("list_artifacts")
+async def list_artifacts(
+    artifact_type: str | None = None,
+    store: str | None = None,
+    lifecycle_state: str | None = None,
+    limit: int = 20,
+    ctx: ToolContext = None,
+) -> list[dict[str, Any]]:
+    """
+    Query artifacts with filters.
+
+    Returns:
+        List of artifacts matching filters (summary view)
+    """
+```
+
+### request_lifecycle_transition
+
+```python
+@tool_registry.register("request_lifecycle_transition")
+async def request_lifecycle_transition(
+    artifact_id: str,
+    to_state: str,
+    justification: str | None = None,
+    ctx: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Request a lifecycle state transition for an artifact.
+
+    Args:
+        artifact_id: The artifact to transition
+        to_state: Target state
+        justification: Why the transition criteria are met
+
+    Returns:
+        {
+            "result": "committed" | "rejected" | "deferred",
+            "new_state": "...",
+            "validation_results": [...],  # If requires_validation
+            "rejection_reason": "...",    # If rejected
+            "guidance": "..."             # Next steps
+        }
+    """
+    # 1. Get artifact and its type
+    # 2. Get lifecycle for artifact type
+    # 3. Check transition validity (from current state)
+    # 4. Check allowed_agents
+    # 5. Run requires_validation checks
+    # 6. Commit or reject
+    # 7. Create lifecycle_transition_response message
+```
+
+---
+
+## 8. Store Semantics Enforcement
+
+Enforcement in `Project` methods:
+
+```python
+class Project:
+    def __init__(self, path: Path, store_manager: StoreManager | None = None):
+        self._store_manager = store_manager
+
+    def create_artifact(self, ..., store: str | None = None) -> dict[str, Any]:
+        """Create artifact - allowed for all semantics."""
+        # Existing implementation
+
+    def update_artifact(self, artifact_id: str, data: dict, ...) -> dict[str, Any] | None:
+        """Update artifact - blocked for cold/append_only stores."""
+        existing = self.get_artifact(artifact_id)
+        if existing and self._store_manager:
+            store = existing.get("_store")
+            if store:
+                store_def = self._store_manager.get_store(store)
+                if store_def and store_def.semantics in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY):
+                    raise StoreSemanticViolation(
+                        f"Cannot update artifact in {store_def.semantics} store '{store}'"
+                    )
+                if store_def and store_def.semantics == StoreSemantics.VERSIONED:
+                    self._save_version(artifact_id, existing)
+        # Continue with update
+
+    def delete_artifact(self, artifact_id: str) -> bool:
+        """Delete artifact - blocked for cold/append_only stores."""
+        existing = self.get_artifact(artifact_id)
+        if existing and self._store_manager:
+            store = existing.get("_store")
+            if store:
+                store_def = self._store_manager.get_store(store)
+                if store_def and store_def.semantics in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY):
+                    raise StoreSemanticViolation(
+                        f"Cannot delete artifact from {store_def.semantics} store '{store}'"
+                    )
+        # Continue with delete
+
+    def _save_version(self, artifact_id: str, artifact: dict) -> None:
+        """Save artifact version to artifact_versions table."""
+```
+
+---
+
+## 9. CLI Integration
+
+```bash
+# List artifacts
+qf artifacts list --project my_story
+qf artifacts list --project my_story --store workspace
+qf artifacts list --project my_story --type section --state draft
+
+# Show artifact details
+qf artifacts show --project my_story artifact_id
+
+# Example output
+$ qf artifacts list --project mystery_manor --store workspace
+ID                  TYPE           STATE    STORE      UPDATED
+section_001         section        draft    workspace  2024-12-16 10:30
+section_002         section        review   workspace  2024-12-16 11:45
+brief_opening       section_brief  draft    workspace  2024-12-16 09:15
+```
+
+---
+
+## 10. Implementation Order
+
+| Step | Files | Description |
+|------|-------|-------------|
+| 1 | `storage/store_manager.py` | StoreManager, load from domain |
+| 2 | `tools/save_artifact.py` | Agent tool to persist artifacts |
+| 3 | `storage/project.py` | Add semantics enforcement to update/delete |
+| 4 | `storage/exclusive_writer.py` | ExclusiveWriterEnforcer with configurable policy |
+| 5 | `storage/artifact_lifecycle.py` | ArtifactLifecycle, LifecycleRegistry |
+| 6 | `tools/request_lifecycle_transition.py` | Transition request tool |
+| 7 | `storage/project.py` | Version history for versioned stores |
+| 8 | `tools/get_artifact.py`, `tools/list_artifacts.py` | Query tools |
+| 9 | `cli.py` | `qf artifacts` subcommand |
+
+---
+
+## 11. Test Strategy
+
+**Unit tests:**
+- `tests/runtime/storage/test_store_manager.py` - Load stores, resolve defaults
+- `tests/runtime/storage/test_exclusive_writer.py` - Policy enforcement
+- `tests/runtime/storage/test_artifact_lifecycle.py` - State machine, transitions
+- `tests/runtime/tools/test_save_artifact.py` - Persist with validation
+- `tests/runtime/tools/test_lifecycle_transition.py` - Transition flow
+
+**Integration tests:**
+- `test_artifact_creation_in_workspace`
+- `test_exclusive_writer_warning_on_canon_violation`
+- `test_lifecycle_transition_draft_to_review`
+- `test_lifecycle_transition_requires_validation`
+- `test_cold_store_blocks_update`
+- `test_versioned_store_saves_history`
+
+---
+
+## 12. Acceptance Criteria
+
+```bash
+# Artifact creation
+# Agent creates draft artifact in workspace
+qf ask -p ollama test_project "Create a section brief for the opening scene"
+# Artifact visible via CLI
+qf artifacts list --project test_project --type section_brief
+
+# Lifecycle transition
+# Agent requests transition draft → review
+# If validation required, quality criteria checked
+# Transition committed or rejected with feedback
+
+# Exclusive writer
+# Non-Lorekeeper attempts to write to canon
+# Log: "Workflow deviation: scene_smith wrote to canon (exclusive to lore_weaver)"
+# Write still succeeds (open floor principle)
+```
+
+---
+
+## Dependencies
+
+- Phase 0 (domain loader, project structure)
+- Phase 2 (tool registry, validate_artifact)
+- Phase 3 (AsyncMessageBroker for nudges, lifecycle_transition messages)
+
+## References
+
+- `meta/schemas/core/store.schema.json` - Store contract
+- `meta/schemas/core/artifact-type.schema.json` - Lifecycle contract
+- `meta/schemas/core/message.schema.json` - Transition messages
+- `domain-v4/stores/*.json` - Store definitions
+- `domain-v4/artifact-types/*.json` - Artifact type definitions with lifecycles

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1150,6 +1150,224 @@ async def _ask_repl(
 # =============================================================================
 
 
+# =============================================================================
+# Artifacts Subcommand
+# =============================================================================
+
+artifacts_app = typer.Typer(help="View artifacts in a project", no_args_is_help=True)
+app.add_typer(artifacts_app, name="artifacts")
+
+
+@artifacts_app.command("list")
+def artifacts_list(
+    project_id: Annotated[str, typer.Argument(help="Project ID")],
+    projects_dir: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Projects directory"),
+    ] = Path("projects"),
+    artifact_type: Annotated[
+        str | None,
+        typer.Option("--type", "-t", help="Filter by artifact type"),
+    ] = None,
+    store: Annotated[
+        str | None,
+        typer.Option("--store", "-s", help="Filter by store"),
+    ] = None,
+    lifecycle_state: Annotated[
+        str | None,
+        typer.Option("--state", help="Filter by lifecycle state"),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum artifacts to show"),
+    ] = 50,
+) -> None:
+    """List artifacts in a project."""
+    from questfoundry.runtime.storage import Project
+
+    project_path = projects_dir / project_id
+
+    try:
+        project = Project.open(project_path)
+    except FileNotFoundError:
+        console.print(f"[red]✗ Project not found: {project_id}[/red]")
+        raise typer.Exit(1) from None
+
+    artifacts = project.query_artifacts(
+        artifact_type=artifact_type,
+        store=store,
+        lifecycle_state=lifecycle_state,
+        limit=limit,
+    )
+
+    if not artifacts:
+        console.print("[dim]No artifacts found[/dim]")
+        project.close()
+        return
+
+    table = Table(title=f"Artifacts in {project_id}")
+    table.add_column("ID", style="cyan")
+    table.add_column("Type", style="green")
+    table.add_column("Store")
+    table.add_column("State")
+    table.add_column("Version")
+    table.add_column("Updated")
+    table.add_column("Created By", style="dim")
+
+    for artifact in artifacts:
+        updated = artifact.get("_updated_at", "")
+        if updated:
+            # Shorten timestamp
+            updated = updated[:16].replace("T", " ")
+
+        table.add_row(
+            artifact.get("_id", "-"),
+            artifact.get("_type", "-"),
+            artifact.get("_store", "-"),
+            artifact.get("_lifecycle_state", "-"),
+            str(artifact.get("_version", 1)),
+            updated,
+            artifact.get("_created_by", "-"),
+        )
+
+    console.print(table)
+    console.print(f"[dim]Showing {len(artifacts)} artifact(s)[/dim]")
+
+    project.close()
+
+
+@artifacts_app.command("show")
+def artifacts_show(
+    project_id: Annotated[str, typer.Argument(help="Project ID")],
+    artifact_id: Annotated[str, typer.Argument(help="Artifact ID")],
+    projects_dir: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Projects directory"),
+    ] = Path("projects"),
+    version: Annotated[
+        int | None,
+        typer.Option("--version", "-v", help="Show specific version"),
+    ] = None,
+) -> None:
+    """Show an artifact's details."""
+    import json
+
+    from questfoundry.runtime.storage import Project
+
+    project_path = projects_dir / project_id
+
+    try:
+        project = Project.open(project_path)
+    except FileNotFoundError:
+        console.print(f"[red]✗ Project not found: {project_id}[/red]")
+        raise typer.Exit(1) from None
+
+    if version is not None:
+        # Get specific version
+        version_data = project.get_artifact_at_version(artifact_id, version)
+        if not version_data:
+            console.print(f"[red]✗ Version {version} not found for: {artifact_id}[/red]")
+            project.close()
+            raise typer.Exit(1)
+
+        console.print(Panel(f"[dim]Version {version}[/dim]", title=f"Artifact: {artifact_id}"))
+        console.print(f"[bold]Created At:[/bold] {version_data.get('created_at', '-')}")
+        console.print(f"[bold]Created By:[/bold] {version_data.get('created_by', '-')}")
+        console.print()
+        console.print("[bold]Data:[/bold]")
+        console.print(json.dumps(version_data.get("data", {}), indent=2))
+    else:
+        # Get current artifact
+        artifact = project.get_artifact(artifact_id)
+        if not artifact:
+            console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
+            project.close()
+            raise typer.Exit(1)
+
+        # Separate system fields from user data
+        system_fields = {k: v for k, v in artifact.items() if k.startswith("_")}
+        user_data = {k: v for k, v in artifact.items() if not k.startswith("_")}
+
+        console.print(Panel(f"[cyan]{artifact_id}[/cyan]", title="Artifact"))
+
+        # System metadata
+        console.print("[bold]Metadata:[/bold]")
+        console.print(f"  Type: [green]{system_fields.get('_type', '-')}[/green]")
+        console.print(f"  Store: {system_fields.get('_store', '-')}")
+        console.print(f"  State: {system_fields.get('_lifecycle_state', '-')}")
+        console.print(f"  Version: {system_fields.get('_version', 1)}")
+        console.print(f"  Created: {system_fields.get('_created_at', '-')}")
+        console.print(f"  Updated: {system_fields.get('_updated_at', '-')}")
+        console.print(f"  Created By: {system_fields.get('_created_by', '-')}")
+        console.print()
+
+        # User data
+        console.print("[bold]Data:[/bold]")
+        console.print(json.dumps(user_data, indent=2))
+
+    project.close()
+
+
+@artifacts_app.command("versions")
+def artifacts_versions(
+    project_id: Annotated[str, typer.Argument(help="Project ID")],
+    artifact_id: Annotated[str, typer.Argument(help="Artifact ID")],
+    projects_dir: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Projects directory"),
+    ] = Path("projects"),
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum versions to show"),
+    ] = 20,
+) -> None:
+    """Show version history for an artifact."""
+    from questfoundry.runtime.storage import Project
+
+    project_path = projects_dir / project_id
+
+    try:
+        project = Project.open(project_path)
+    except FileNotFoundError:
+        console.print(f"[red]✗ Project not found: {project_id}[/red]")
+        raise typer.Exit(1) from None
+
+    # Check artifact exists
+    artifact = project.get_artifact(artifact_id)
+    if not artifact:
+        console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
+        project.close()
+        raise typer.Exit(1)
+
+    versions = project.get_artifact_versions(artifact_id, limit=limit)
+
+    if not versions:
+        console.print(f"[dim]No version history for: {artifact_id}[/dim]")
+        console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
+        project.close()
+        return
+
+    table = Table(title=f"Version History: {artifact_id}")
+    table.add_column("Version", style="cyan")
+    table.add_column("Created At")
+    table.add_column("Created By")
+
+    for ver in versions:
+        table.add_row(
+            str(ver.get("version", "-")),
+            ver.get("created_at", "-"),
+            ver.get("created_by", "-") or "-",
+        )
+
+    console.print(table)
+    console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
+    console.print(
+        f"[dim]Use 'qf artifacts show {project_id} {artifact_id} --version N' to view a version[/dim]"
+    )
+
+    project.close()
+
+
 @projects_app.command("info")
 def projects_info(
     project_id: Annotated[str, typer.Argument(help="Project ID")],

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1186,54 +1186,56 @@ def artifacts_list(
     from questfoundry.runtime.storage import Project
 
     project_path = projects_dir / project_id
+    project = None
 
     try:
         project = Project.open(project_path)
+
+        artifacts = project.query_artifacts(
+            artifact_type=artifact_type,
+            store=store,
+            lifecycle_state=lifecycle_state,
+            limit=limit,
+        )
+
+        if not artifacts:
+            console.print("[dim]No artifacts found[/dim]")
+            return
+
+        table = Table(title=f"Artifacts in {project_id}")
+        table.add_column("ID", style="cyan")
+        table.add_column("Type", style="green")
+        table.add_column("Store")
+        table.add_column("State")
+        table.add_column("Version")
+        table.add_column("Updated")
+        table.add_column("Created By", style="dim")
+
+        for artifact in artifacts:
+            updated = artifact.get("_updated_at", "")
+            if updated:
+                # Shorten timestamp
+                updated = updated[:16].replace("T", " ")
+
+            table.add_row(
+                artifact.get("_id", "-"),
+                artifact.get("_type", "-"),
+                artifact.get("_store", "-"),
+                artifact.get("_lifecycle_state", "-"),
+                str(artifact.get("_version", 1)),
+                updated,
+                artifact.get("_created_by") or "-",
+            )
+
+        console.print(table)
+        console.print(f"[dim]Showing {len(artifacts)} artifact(s)[/dim]")
+
     except FileNotFoundError:
         console.print(f"[red]✗ Project not found: {project_id}[/red]")
         raise typer.Exit(1) from None
-
-    artifacts = project.query_artifacts(
-        artifact_type=artifact_type,
-        store=store,
-        lifecycle_state=lifecycle_state,
-        limit=limit,
-    )
-
-    if not artifacts:
-        console.print("[dim]No artifacts found[/dim]")
-        project.close()
-        return
-
-    table = Table(title=f"Artifacts in {project_id}")
-    table.add_column("ID", style="cyan")
-    table.add_column("Type", style="green")
-    table.add_column("Store")
-    table.add_column("State")
-    table.add_column("Version")
-    table.add_column("Updated")
-    table.add_column("Created By", style="dim")
-
-    for artifact in artifacts:
-        updated = artifact.get("_updated_at", "")
-        if updated:
-            # Shorten timestamp
-            updated = updated[:16].replace("T", " ")
-
-        table.add_row(
-            artifact.get("_id", "-"),
-            artifact.get("_type", "-"),
-            artifact.get("_store", "-"),
-            artifact.get("_lifecycle_state", "-"),
-            str(artifact.get("_version", 1)),
-            updated,
-            artifact.get("_created_by", "-"),
-        )
-
-    console.print(table)
-    console.print(f"[dim]Showing {len(artifacts)} artifact(s)[/dim]")
-
-    project.close()
+    finally:
+        if project:
+            project.close()
 
 
 @artifacts_app.command("show")
@@ -1255,57 +1257,57 @@ def artifacts_show(
     from questfoundry.runtime.storage import Project
 
     project_path = projects_dir / project_id
+    project = None
 
     try:
         project = Project.open(project_path)
+
+        if version is not None:
+            # Get specific version
+            version_data = project.get_artifact_at_version(artifact_id, version)
+            if not version_data:
+                console.print(f"[red]✗ Version {version} not found for: {artifact_id}[/red]")
+                raise typer.Exit(1)
+
+            console.print(Panel(f"[dim]Version {version}[/dim]", title=f"Artifact: {artifact_id}"))
+            console.print(f"[bold]Created At:[/bold] {version_data.get('created_at') or '-'}")
+            console.print(f"[bold]Created By:[/bold] {version_data.get('created_by') or '-'}")
+            console.print()
+            console.print("[bold]Data:[/bold]")
+            console.print(json.dumps(version_data.get("data", {}), indent=2))
+        else:
+            # Get current artifact
+            artifact = project.get_artifact(artifact_id)
+            if not artifact:
+                console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
+                raise typer.Exit(1)
+
+            # Separate system fields from user data
+            user_data = {k: v for k, v in artifact.items() if not k.startswith("_")}
+
+            console.print(Panel(f"[cyan]{artifact_id}[/cyan]", title="Artifact"))
+
+            # System metadata
+            console.print("[bold]Metadata:[/bold]")
+            console.print(f"  Type: [green]{artifact.get('_type') or '-'}[/green]")
+            console.print(f"  Store: {artifact.get('_store') or '-'}")
+            console.print(f"  State: {artifact.get('_lifecycle_state') or '-'}")
+            console.print(f"  Version: {artifact.get('_version', 1)}")
+            console.print(f"  Created: {artifact.get('_created_at') or '-'}")
+            console.print(f"  Updated: {artifact.get('_updated_at') or '-'}")
+            console.print(f"  Created By: {artifact.get('_created_by') or '-'}")
+            console.print()
+
+            # User data
+            console.print("[bold]Data:[/bold]")
+            console.print(json.dumps(user_data, indent=2))
+
     except FileNotFoundError:
         console.print(f"[red]✗ Project not found: {project_id}[/red]")
         raise typer.Exit(1) from None
-
-    if version is not None:
-        # Get specific version
-        version_data = project.get_artifact_at_version(artifact_id, version)
-        if not version_data:
-            console.print(f"[red]✗ Version {version} not found for: {artifact_id}[/red]")
+    finally:
+        if project:
             project.close()
-            raise typer.Exit(1)
-
-        console.print(Panel(f"[dim]Version {version}[/dim]", title=f"Artifact: {artifact_id}"))
-        console.print(f"[bold]Created At:[/bold] {version_data.get('created_at', '-')}")
-        console.print(f"[bold]Created By:[/bold] {version_data.get('created_by', '-')}")
-        console.print()
-        console.print("[bold]Data:[/bold]")
-        console.print(json.dumps(version_data.get("data", {}), indent=2))
-    else:
-        # Get current artifact
-        artifact = project.get_artifact(artifact_id)
-        if not artifact:
-            console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
-            project.close()
-            raise typer.Exit(1)
-
-        # Separate system fields from user data
-        system_fields = {k: v for k, v in artifact.items() if k.startswith("_")}
-        user_data = {k: v for k, v in artifact.items() if not k.startswith("_")}
-
-        console.print(Panel(f"[cyan]{artifact_id}[/cyan]", title="Artifact"))
-
-        # System metadata
-        console.print("[bold]Metadata:[/bold]")
-        console.print(f"  Type: [green]{system_fields.get('_type', '-')}[/green]")
-        console.print(f"  Store: {system_fields.get('_store', '-')}")
-        console.print(f"  State: {system_fields.get('_lifecycle_state', '-')}")
-        console.print(f"  Version: {system_fields.get('_version', 1)}")
-        console.print(f"  Created: {system_fields.get('_created_at', '-')}")
-        console.print(f"  Updated: {system_fields.get('_updated_at', '-')}")
-        console.print(f"  Created By: {system_fields.get('_created_by', '-')}")
-        console.print()
-
-        # User data
-        console.print("[bold]Data:[/bold]")
-        console.print(json.dumps(user_data, indent=2))
-
-    project.close()
 
 
 @artifacts_app.command("versions")
@@ -1325,47 +1327,49 @@ def artifacts_versions(
     from questfoundry.runtime.storage import Project
 
     project_path = projects_dir / project_id
+    project = None
 
     try:
         project = Project.open(project_path)
+
+        # Check artifact exists
+        artifact = project.get_artifact(artifact_id)
+        if not artifact:
+            console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
+            raise typer.Exit(1)
+
+        versions = project.get_artifact_versions(artifact_id, limit=limit)
+
+        if not versions:
+            console.print(f"[dim]No version history for: {artifact_id}[/dim]")
+            console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
+            return
+
+        table = Table(title=f"Version History: {artifact_id}")
+        table.add_column("Version", style="cyan")
+        table.add_column("Created At")
+        table.add_column("Created By")
+
+        for ver in versions:
+            table.add_row(
+                str(ver.get("version", "-")),
+                ver.get("created_at") or "-",
+                ver.get("created_by") or "-",
+            )
+
+        console.print(table)
+        console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
+        console.print(
+            f"[dim]Use 'qf artifacts show {project_id} {artifact_id} --version N' "
+            "to view a version[/dim]"
+        )
+
     except FileNotFoundError:
         console.print(f"[red]✗ Project not found: {project_id}[/red]")
         raise typer.Exit(1) from None
-
-    # Check artifact exists
-    artifact = project.get_artifact(artifact_id)
-    if not artifact:
-        console.print(f"[red]✗ Artifact not found: {artifact_id}[/red]")
-        project.close()
-        raise typer.Exit(1)
-
-    versions = project.get_artifact_versions(artifact_id, limit=limit)
-
-    if not versions:
-        console.print(f"[dim]No version history for: {artifact_id}[/dim]")
-        console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
-        project.close()
-        return
-
-    table = Table(title=f"Version History: {artifact_id}")
-    table.add_column("Version", style="cyan")
-    table.add_column("Created At")
-    table.add_column("Created By")
-
-    for ver in versions:
-        table.add_row(
-            str(ver.get("version", "-")),
-            ver.get("created_at", "-"),
-            ver.get("created_by", "-") or "-",
-        )
-
-    console.print(table)
-    console.print(f"[dim]Current version: {artifact.get('_version', 1)}[/dim]")
-    console.print(
-        f"[dim]Use 'qf artifacts show {project_id} {artifact_id} --version N' to view a version[/dim]"
-    )
-
-    project.close()
+    finally:
+        if project:
+            project.close()
 
 
 @projects_app.command("info")

--- a/src/questfoundry/runtime/storage/__init__.py
+++ b/src/questfoundry/runtime/storage/__init__.py
@@ -6,6 +6,7 @@ Provides:
 - Artifact storage in SQLite
 - Version history tracking
 - Message storage for agent communication
+- StoreManager: Registry for store definitions
 """
 
 from questfoundry.runtime.storage.project import (
@@ -13,9 +14,21 @@ from questfoundry.runtime.storage.project import (
     ProjectInfo,
     list_projects,
 )
+from questfoundry.runtime.storage.store_manager import (
+    AssetStorageConfig,
+    RetentionPolicy,
+    StoreDefinition,
+    StoreManager,
+    WorkflowIntent,
+)
 
 __all__ = [
     "Project",
     "ProjectInfo",
     "list_projects",
+    "StoreManager",
+    "StoreDefinition",
+    "WorkflowIntent",
+    "RetentionPolicy",
+    "AssetStorageConfig",
 ]

--- a/src/questfoundry/runtime/storage/__init__.py
+++ b/src/questfoundry/runtime/storage/__init__.py
@@ -7,8 +7,15 @@ Provides:
 - Version history tracking
 - Message storage for agent communication
 - StoreManager: Registry for store definitions
+- LifecycleManager: Artifact lifecycle state machines
 """
 
+from questfoundry.runtime.storage.lifecycle import (
+    ArtifactLifecycle,
+    LifecycleManager,
+    LifecycleState,
+    LifecycleTransition,
+)
 from questfoundry.runtime.storage.project import (
     Project,
     ProjectInfo,
@@ -23,12 +30,19 @@ from questfoundry.runtime.storage.store_manager import (
 )
 
 __all__ = [
+    # Project
     "Project",
     "ProjectInfo",
     "list_projects",
+    # Store management
     "StoreManager",
     "StoreDefinition",
     "WorkflowIntent",
     "RetentionPolicy",
     "AssetStorageConfig",
+    # Lifecycle management
+    "LifecycleManager",
+    "ArtifactLifecycle",
+    "LifecycleState",
+    "LifecycleTransition",
 ]

--- a/src/questfoundry/runtime/storage/lifecycle.py
+++ b/src/questfoundry/runtime/storage/lifecycle.py
@@ -1,0 +1,307 @@
+"""
+Artifact lifecycle management.
+
+Loads lifecycle state machines from artifact type definitions and validates
+state transitions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LifecycleState:
+    """A state in the lifecycle state machine."""
+
+    id: str
+    name: str
+    description: str | None = None
+    terminal: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LifecycleState:
+        """Create from dictionary."""
+        return cls(
+            id=data["id"],
+            name=data.get("name", data["id"]),
+            description=data.get("description"),
+            terminal=data.get("terminal", False),
+        )
+
+
+@dataclass
+class LifecycleTransition:
+    """A transition between lifecycle states."""
+
+    from_state: str
+    to_state: str
+    allowed_agents: list[str] = field(default_factory=list)
+    requires_validation: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LifecycleTransition:
+        """Create from dictionary."""
+        return cls(
+            from_state=data["from"],
+            to_state=data["to"],
+            allowed_agents=data.get("allowed_agents", []),
+            requires_validation=data.get("requires_validation", []),
+        )
+
+    def is_agent_allowed(self, agent_id: str | None) -> bool:
+        """Check if an agent is allowed to make this transition."""
+        # Empty list means any agent can make this transition
+        if not self.allowed_agents:
+            return True
+        return agent_id in self.allowed_agents
+
+
+@dataclass
+class ArtifactLifecycle:
+    """
+    Lifecycle state machine for an artifact type.
+
+    Tracks states and valid transitions between them.
+    """
+
+    artifact_type_id: str
+    states: dict[str, LifecycleState] = field(default_factory=dict)
+    transitions: list[LifecycleTransition] = field(default_factory=list)
+    initial_state: str = "draft"
+
+    @classmethod
+    def from_dict(
+        cls, artifact_type_id: str, data: dict[str, Any] | None
+    ) -> ArtifactLifecycle | None:
+        """
+        Create lifecycle from artifact type definition.
+
+        Args:
+            artifact_type_id: ID of the artifact type
+            data: Lifecycle section from artifact type definition
+
+        Returns:
+            ArtifactLifecycle or None if no lifecycle defined
+        """
+        if data is None:
+            return None
+
+        # Parse states
+        states = {}
+        for state_data in data.get("states", []):
+            state = LifecycleState.from_dict(state_data)
+            states[state.id] = state
+
+        # Parse transitions
+        transitions = []
+        for trans_data in data.get("transitions", []):
+            transitions.append(LifecycleTransition.from_dict(trans_data))
+
+        return cls(
+            artifact_type_id=artifact_type_id,
+            states=states,
+            transitions=transitions,
+            initial_state=data.get("initial_state", "draft"),
+        )
+
+    def get_state(self, state_id: str) -> LifecycleState | None:
+        """Get a state by ID."""
+        return self.states.get(state_id)
+
+    def is_terminal_state(self, state_id: str) -> bool:
+        """Check if a state is terminal (no further transitions allowed)."""
+        state = self.states.get(state_id)
+        return state.terminal if state else False
+
+    def get_valid_transitions(
+        self, from_state: str, agent_id: str | None = None
+    ) -> list[LifecycleTransition]:
+        """
+        Get valid transitions from a state.
+
+        Args:
+            from_state: Current state
+            agent_id: Optional agent ID to filter by allowed_agents
+
+        Returns:
+            List of valid transitions
+        """
+        valid = []
+        for trans in self.transitions:
+            if trans.from_state == from_state and (
+                agent_id is None or trans.is_agent_allowed(agent_id)
+            ):
+                valid.append(trans)
+        return valid
+
+    def get_transition(self, from_state: str, to_state: str) -> LifecycleTransition | None:
+        """Get a specific transition if it exists."""
+        for trans in self.transitions:
+            if trans.from_state == from_state and trans.to_state == to_state:
+                return trans
+        return None
+
+    def validate_transition(
+        self, from_state: str, to_state: str, agent_id: str | None = None
+    ) -> tuple[bool, str | None]:
+        """
+        Validate if a transition is allowed.
+
+        Args:
+            from_state: Current state
+            to_state: Target state
+            agent_id: Agent requesting the transition
+
+        Returns:
+            Tuple of (allowed, reason if not allowed)
+        """
+        # Check if from_state is terminal
+        if self.is_terminal_state(from_state):
+            return False, f"Cannot transition from terminal state '{from_state}'"
+
+        # Find the transition
+        transition = self.get_transition(from_state, to_state)
+        if transition is None:
+            return False, f"No transition defined from '{from_state}' to '{to_state}'"
+
+        # Check agent permission
+        if not transition.is_agent_allowed(agent_id):
+            allowed_str = ", ".join(transition.allowed_agents)
+            return (
+                False,
+                f"Agent '{agent_id}' not allowed for this transition. "
+                f"Allowed agents: {allowed_str}",
+            )
+
+        return True, None
+
+    def list_states(self) -> list[LifecycleState]:
+        """List all states in order of definition."""
+        return list(self.states.values())
+
+
+class LifecycleManager:
+    """
+    Manages lifecycles for multiple artifact types.
+
+    Loads lifecycle definitions from artifact types and provides
+    lookup and validation services.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty lifecycle manager."""
+        self._lifecycles: dict[str, ArtifactLifecycle] = {}
+
+    def register_lifecycle(self, lifecycle: ArtifactLifecycle) -> None:
+        """Register a lifecycle for an artifact type."""
+        self._lifecycles[lifecycle.artifact_type_id] = lifecycle
+        logger.debug(f"Registered lifecycle for artifact type: {lifecycle.artifact_type_id}")
+
+    def get_lifecycle(self, artifact_type_id: str) -> ArtifactLifecycle | None:
+        """Get lifecycle for an artifact type."""
+        return self._lifecycles.get(artifact_type_id)
+
+    def has_lifecycle(self, artifact_type_id: str) -> bool:
+        """Check if an artifact type has a lifecycle."""
+        return artifact_type_id in self._lifecycles
+
+    def get_initial_state(self, artifact_type_id: str) -> str:
+        """Get initial state for an artifact type (defaults to 'draft')."""
+        lifecycle = self._lifecycles.get(artifact_type_id)
+        if lifecycle:
+            return lifecycle.initial_state
+        return "draft"
+
+    def validate_transition(
+        self,
+        artifact_type_id: str,
+        from_state: str,
+        to_state: str,
+        agent_id: str | None = None,
+    ) -> tuple[bool, str | None]:
+        """
+        Validate a lifecycle transition.
+
+        Args:
+            artifact_type_id: Artifact type
+            from_state: Current state
+            to_state: Target state
+            agent_id: Agent requesting the transition
+
+        Returns:
+            Tuple of (allowed, reason if not allowed)
+        """
+        lifecycle = self._lifecycles.get(artifact_type_id)
+        if lifecycle is None:
+            # No lifecycle defined - allow any state change
+            return True, None
+
+        return lifecycle.validate_transition(from_state, to_state, agent_id)
+
+    def get_required_validations(
+        self, artifact_type_id: str, from_state: str, to_state: str
+    ) -> list[str]:
+        """
+        Get required validations for a transition.
+
+        Args:
+            artifact_type_id: Artifact type
+            from_state: Current state
+            to_state: Target state
+
+        Returns:
+            List of validation IDs required for this transition
+        """
+        lifecycle = self._lifecycles.get(artifact_type_id)
+        if lifecycle is None:
+            return []
+
+        transition = lifecycle.get_transition(from_state, to_state)
+        if transition is None:
+            return []
+
+        return transition.requires_validation
+
+    @classmethod
+    def from_artifact_types(cls, artifact_types: list[Any]) -> LifecycleManager:
+        """
+        Create manager from artifact type definitions.
+
+        Args:
+            artifact_types: List of artifact type objects with lifecycle attribute
+
+        Returns:
+            LifecycleManager with all lifecycles registered
+        """
+        manager = cls()
+
+        for artifact_type in artifact_types:
+            # Handle both dict and object types
+            if isinstance(artifact_type, dict):
+                type_id = artifact_type.get("id")
+                lifecycle_data = artifact_type.get("lifecycle")
+            else:
+                type_id = getattr(artifact_type, "id", None)
+                lifecycle_data = getattr(artifact_type, "lifecycle", None)
+                # If lifecycle is an object, convert to dict
+                if lifecycle_data and hasattr(lifecycle_data, "to_dict"):
+                    lifecycle_data = lifecycle_data.to_dict()
+                elif lifecycle_data and not isinstance(lifecycle_data, dict):
+                    # Try to access as object attributes
+                    lifecycle_data = {
+                        "states": getattr(lifecycle_data, "states", []),
+                        "initial_state": getattr(lifecycle_data, "initial_state", "draft"),
+                        "transitions": getattr(lifecycle_data, "transitions", []),
+                    }
+
+            if type_id and lifecycle_data:
+                lifecycle = ArtifactLifecycle.from_dict(type_id, lifecycle_data)
+                if lifecycle:
+                    manager.register_lifecycle(lifecycle)
+
+        return manager

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -439,6 +439,39 @@ class Project:
 
         return self.get_artifact(artifact_id)
 
+    def delete_artifact(self, artifact_id: str) -> bool:
+        """
+        Delete an artifact.
+
+        Args:
+            artifact_id: Artifact ID to delete
+
+        Returns:
+            True if deleted, False if not found
+
+        Note:
+            Store semantics enforcement should be done at the tool level
+            via StoreManager before calling this method.
+        """
+        conn = self._get_connection()
+
+        # Check if exists
+        existing = conn.execute(
+            "SELECT _id FROM artifacts WHERE _id = ?", (artifact_id,)
+        ).fetchone()
+
+        if existing is None:
+            return False
+
+        # Delete any version history
+        conn.execute("DELETE FROM artifact_versions WHERE artifact_id = ?", (artifact_id,))
+
+        # Delete the artifact
+        conn.execute("DELETE FROM artifacts WHERE _id = ?", (artifact_id,))
+        conn.commit()
+
+        return True
+
     def query_artifacts(
         self,
         artifact_type: str | None = None,

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -532,6 +532,126 @@ class Project:
 
         return results
 
+    # Version history operations
+
+    def save_version(
+        self,
+        artifact_id: str,
+        created_by: str | None = None,
+    ) -> int | None:
+        """
+        Save the current state of an artifact as a version snapshot.
+
+        This should be called BEFORE updating an artifact in a versioned store.
+        The snapshot preserves the complete artifact state including system fields.
+
+        Args:
+            artifact_id: Artifact ID to snapshot
+            created_by: Agent ID creating the version
+
+        Returns:
+            The version number saved, or None if artifact not found
+        """
+        artifact = self.get_artifact(artifact_id)
+        if artifact is None:
+            return None
+
+        conn = self._get_connection()
+        now = datetime.now().isoformat()
+        version: int = artifact["_version"]
+
+        # Save complete artifact data (user fields only for storage efficiency)
+        user_data = {k: v for k, v in artifact.items() if not k.startswith("_")}
+
+        conn.execute(
+            """
+            INSERT INTO artifact_versions (artifact_id, version, data, created_at, created_by)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (artifact_id, version, json.dumps(user_data), now, created_by),
+        )
+        conn.commit()
+
+        return version
+
+    def get_artifact_versions(
+        self,
+        artifact_id: str,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """
+        Get version history for an artifact.
+
+        Args:
+            artifact_id: Artifact ID
+            limit: Maximum versions to return
+
+        Returns:
+            List of version snapshots, newest first
+        """
+        conn = self._get_connection()
+
+        rows = conn.execute(
+            """
+            SELECT version, data, created_at, created_by
+            FROM artifact_versions
+            WHERE artifact_id = ?
+            ORDER BY version DESC
+            LIMIT ?
+            """,
+            (artifact_id, limit),
+        ).fetchall()
+
+        versions = []
+        for row in rows:
+            versions.append(
+                {
+                    "version": row["version"],
+                    "data": json.loads(row["data"]),
+                    "created_at": row["created_at"],
+                    "created_by": row["created_by"],
+                }
+            )
+
+        return versions
+
+    def get_artifact_at_version(
+        self,
+        artifact_id: str,
+        version: int,
+    ) -> dict[str, Any] | None:
+        """
+        Get a specific version of an artifact.
+
+        Args:
+            artifact_id: Artifact ID
+            version: Version number to retrieve
+
+        Returns:
+            Artifact data at that version, or None if not found
+        """
+        conn = self._get_connection()
+
+        row = conn.execute(
+            """
+            SELECT data, created_at, created_by
+            FROM artifact_versions
+            WHERE artifact_id = ? AND version = ?
+            """,
+            (artifact_id, version),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        return {
+            "artifact_id": artifact_id,
+            "version": version,
+            "data": json.loads(row["data"]),
+            "created_at": row["created_at"],
+            "created_by": row["created_by"],
+        }
+
 
 def list_projects(projects_dir: Path) -> list[Project]:
     """

--- a/src/questfoundry/runtime/storage/store_manager.py
+++ b/src/questfoundry/runtime/storage/store_manager.py
@@ -1,0 +1,323 @@
+"""
+Store manager for loading and querying store definitions.
+
+Loads store definitions from domain and provides:
+- Store lookup by ID
+- Default store resolution for artifact types
+- Exclusive producer tracking
+- Workflow intent (consumption/production guidance)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from questfoundry.runtime.models.enums import StoreSemantics
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetentionPolicy:
+    """How long data is kept in a store."""
+
+    type: str  # "forever", "duration", "count", "project_scoped"
+    duration_days: int | None = None
+    max_count: int | None = None
+    max_versions: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> RetentionPolicy | None:
+        """Create from dictionary."""
+        if not data:
+            return None
+        return cls(
+            type=data.get("type", "forever"),
+            duration_days=data.get("duration_days"),
+            max_count=data.get("max_count"),
+            max_versions=data.get("max_versions"),
+        )
+
+
+@dataclass
+class WorkflowIntent:
+    """
+    Workflow guidance for a store.
+
+    Serves two purposes:
+    1. ATTENTION MECHANISM: Helps Runtime decide what to load into agent context
+    2. WORKFLOW OBSERVABILITY: Enables nudging when agents deviate from intended patterns
+
+    NOT access control - the Runtime never denies access based on this.
+    """
+
+    consumption_guidance: str = "all"  # "all", "specified", "none"
+    production_guidance: str = "all"  # "all", "specified", "exclusive", "none"
+    designated_consumers: list[str] = field(default_factory=list)
+    designated_producers: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> WorkflowIntent | None:
+        """Create from dictionary."""
+        if data is None:
+            return None
+        return cls(
+            consumption_guidance=data.get("consumption_guidance", "all"),
+            production_guidance=data.get("production_guidance", "all"),
+            designated_consumers=data.get("designated_consumers", []),
+            designated_producers=data.get("designated_producers", []),
+        )
+
+    @property
+    def is_exclusive(self) -> bool:
+        """Check if this store has exclusive production semantics."""
+        return self.production_guidance == "exclusive"
+
+
+@dataclass
+class AssetStorageConfig:
+    """Configuration for binary asset storage."""
+
+    backend: str = "filesystem"  # "filesystem", "s3", "azure_blob", "gcs"
+    base_path: str | None = None
+    bucket: str | None = None
+    prefix: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AssetStorageConfig | None:
+        """Create from dictionary."""
+        if not data:
+            return None
+        return cls(
+            backend=data.get("backend", "filesystem"),
+            base_path=data.get("base_path"),
+            bucket=data.get("bucket"),
+            prefix=data.get("prefix"),
+        )
+
+
+@dataclass
+class StoreDefinition:
+    """
+    Definition of a storage location for artifacts and assets.
+
+    Loaded from domain stores (e.g., domain-v4/stores/workspace.json).
+    """
+
+    id: str
+    name: str
+    description: str | None = None
+    semantics: StoreSemantics = StoreSemantics.MUTABLE
+    artifact_types: list[str] = field(default_factory=list)
+    asset_types: list[str] = field(default_factory=list)
+    workflow_intent: WorkflowIntent | None = None
+    retention: RetentionPolicy | None = None
+    asset_storage: AssetStorageConfig | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StoreDefinition:
+        """Create from dictionary (loaded from JSON)."""
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            description=data.get("description"),
+            semantics=StoreSemantics(data.get("semantics", "mutable")),
+            artifact_types=data.get("artifact_types", []),
+            asset_types=data.get("asset_types", []),
+            workflow_intent=WorkflowIntent.from_dict(data.get("workflow_intent")),
+            retention=RetentionPolicy.from_dict(data.get("retention")),
+            asset_storage=AssetStorageConfig.from_dict(data.get("asset_storage")),
+        )
+
+    @property
+    def is_exclusive(self) -> bool:
+        """Check if this store has exclusive production semantics."""
+        return self.workflow_intent is not None and self.workflow_intent.is_exclusive
+
+    @property
+    def exclusive_producers(self) -> list[str]:
+        """Get designated producers for exclusive stores."""
+        if self.workflow_intent and self.workflow_intent.is_exclusive:
+            return self.workflow_intent.designated_producers
+        return []
+
+    def allows_artifact_type(self, artifact_type: str) -> bool:
+        """Check if this store accepts the given artifact type."""
+        # Empty list means any type is allowed
+        if not self.artifact_types:
+            return True
+        return artifact_type in self.artifact_types
+
+    def allows_updates(self) -> bool:
+        """Check if this store allows artifact updates."""
+        return self.semantics not in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY)
+
+    def allows_deletes(self) -> bool:
+        """Check if this store allows artifact deletion."""
+        return self.semantics not in (StoreSemantics.COLD, StoreSemantics.APPEND_ONLY)
+
+    def requires_version_history(self) -> bool:
+        """Check if this store requires version history on updates."""
+        return self.semantics == StoreSemantics.VERSIONED
+
+
+class StoreManager:
+    """
+    Central registry for store definitions.
+
+    Responsibilities:
+    - Load store definitions from domain
+    - Provide store lookup by ID
+    - Resolve default stores for artifact types
+    - Track exclusive producers
+    """
+
+    def __init__(self, stores: dict[str, StoreDefinition] | None = None):
+        """
+        Initialize store manager.
+
+        Args:
+            stores: Dictionary of store ID -> StoreDefinition.
+                    If None, starts empty (use from_domain to load).
+        """
+        self._stores: dict[str, StoreDefinition] = stores or {}
+        # Cache: artifact_type -> default store ID
+        self._default_store_cache: dict[str, str] = {}
+
+    @classmethod
+    def from_domain(cls, domain_path: Path) -> StoreManager:
+        """
+        Load store definitions from domain directory.
+
+        Args:
+            domain_path: Path to domain directory (e.g., domain-v4/)
+
+        Returns:
+            StoreManager with loaded stores
+        """
+        stores_dir = domain_path / "stores"
+        stores: dict[str, StoreDefinition] = {}
+
+        if not stores_dir.exists():
+            logger.warning(f"Stores directory not found: {stores_dir}")
+            return cls(stores)
+
+        for store_file in stores_dir.glob("*.json"):
+            try:
+                data = json.loads(store_file.read_text())
+                store = StoreDefinition.from_dict(data)
+                stores[store.id] = store
+                logger.debug(f"Loaded store: {store.id} ({store.semantics.value})")
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.error(f"Failed to load store from {store_file}: {e}")
+
+        logger.info(f"Loaded {len(stores)} store definitions")
+        return cls(stores)
+
+    def get_store(self, store_id: str) -> StoreDefinition | None:
+        """Get store definition by ID."""
+        return self._stores.get(store_id)
+
+    def list_stores(self) -> list[StoreDefinition]:
+        """List all store definitions."""
+        return list(self._stores.values())
+
+    def get_store_ids(self) -> list[str]:
+        """Get all store IDs."""
+        return list(self._stores.keys())
+
+    def get_default_store(self, artifact_type: str) -> str:
+        """
+        Get default store for an artifact type.
+
+        Resolution order:
+        1. Cached value
+        2. First store that explicitly lists the artifact type
+        3. "workspace" (fallback)
+
+        Args:
+            artifact_type: Artifact type ID
+
+        Returns:
+            Store ID
+        """
+        # Check cache
+        if artifact_type in self._default_store_cache:
+            return self._default_store_cache[artifact_type]
+
+        # Find first store that explicitly lists this type
+        for store in self._stores.values():
+            if artifact_type in store.artifact_types:
+                self._default_store_cache[artifact_type] = store.id
+                return store.id
+
+        # Fallback to workspace
+        default = "workspace"
+        self._default_store_cache[artifact_type] = default
+        return default
+
+    def set_default_store(self, artifact_type: str, store_id: str) -> None:
+        """
+        Set default store for an artifact type (from artifact type definitions).
+
+        Called when loading artifact types that specify default_store.
+        """
+        if store_id in self._stores:
+            self._default_store_cache[artifact_type] = store_id
+        else:
+            logger.warning(f"Unknown store '{store_id}' set as default for {artifact_type}")
+
+    def get_exclusive_producer(self, store_id: str) -> str | None:
+        """
+        Get exclusive producer agent ID for a store.
+
+        Args:
+            store_id: Store ID
+
+        Returns:
+            Agent ID if store is exclusive, None otherwise
+        """
+        store = self._stores.get(store_id)
+        if store and store.exclusive_producers:
+            # Return first designated producer (usually only one for exclusive stores)
+            return store.exclusive_producers[0]
+        return None
+
+    def get_stores_by_semantics(self, semantics: StoreSemantics) -> list[StoreDefinition]:
+        """Get all stores with the given semantics."""
+        return [s for s in self._stores.values() if s.semantics == semantics]
+
+    def get_exclusive_stores(self) -> list[StoreDefinition]:
+        """Get all stores with exclusive production semantics."""
+        return [s for s in self._stores.values() if s.is_exclusive]
+
+    def validate_write(
+        self,
+        store_id: str,
+        artifact_type: str,
+    ) -> tuple[bool, str | None]:
+        """
+        Validate if artifact type can be written to store.
+
+        Args:
+            store_id: Target store ID
+            artifact_type: Artifact type to write
+
+        Returns:
+            (allowed, reason_if_not)
+        """
+        store = self._stores.get(store_id)
+        if not store:
+            return False, f"Unknown store: {store_id}"
+
+        if not store.allows_artifact_type(artifact_type):
+            return False, (
+                f"Store '{store_id}' does not accept artifact type '{artifact_type}'. "
+                f"Allowed types: {store.artifact_types}"
+            )
+
+        return True, None

--- a/src/questfoundry/runtime/storage/store_manager.py
+++ b/src/questfoundry/runtime/storage/store_manager.py
@@ -206,7 +206,7 @@ class StoreManager:
             logger.warning(f"Stores directory not found: {stores_dir}")
             return cls(stores)
 
-        for store_file in stores_dir.glob("*.json"):
+        for store_file in sorted(stores_dir.glob("*.json")):
             try:
                 data = json.loads(store_file.read_text())
                 store = StoreDefinition.from_dict(data)
@@ -283,7 +283,12 @@ class StoreManager:
         """
         store = self._stores.get(store_id)
         if store and store.exclusive_producers:
-            # Return first designated producer (usually only one for exclusive stores)
+            # Warn if multiple exclusive producers configured (may indicate domain issue)
+            if len(store.exclusive_producers) > 1:
+                logger.warning(
+                    f"Store '{store_id}' has multiple exclusive producers: "
+                    f"{store.exclusive_producers}. This may indicate a domain configuration issue."
+                )
             return store.exclusive_producers[0]
         return None
 

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -23,6 +23,7 @@ from questfoundry.runtime.tools import (
     consult_playbook,  # noqa: F401
     consult_schema,  # noqa: F401
     delegate,  # noqa: F401
+    lifecycle_transition,  # noqa: F401  # Phase 4: lifecycle transitions
     list_agents,  # noqa: F401
     list_artifact_types,  # noqa: F401
     list_stores,  # noqa: F401

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -27,6 +27,7 @@ from questfoundry.runtime.tools import (
     list_artifact_types,  # noqa: F401
     list_stores,  # noqa: F401
     request_clarification,  # noqa: F401
+    save_artifact,  # noqa: F401  # Phase 4: artifact persistence
     search_workspace,  # noqa: F401
     stubs,  # noqa: F401
     validate_artifact,  # noqa: F401

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Studio, Tool
-    from questfoundry.runtime.storage import Project, StoreManager
+    from questfoundry.runtime.storage import LifecycleManager, Project, StoreManager
 
 
 class ToolError(Exception):
@@ -89,6 +89,7 @@ class ToolContext:
 
     # Storage infrastructure (Phase 4)
     store_manager: StoreManager | None = None
+    lifecycle_manager: LifecycleManager | None = None
 
     # Additional context that may be needed
     domain_path: Path | None = None  # Path to domain directory

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Studio, Tool
-    from questfoundry.runtime.storage import Project
+    from questfoundry.runtime.storage import Project, StoreManager
 
 
 class ToolError(Exception):
@@ -86,6 +86,9 @@ class ToolContext:
 
     # Messaging infrastructure (Phase 3)
     broker: AsyncMessageBroker | None = None
+
+    # Storage infrastructure (Phase 4)
+    store_manager: StoreManager | None = None
 
     # Additional context that may be needed
     domain_path: Path | None = None  # Path to domain directory

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -1,0 +1,266 @@
+"""
+Lifecycle transition tool implementation.
+
+Allows agents to request lifecycle state changes for artifacts.
+Validates transitions against the lifecycle state machine and
+enforces allowed_agents restrictions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult
+from questfoundry.runtime.tools.registry import register_tool
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.storage.lifecycle import LifecycleManager
+
+logger = logging.getLogger(__name__)
+
+
+@register_tool("request_lifecycle_transition")
+class RequestLifecycleTransitionTool(BaseTool):
+    """
+    Request a lifecycle state transition for an artifact.
+
+    Validates the transition against the lifecycle state machine:
+    - Checks if transition is defined
+    - Checks if current agent is allowed to make the transition
+    - Returns required validations if any
+
+    Note: If transition requires_validation, the actual state change
+    may be deferred until validations pass.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute lifecycle transition request."""
+        artifact_id: str | None = args.get("artifact_id")
+        target_state: str | None = args.get("target_state")
+        force: bool = args.get("force", False)
+
+        # Validate required fields
+        if not artifact_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_id is required",
+            )
+
+        if not target_state:
+            return ToolResult(
+                success=False,
+                data={},
+                error="target_state is required",
+            )
+
+        # Validate we have a project
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot transition artifact",
+            )
+
+        # Get the artifact
+        artifact = self._context.project.get_artifact(artifact_id)
+        if not artifact:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Artifact not found: {artifact_id}",
+            )
+
+        # Get current state
+        current_state = artifact.get("_lifecycle_state", "draft")
+        artifact_type = artifact.get("_type")
+
+        # Check if already in target state
+        if current_state == target_state:
+            return ToolResult(
+                success=True,
+                data={
+                    "artifact_id": artifact_id,
+                    "current_state": current_state,
+                    "target_state": target_state,
+                    "transitioned": False,
+                    "message": f"Artifact already in '{target_state}' state",
+                },
+            )
+
+        # Get lifecycle manager if available
+        lifecycle_manager = self._get_lifecycle_manager()
+
+        # Validate transition
+        if lifecycle_manager and artifact_type:
+            allowed, reason = lifecycle_manager.validate_transition(
+                artifact_type,
+                current_state,
+                target_state,
+                agent_id=self._context.agent_id,
+            )
+
+            if not allowed:
+                return ToolResult(
+                    success=False,
+                    data={
+                        "artifact_id": artifact_id,
+                        "current_state": current_state,
+                        "target_state": target_state,
+                    },
+                    error=f"Transition not allowed: {reason}",
+                )
+
+            # Check for required validations
+            required_validations = lifecycle_manager.get_required_validations(
+                artifact_type, current_state, target_state
+            )
+
+            if required_validations and not force:
+                # Return pending status with required validations
+                return ToolResult(
+                    success=True,
+                    data={
+                        "artifact_id": artifact_id,
+                        "current_state": current_state,
+                        "target_state": target_state,
+                        "transitioned": False,
+                        "status": "pending_validation",
+                        "required_validations": required_validations,
+                        "message": (
+                            f"Transition requires validations: {', '.join(required_validations)}. "
+                            "Use force=true to bypass (not recommended)."
+                        ),
+                    },
+                )
+
+            if required_validations and force:
+                logger.warning(
+                    f"Forcing transition {current_state} -> {target_state} for {artifact_id} "
+                    f"without validations: {required_validations}"
+                )
+
+        # Perform the transition
+        try:
+            updated = self._context.project.update_artifact(
+                artifact_id=artifact_id,
+                data={"_lifecycle_state": target_state},
+            )
+
+            if updated:
+                logger.info(
+                    f"Lifecycle transition: {artifact_id} {current_state} -> {target_state} "
+                    f"(by {self._context.agent_id})"
+                )
+
+                return ToolResult(
+                    success=True,
+                    data={
+                        "artifact_id": artifact_id,
+                        "previous_state": current_state,
+                        "current_state": target_state,
+                        "transitioned": True,
+                        "transitioned_by": self._context.agent_id,
+                    },
+                )
+            else:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=f"Failed to update artifact: {artifact_id}",
+                )
+
+        except Exception as e:
+            logger.exception(f"Failed to transition artifact: {e}")
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Failed to transition artifact: {e}",
+            )
+
+    def _get_lifecycle_manager(self) -> LifecycleManager | None:
+        """
+        Get lifecycle manager from context.
+
+        Note: LifecycleManager is not yet in ToolContext.
+        This will be added when we integrate with the runtime.
+        For now, return None to allow any transition.
+        """
+        # TODO: Add lifecycle_manager to ToolContext
+        # return self._context.lifecycle_manager
+        return getattr(self._context, "lifecycle_manager", None)
+
+
+@register_tool("get_lifecycle_state")
+class GetLifecycleStateTool(BaseTool):
+    """
+    Get the current lifecycle state of an artifact.
+
+    Returns the current state and available transitions.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute lifecycle state retrieval."""
+        artifact_id: str | None = args.get("artifact_id")
+
+        if not artifact_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_id is required",
+            )
+
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot get lifecycle state",
+            )
+
+        # Get the artifact
+        artifact = self._context.project.get_artifact(artifact_id)
+        if not artifact:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Artifact not found: {artifact_id}",
+            )
+
+        current_state = artifact.get("_lifecycle_state", "draft")
+        artifact_type = artifact.get("_type")
+
+        result_data: dict[str, Any] = {
+            "artifact_id": artifact_id,
+            "artifact_type": artifact_type,
+            "current_state": current_state,
+        }
+
+        # Get available transitions if lifecycle manager available
+        lifecycle_manager = self._get_lifecycle_manager()
+        if lifecycle_manager and artifact_type:
+            lifecycle = lifecycle_manager.get_lifecycle(artifact_type)
+            if lifecycle:
+                # Get valid transitions for current agent
+                valid_transitions = lifecycle.get_valid_transitions(
+                    current_state, agent_id=self._context.agent_id
+                )
+                result_data["available_transitions"] = [
+                    {
+                        "target_state": t.to_state,
+                        "requires_validation": t.requires_validation,
+                    }
+                    for t in valid_transitions
+                ]
+
+                # Check if current state is terminal
+                result_data["is_terminal"] = lifecycle.is_terminal_state(current_state)
+
+        return ToolResult(
+            success=True,
+            data=result_data,
+        )
+
+    def _get_lifecycle_manager(self) -> LifecycleManager | None:
+        """Get lifecycle manager from context."""
+        return getattr(self._context, "lifecycle_manager", None)

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -231,6 +231,7 @@ class RequestLifecycleTransitionTool(BaseTool):
             }
 
         # Create a mock tool definition for validate_artifact
+        # Import here to avoid circular dependency (models imports from tools)
         from questfoundry.runtime.models import Tool
 
         validate_def = Tool(

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -4,6 +4,9 @@ Lifecycle transition tool implementation.
 Allows agents to request lifecycle state changes for artifacts.
 Validates transitions against the lifecycle state machine and
 enforces allowed_agents restrictions.
+
+Transitions with `requires_validation` run quality bar checks
+and commit/reject based on results.
 """
 
 from __future__ import annotations
@@ -12,7 +15,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.runtime.tools.base import BaseTool, ToolResult
-from questfoundry.runtime.tools.registry import register_tool
+from questfoundry.runtime.tools.registry import TOOL_IMPLEMENTATIONS, register_tool
 
 if TYPE_CHECKING:
     from questfoundry.runtime.storage.lifecycle import LifecycleManager
@@ -117,29 +120,35 @@ class RequestLifecycleTransitionTool(BaseTool):
                 artifact_type, current_state, target_state
             )
 
-            if required_validations and not force:
-                # Return pending status with required validations
-                return ToolResult(
-                    success=True,
-                    data={
-                        "artifact_id": artifact_id,
-                        "current_state": current_state,
-                        "target_state": target_state,
-                        "transitioned": False,
-                        "status": "pending_validation",
-                        "required_validations": required_validations,
-                        "message": (
-                            f"Transition requires validations: {', '.join(required_validations)}. "
-                            "Use force=true to bypass (not recommended)."
-                        ),
-                    },
-                )
-
             if required_validations and force:
                 logger.warning(
                     f"Forcing transition {current_state} -> {target_state} for {artifact_id} "
                     f"without validations: {required_validations}"
                 )
+            elif required_validations:
+                # Run validations
+                validation_result = await self._run_validations(
+                    artifact_id, artifact_type, artifact, required_validations
+                )
+
+                if not validation_result["passed"]:
+                    # Reject transition
+                    return ToolResult(
+                        success=True,
+                        data={
+                            "result": "rejected",
+                            "artifact_id": artifact_id,
+                            "current_state": current_state,
+                            "target_state": target_state,
+                            "transitioned": False,
+                            "validation_results": validation_result["results"],
+                            "rejection_reason": validation_result["reason"],
+                            "guidance": validation_result["guidance"],
+                        },
+                    )
+
+                # Validations passed - continue to commit
+                logger.info(f"Validations passed for {artifact_id}: {required_validations}")
 
         # Perform the transition
         try:
@@ -157,9 +166,10 @@ class RequestLifecycleTransitionTool(BaseTool):
                 return ToolResult(
                     success=True,
                     data={
+                        "result": "committed",
                         "artifact_id": artifact_id,
                         "previous_state": current_state,
-                        "current_state": target_state,
+                        "new_state": target_state,
                         "transitioned": True,
                         "transitioned_by": self._context.agent_id,
                     },
@@ -180,16 +190,105 @@ class RequestLifecycleTransitionTool(BaseTool):
             )
 
     def _get_lifecycle_manager(self) -> LifecycleManager | None:
-        """
-        Get lifecycle manager from context.
-
-        Note: LifecycleManager is not yet in ToolContext.
-        This will be added when we integrate with the runtime.
-        For now, return None to allow any transition.
-        """
-        # TODO: Add lifecycle_manager to ToolContext
-        # return self._context.lifecycle_manager
+        """Get lifecycle manager from context."""
         return getattr(self._context, "lifecycle_manager", None)
+
+    async def _run_validations(
+        self,
+        artifact_id: str,
+        artifact_type: str,
+        artifact: dict[str, Any],
+        required_validations: list[str],
+    ) -> dict[str, Any]:
+        """
+        Run required validation checks on an artifact.
+
+        Args:
+            artifact_id: The artifact to validate
+            artifact_type: The artifact type ID
+            artifact: The artifact data
+            required_validations: List of quality bar names to check
+
+        Returns:
+            Dict with:
+                passed: bool - True if all validations pass
+                results: list - Detailed results per validation
+                reason: str | None - Rejection reason if failed
+                guidance: str | None - Fix guidance if failed
+        """
+        # Try to get validate_artifact tool implementation
+        validate_tool_class = TOOL_IMPLEMENTATIONS.get("validate_artifact")
+        if not validate_tool_class:
+            # No validate tool - assume validations pass (permissive)
+            logger.warning(
+                f"validate_artifact tool not found - skipping validations for {artifact_id}"
+            )
+            return {
+                "passed": True,
+                "results": [],
+                "reason": None,
+                "guidance": None,
+            }
+
+        # Create a mock tool definition for validate_artifact
+        from questfoundry.runtime.models import Tool
+
+        validate_def = Tool(
+            id="validate_artifact",
+            name="validate_artifact",
+            description="Validate artifact against quality bars",
+            timeout_ms=30000,
+        )
+
+        # Instantiate the validate tool with current context
+        validate_tool = validate_tool_class(validate_def, self._context)
+
+        # Extract user data from artifact (exclude system fields)
+        artifact_data = {k: v for k, v in artifact.items() if not k.startswith("_")}
+
+        # Run validation
+        result = await validate_tool.execute(
+            {
+                "artifact_id": artifact_id,
+                "artifact_type_id": artifact_type,
+                "artifact_data": artifact_data,
+                "validation_mode": "bars_only",  # Focus on quality bars
+                "bars_to_check": required_validations,
+            }
+        )
+
+        if not result.success:
+            # Validation tool itself failed
+            return {
+                "passed": False,
+                "results": [],
+                "reason": f"Validation failed: {result.error}",
+                "guidance": "Check artifact data and retry",
+            }
+
+        # Check bar results
+        bar_results = result.data.get("bar_results", [])
+        failed_bars = [br for br in bar_results if br.get("status") == "red"]
+
+        if failed_bars:
+            # Collect failure details
+            failed_names = [br["bar"] for br in failed_bars]
+            fixes = [br.get("smallest_fix") for br in failed_bars if br.get("smallest_fix")]
+
+            return {
+                "passed": False,
+                "results": bar_results,
+                "reason": f"Quality bar failures: {', '.join(failed_names)}",
+                "guidance": "; ".join(fixes) if fixes else "Address the failing quality bars",
+            }
+
+        # All validations passed
+        return {
+            "passed": True,
+            "results": bar_results,
+            "reason": None,
+            "guidance": None,
+        }
 
 
 @register_tool("get_lifecycle_state")

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -327,6 +327,7 @@ class UpdateArtifactTool(BaseTool):
 
         # Check store semantics
         store_id = existing.get("_store")
+        save_version = False
         if store_id and self._context.store_manager:
             store = self._context.store_manager.get_store(store_id)
             if store and not store.allows_updates():
@@ -338,21 +339,37 @@ class UpdateArtifactTool(BaseTool):
                         "Store does not allow updates."
                     ),
                 )
+            # Check if store requires version history
+            if store and store.requires_version_history():
+                save_version = True
 
         # Update artifact
         try:
+            # Save version history before update for versioned stores
+            version_saved = None
+            if save_version:
+                version_saved = self._context.project.save_version(
+                    artifact_id=artifact_id,
+                    created_by=self._context.agent_id,
+                )
+                logger.debug(f"Saved version {version_saved} for {artifact_id}")
+
             updated = self._context.project.update_artifact(
                 artifact_id=artifact_id,
                 data=data,
             )
 
             if updated:
+                result_data = {
+                    "artifact": updated,
+                    "artifact_id": artifact_id,
+                }
+                if version_saved is not None:
+                    result_data["version_saved"] = version_saved
+
                 return ToolResult(
                     success=True,
-                    data={
-                        "artifact": updated,
-                        "artifact_id": artifact_id,
-                    },
+                    data=result_data,
                 )
             else:
                 return ToolResult(

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -1,0 +1,537 @@
+"""
+Save Artifact tool implementation.
+
+Allows agents to persist artifacts to stores. Validates schema,
+checks exclusive writer policy, and assigns initial lifecycle state.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from enum import Enum
+from typing import Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult
+from questfoundry.runtime.tools.registry import register_tool
+
+logger = logging.getLogger(__name__)
+
+
+class ExclusiveWriterPolicy(Enum):
+    """
+    Policy for handling exclusive writer violations.
+
+    WARN: Log warning, include in result, but allow the write (open floor principle)
+    BLOCK: Reject writes from non-designated agents
+    """
+
+    WARN = "warn"
+    BLOCK = "block"
+
+
+# Default policy - can be changed to BLOCK for stricter enforcement
+DEFAULT_EXCLUSIVE_WRITER_POLICY = ExclusiveWriterPolicy.WARN
+
+
+@register_tool("save_artifact")
+class SaveArtifactTool(BaseTool):
+    """
+    Save an artifact to a store.
+
+    Validates artifact against its type schema, checks store permissions,
+    and persists to the project database.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact save."""
+        artifact_type_id: str | None = args.get("artifact_type")
+        data = args.get("data", {})
+        artifact_id: str | None = args.get("artifact_id")
+        store_id: str | None = args.get("store")
+
+        # Validate required fields
+        if not artifact_type_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_type is required",
+            )
+
+        # Validate we have a project
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot save artifact",
+            )
+
+        # Validate artifact type exists
+        artifact_type = None
+        for at in self._context.studio.artifact_types:
+            if at.id == artifact_type_id:
+                artifact_type = at
+                break
+
+        if not artifact_type:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Unknown artifact type: {artifact_type_id}",
+            )
+
+        # Resolve store
+        resolved_store_id = self._resolve_store(artifact_type_id, store_id)
+
+        # Validate store accepts this artifact type
+        if self._context.store_manager:
+            allowed, reason = self._context.store_manager.validate_write(
+                resolved_store_id, artifact_type_id
+            )
+            if not allowed:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=reason or f"Cannot write to store: {resolved_store_id}",
+                )
+
+            # Check exclusive writer policy
+            workflow_warning = self._check_exclusive_writer(resolved_store_id)
+            if workflow_warning:
+                logger.warning(workflow_warning)
+
+                # Check policy - block or warn
+                if DEFAULT_EXCLUSIVE_WRITER_POLICY == ExclusiveWriterPolicy.BLOCK:
+                    return ToolResult(
+                        success=False,
+                        data={"workflow_violation": workflow_warning},
+                        error=f"Exclusive writer violation: {workflow_warning}",
+                    )
+                # WARN policy: continue with save (open floor principle)
+        else:
+            workflow_warning = None
+
+        # Validate artifact data against schema
+        validation_errors = self._validate_artifact_data(artifact_type, data)
+        if validation_errors:
+            return ToolResult(
+                success=False,
+                data={"validation_errors": validation_errors},
+                error=f"Artifact validation failed: {len(validation_errors)} error(s)",
+            )
+
+        # Generate artifact ID if not provided
+        if not artifact_id:
+            artifact_id = self._generate_artifact_id(artifact_type_id)
+
+        # Get initial lifecycle state
+        initial_state = self._get_initial_lifecycle_state(artifact_type)
+
+        # Save to project
+        try:
+            artifact = self._context.project.create_artifact(
+                artifact_id=artifact_id,
+                artifact_type=artifact_type_id,
+                data=data,
+                store=resolved_store_id,
+                created_by=self._context.agent_id,
+            )
+
+            # Update lifecycle state if artifact type has lifecycle
+            if initial_state and initial_state != "draft":
+                self._context.project.update_artifact(
+                    artifact_id=artifact_id,
+                    data={"_lifecycle_state": initial_state},
+                )
+                artifact["_lifecycle_state"] = initial_state
+
+            result_data = {
+                "artifact": artifact,
+                "artifact_id": artifact_id,
+                "store": resolved_store_id,
+                "lifecycle_state": artifact.get("_lifecycle_state", "draft"),
+            }
+
+            # Include workflow warning if present (open floor principle)
+            if workflow_warning:
+                result_data["workflow_warning"] = workflow_warning
+
+            return ToolResult(
+                success=True,
+                data=result_data,
+            )
+
+        except Exception as e:
+            logger.exception(f"Failed to save artifact: {e}")
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Failed to save artifact: {e}",
+            )
+
+    def _resolve_store(self, artifact_type_id: str, explicit_store: str | None) -> str:
+        """
+        Resolve which store to use.
+
+        Priority:
+        1. Explicit store parameter
+        2. StoreManager default for artifact type
+        3. Artifact type's default_store
+        4. "workspace" fallback
+        """
+        if explicit_store:
+            return explicit_store
+
+        # Check store manager
+        if self._context.store_manager:
+            return self._context.store_manager.get_default_store(artifact_type_id)
+
+        # Check artifact type definition
+        for at in self._context.studio.artifact_types:
+            if at.id == artifact_type_id and at.default_store:
+                return at.default_store
+
+        # Fallback
+        return "workspace"
+
+    def _check_exclusive_writer(self, store_id: str) -> str | None:
+        """
+        Check if current agent violates exclusive writer policy.
+
+        Returns warning message if violation detected, None otherwise.
+        """
+        if not self._context.store_manager or not self._context.agent_id:
+            return None
+
+        exclusive_producer = self._context.store_manager.get_exclusive_producer(store_id)
+        if exclusive_producer and exclusive_producer != self._context.agent_id:
+            return (
+                f"Workflow deviation: {self._context.agent_id} writing to {store_id} "
+                f"(exclusive to {exclusive_producer})"
+            )
+
+        return None
+
+    def _validate_artifact_data(
+        self, artifact_type: Any, data: dict[str, Any]
+    ) -> list[dict[str, str]]:
+        """
+        Validate artifact data against type schema.
+
+        Returns list of validation errors.
+        """
+        errors: list[dict[str, str]] = []
+
+        if not artifact_type.fields:
+            return errors
+
+        # Check required fields
+        for field in artifact_type.fields:
+            if field.required and field.name not in data:
+                errors.append(
+                    {
+                        "field": field.name,
+                        "error": f"Required field '{field.name}' is missing",
+                    }
+                )
+
+        # Check field types
+        for field in artifact_type.fields:
+            if field.name in data:
+                value = data[field.name]
+                field_type = field.type.value if field.type else "string"
+                type_error = self._check_field_type(field.name, value, field_type)
+                if type_error:
+                    errors.append(type_error)
+
+        return errors
+
+    def _check_field_type(
+        self, field_name: str, value: Any, expected_type: str
+    ) -> dict[str, str] | None:
+        """Check if a field value matches the expected type."""
+        type_checks = {
+            "string": lambda v: isinstance(v, str),
+            "text": lambda v: isinstance(v, str),
+            "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+            "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+            "boolean": lambda v: isinstance(v, bool),
+            "array": lambda v: isinstance(v, list),
+            "object": lambda v: isinstance(v, dict),
+            "ref": lambda v: isinstance(v, str),
+        }
+
+        checker = type_checks.get(expected_type)
+        if checker and not checker(value):
+            return {
+                "field": field_name,
+                "error": (
+                    f"Field '{field_name}' has wrong type. "
+                    f"Expected {expected_type}, got {type(value).__name__}"
+                ),
+            }
+
+        return None
+
+    def _generate_artifact_id(self, artifact_type_id: str) -> str:
+        """Generate a unique artifact ID."""
+        short_uuid = uuid.uuid4().hex[:8]
+        return f"{artifact_type_id}_{short_uuid}"
+
+    def _get_initial_lifecycle_state(self, artifact_type: Any) -> str | None:
+        """Get initial lifecycle state from artifact type definition."""
+        if hasattr(artifact_type, "lifecycle") and artifact_type.lifecycle:
+            lifecycle = artifact_type.lifecycle
+            if hasattr(lifecycle, "initial_state"):
+                initial_state = lifecycle.initial_state
+                return str(initial_state) if initial_state else "draft"
+        return "draft"
+
+
+@register_tool("update_artifact")
+class UpdateArtifactTool(BaseTool):
+    """
+    Update an existing artifact.
+
+    Merges provided data with existing artifact data.
+    Respects store semantics (blocks updates to cold/append_only stores).
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact update."""
+        artifact_id = args.get("artifact_id")
+        data = args.get("data", {})
+
+        if not artifact_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_id is required",
+            )
+
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot update artifact",
+            )
+
+        # Get existing artifact
+        existing = self._context.project.get_artifact(artifact_id)
+        if not existing:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Artifact not found: {artifact_id}",
+            )
+
+        # Check store semantics
+        store_id = existing.get("_store")
+        if store_id and self._context.store_manager:
+            store = self._context.store_manager.get_store(store_id)
+            if store and not store.allows_updates():
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=(
+                        f"Cannot update artifact in {store.semantics.value} store '{store_id}'. "
+                        "Store does not allow updates."
+                    ),
+                )
+
+        # Update artifact
+        try:
+            updated = self._context.project.update_artifact(
+                artifact_id=artifact_id,
+                data=data,
+            )
+
+            if updated:
+                return ToolResult(
+                    success=True,
+                    data={
+                        "artifact": updated,
+                        "artifact_id": artifact_id,
+                    },
+                )
+            else:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=f"Failed to update artifact: {artifact_id}",
+                )
+
+        except Exception as e:
+            logger.exception(f"Failed to update artifact: {e}")
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Failed to update artifact: {e}",
+            )
+
+
+@register_tool("get_artifact")
+class GetArtifactTool(BaseTool):
+    """
+    Retrieve an artifact by ID.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact retrieval."""
+        artifact_id = args.get("artifact_id")
+
+        if not artifact_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_id is required",
+            )
+
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot retrieve artifact",
+            )
+
+        artifact = self._context.project.get_artifact(artifact_id)
+
+        if artifact:
+            return ToolResult(
+                success=True,
+                data={"artifact": artifact},
+            )
+        else:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Artifact not found: {artifact_id}",
+            )
+
+
+@register_tool("delete_artifact")
+class DeleteArtifactTool(BaseTool):
+    """
+    Delete an artifact from a store.
+
+    Respects store semantics (blocks deletes from cold/append_only stores).
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact deletion."""
+        artifact_id = args.get("artifact_id")
+
+        if not artifact_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="artifact_id is required",
+            )
+
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot delete artifact",
+            )
+
+        # Get existing artifact to check store
+        existing = self._context.project.get_artifact(artifact_id)
+        if not existing:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Artifact not found: {artifact_id}",
+            )
+
+        # Check store semantics
+        store_id = existing.get("_store")
+        if store_id and self._context.store_manager:
+            store = self._context.store_manager.get_store(store_id)
+            if store and not store.allows_deletes():
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=(
+                        f"Cannot delete artifact from {store.semantics.value} store '{store_id}'. "
+                        "Store does not allow deletions."
+                    ),
+                )
+
+        # Delete artifact
+        try:
+            deleted = self._context.project.delete_artifact(artifact_id)
+
+            if deleted:
+                return ToolResult(
+                    success=True,
+                    data={
+                        "artifact_id": artifact_id,
+                        "deleted": True,
+                    },
+                )
+            else:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=f"Failed to delete artifact: {artifact_id}",
+                )
+
+        except Exception as e:
+            logger.exception(f"Failed to delete artifact: {e}")
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Failed to delete artifact: {e}",
+            )
+
+
+@register_tool("list_artifacts")
+class ListArtifactsTool(BaseTool):
+    """
+    Query artifacts with filters.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute artifact listing."""
+        artifact_type = args.get("artifact_type")
+        store = args.get("store")
+        lifecycle_state = args.get("lifecycle_state")
+        limit = args.get("limit", 20)
+
+        if not self._context.project:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No project available - cannot list artifacts",
+            )
+
+        artifacts = self._context.project.query_artifacts(
+            artifact_type=artifact_type,
+            store=store,
+            lifecycle_state=lifecycle_state,
+            limit=limit,
+        )
+
+        # Return summary view (exclude large data fields)
+        summaries = []
+        for artifact in artifacts:
+            summaries.append(
+                {
+                    "_id": artifact.get("_id"),
+                    "_type": artifact.get("_type"),
+                    "_version": artifact.get("_version"),
+                    "_lifecycle_state": artifact.get("_lifecycle_state"),
+                    "_store": artifact.get("_store"),
+                    "_updated_at": artifact.get("_updated_at"),
+                    "_created_by": artifact.get("_created_by"),
+                }
+            )
+
+        return ToolResult(
+            success=True,
+            data={
+                "artifacts": summaries,
+                "count": len(summaries),
+            },
+        )

--- a/tests/runtime/storage/test_lifecycle.py
+++ b/tests/runtime/storage/test_lifecycle.py
@@ -1,0 +1,368 @@
+"""Tests for artifact lifecycle management."""
+
+import pytest
+
+from questfoundry.runtime.storage.lifecycle import (
+    ArtifactLifecycle,
+    LifecycleManager,
+    LifecycleState,
+    LifecycleTransition,
+)
+
+
+class TestLifecycleState:
+    """Tests for LifecycleState dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Create state with minimal data."""
+        state = LifecycleState.from_dict({"id": "draft"})
+        assert state.id == "draft"
+        assert state.name == "draft"  # Defaults to ID
+        assert state.description is None
+        assert state.terminal is False
+
+    def test_from_dict_full(self):
+        """Create state with full data."""
+        state = LifecycleState.from_dict(
+            {
+                "id": "cold",
+                "name": "Cold",
+                "description": "Committed to canon",
+                "terminal": True,
+            }
+        )
+        assert state.id == "cold"
+        assert state.name == "Cold"
+        assert state.description == "Committed to canon"
+        assert state.terminal is True
+
+
+class TestLifecycleTransition:
+    """Tests for LifecycleTransition dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Create transition with minimal data."""
+        trans = LifecycleTransition.from_dict(
+            {
+                "from": "draft",
+                "to": "review",
+            }
+        )
+        assert trans.from_state == "draft"
+        assert trans.to_state == "review"
+        assert trans.allowed_agents == []
+        assert trans.requires_validation == []
+
+    def test_from_dict_full(self):
+        """Create transition with full data."""
+        trans = LifecycleTransition.from_dict(
+            {
+                "from": "approved",
+                "to": "cold",
+                "allowed_agents": ["gatekeeper"],
+                "requires_validation": ["integrity", "style"],
+            }
+        )
+        assert trans.from_state == "approved"
+        assert trans.to_state == "cold"
+        assert trans.allowed_agents == ["gatekeeper"]
+        assert trans.requires_validation == ["integrity", "style"]
+
+    def test_is_agent_allowed_empty_list(self):
+        """Empty allowed_agents means any agent allowed."""
+        trans = LifecycleTransition(from_state="draft", to_state="review")
+        assert trans.is_agent_allowed("any_agent")
+        assert trans.is_agent_allowed(None)
+
+    def test_is_agent_allowed_specific(self):
+        """Specific allowed_agents filters by agent."""
+        trans = LifecycleTransition(
+            from_state="approved",
+            to_state="cold",
+            allowed_agents=["gatekeeper", "lorekeeper"],
+        )
+        assert trans.is_agent_allowed("gatekeeper")
+        assert trans.is_agent_allowed("lorekeeper")
+        assert not trans.is_agent_allowed("scene_smith")
+
+
+class TestArtifactLifecycle:
+    """Tests for ArtifactLifecycle."""
+
+    @pytest.fixture
+    def section_lifecycle_data(self):
+        """Lifecycle data from section.json."""
+        return {
+            "states": [
+                {"id": "draft", "name": "Draft", "description": "Section is being written"},
+                {"id": "review", "name": "Review", "description": "Under review"},
+                {"id": "gatecheck", "name": "Gatecheck", "description": "Awaiting validation"},
+                {"id": "approved", "name": "Approved", "description": "Ready for cold"},
+                {
+                    "id": "cold",
+                    "name": "Cold",
+                    "description": "Committed to canon",
+                    "terminal": True,
+                },
+            ],
+            "initial_state": "draft",
+            "transitions": [
+                {"from": "draft", "to": "review"},
+                {"from": "review", "to": "draft"},
+                {"from": "review", "to": "gatecheck"},
+                {"from": "gatecheck", "to": "draft"},
+                {"from": "gatecheck", "to": "approved"},
+                {
+                    "from": "approved",
+                    "to": "cold",
+                    "requires_validation": ["integrity", "style"],
+                },
+            ],
+        }
+
+    def test_from_dict_none(self):
+        """None data returns None."""
+        lifecycle = ArtifactLifecycle.from_dict("test", None)
+        assert lifecycle is None
+
+    def test_from_dict_full(self, section_lifecycle_data):
+        """Create lifecycle from full data."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        assert lifecycle.artifact_type_id == "section"
+        assert lifecycle.initial_state == "draft"
+        assert len(lifecycle.states) == 5
+        assert len(lifecycle.transitions) == 6
+
+    def test_get_state(self, section_lifecycle_data):
+        """Get state by ID."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        draft = lifecycle.get_state("draft")
+        assert draft is not None
+        assert draft.name == "Draft"
+
+        cold = lifecycle.get_state("cold")
+        assert cold.terminal is True
+
+        assert lifecycle.get_state("nonexistent") is None
+
+    def test_is_terminal_state(self, section_lifecycle_data):
+        """Check terminal state."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        assert not lifecycle.is_terminal_state("draft")
+        assert not lifecycle.is_terminal_state("approved")
+        assert lifecycle.is_terminal_state("cold")
+
+    def test_get_valid_transitions(self, section_lifecycle_data):
+        """Get valid transitions from a state."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        # From draft - can only go to review
+        draft_trans = lifecycle.get_valid_transitions("draft")
+        assert len(draft_trans) == 1
+        assert draft_trans[0].to_state == "review"
+
+        # From review - can go to draft or gatecheck
+        review_trans = lifecycle.get_valid_transitions("review")
+        assert len(review_trans) == 2
+        targets = {t.to_state for t in review_trans}
+        assert targets == {"draft", "gatecheck"}
+
+        # From cold - no valid transitions (terminal)
+        cold_trans = lifecycle.get_valid_transitions("cold")
+        assert len(cold_trans) == 0
+
+    def test_get_valid_transitions_with_agent(self):
+        """Filter transitions by agent."""
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="test",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="approved"),
+                LifecycleTransition(
+                    from_state="approved",
+                    to_state="cold",
+                    allowed_agents=["gatekeeper"],
+                ),
+            ],
+            initial_state="draft",
+        )
+
+        # Gatekeeper can make all transitions
+        gk_trans = lifecycle.get_valid_transitions("approved", agent_id="gatekeeper")
+        assert len(gk_trans) == 1
+
+        # Scene smith cannot transition approved -> cold
+        ss_trans = lifecycle.get_valid_transitions("approved", agent_id="scene_smith")
+        assert len(ss_trans) == 0
+
+    def test_get_transition(self, section_lifecycle_data):
+        """Get specific transition."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        trans = lifecycle.get_transition("approved", "cold")
+        assert trans is not None
+        assert trans.requires_validation == ["integrity", "style"]
+
+        assert lifecycle.get_transition("draft", "cold") is None
+
+    def test_validate_transition_success(self, section_lifecycle_data):
+        """Valid transition passes."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        allowed, reason = lifecycle.validate_transition("draft", "review")
+        assert allowed is True
+        assert reason is None
+
+    def test_validate_transition_from_terminal(self, section_lifecycle_data):
+        """Cannot transition from terminal state."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        allowed, reason = lifecycle.validate_transition("cold", "draft")
+        assert allowed is False
+        assert "terminal" in reason
+
+    def test_validate_transition_not_defined(self, section_lifecycle_data):
+        """Reject undefined transition."""
+        lifecycle = ArtifactLifecycle.from_dict("section", section_lifecycle_data)
+
+        allowed, reason = lifecycle.validate_transition("draft", "cold")
+        assert allowed is False
+        assert "No transition defined" in reason
+
+    def test_validate_transition_agent_not_allowed(self):
+        """Reject if agent not in allowed_agents."""
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="test",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(
+                    from_state="draft",
+                    to_state="cold",
+                    allowed_agents=["gatekeeper"],
+                ),
+            ],
+            initial_state="draft",
+        )
+
+        allowed, reason = lifecycle.validate_transition("draft", "cold", agent_id="scene_smith")
+        assert allowed is False
+        assert "not allowed" in reason
+        assert "gatekeeper" in reason
+
+
+class TestLifecycleManager:
+    """Tests for LifecycleManager."""
+
+    @pytest.fixture
+    def manager_with_lifecycles(self):
+        """Create manager with test lifecycles."""
+        manager = LifecycleManager()
+
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="review"),
+                LifecycleTransition(
+                    from_state="review",
+                    to_state="cold",
+                    allowed_agents=["gatekeeper"],
+                    requires_validation=["integrity"],
+                ),
+            ],
+            initial_state="draft",
+        )
+        manager.register_lifecycle(section_lifecycle)
+
+        return manager
+
+    def test_empty_manager(self):
+        """Empty manager has no lifecycles."""
+        manager = LifecycleManager()
+        assert manager.get_lifecycle("section") is None
+        assert not manager.has_lifecycle("section")
+
+    def test_register_and_get(self, manager_with_lifecycles):
+        """Register and retrieve lifecycle."""
+        lifecycle = manager_with_lifecycles.get_lifecycle("section")
+        assert lifecycle is not None
+        assert lifecycle.artifact_type_id == "section"
+
+    def test_has_lifecycle(self, manager_with_lifecycles):
+        """Check lifecycle existence."""
+        assert manager_with_lifecycles.has_lifecycle("section")
+        assert not manager_with_lifecycles.has_lifecycle("unknown")
+
+    def test_get_initial_state(self, manager_with_lifecycles):
+        """Get initial state for artifact type."""
+        assert manager_with_lifecycles.get_initial_state("section") == "draft"
+        # Unknown type defaults to draft
+        assert manager_with_lifecycles.get_initial_state("unknown") == "draft"
+
+    def test_validate_transition(self, manager_with_lifecycles):
+        """Validate transition via manager."""
+        # Valid transition
+        allowed, reason = manager_with_lifecycles.validate_transition("section", "draft", "review")
+        assert allowed is True
+
+        # Invalid - agent not allowed
+        allowed, reason = manager_with_lifecycles.validate_transition(
+            "section", "review", "cold", agent_id="scene_smith"
+        )
+        assert allowed is False
+
+        # Unknown type - allow any transition
+        allowed, reason = manager_with_lifecycles.validate_transition("unknown", "any", "state")
+        assert allowed is True
+
+    def test_get_required_validations(self, manager_with_lifecycles):
+        """Get required validations for transition."""
+        validations = manager_with_lifecycles.get_required_validations("section", "review", "cold")
+        assert validations == ["integrity"]
+
+        # No validations for other transitions
+        validations = manager_with_lifecycles.get_required_validations("section", "draft", "review")
+        assert validations == []
+
+        # Unknown type returns empty
+        validations = manager_with_lifecycles.get_required_validations("unknown", "any", "state")
+        assert validations == []
+
+    def test_from_artifact_types_dict(self):
+        """Create manager from dict artifact types."""
+        artifact_types = [
+            {
+                "id": "section",
+                "lifecycle": {
+                    "states": [
+                        {"id": "draft", "name": "Draft"},
+                        {"id": "cold", "name": "Cold", "terminal": True},
+                    ],
+                    "initial_state": "draft",
+                    "transitions": [{"from": "draft", "to": "cold"}],
+                },
+            },
+            {
+                "id": "note",
+                # No lifecycle
+            },
+        ]
+
+        manager = LifecycleManager.from_artifact_types(artifact_types)
+
+        assert manager.has_lifecycle("section")
+        assert not manager.has_lifecycle("note")

--- a/tests/runtime/storage/test_project.py
+++ b/tests/runtime/storage/test_project.py
@@ -209,6 +209,24 @@ class TestArtifactOperations:
         )
         assert result is None
 
+    def test_delete_artifact(self, project: Project):
+        """delete_artifact removes artifact."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "Test"},
+        )
+
+        result = project.delete_artifact("section-001")
+
+        assert result is True
+        assert project.get_artifact("section-001") is None
+
+    def test_delete_nonexistent_artifact(self, project: Project):
+        """delete_artifact returns False for nonexistent artifact."""
+        result = project.delete_artifact("nonexistent")
+        assert result is False
+
 
 class TestArtifactQueries:
     """Tests for artifact queries."""

--- a/tests/runtime/storage/test_project.py
+++ b/tests/runtime/storage/test_project.py
@@ -290,6 +290,121 @@ class TestArtifactQueries:
         assert len(results) == 1
 
 
+class TestVersionHistory:
+    """Tests for artifact version history."""
+
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> Project:
+        """Create a test project."""
+        project = Project.create(tmp_path / "test", name="Test")
+        yield project
+        project.close()
+
+    def test_save_version(self, project: Project):
+        """save_version creates a version snapshot."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "Original", "content": "First version"},
+        )
+
+        version = project.save_version("section-001", created_by="scene_smith")
+
+        assert version == 1
+
+    def test_save_version_nonexistent(self, project: Project):
+        """save_version returns None for nonexistent artifact."""
+        version = project.save_version("nonexistent")
+        assert version is None
+
+    def test_get_artifact_versions(self, project: Project):
+        """get_artifact_versions retrieves version history."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "V1", "content": "First"},
+        )
+
+        # Save version 1
+        project.save_version("section-001")
+
+        # Update to v2
+        project.update_artifact("section-001", data={"title": "V2"})
+
+        # Save version 2
+        project.save_version("section-001")
+
+        # Update to v3
+        project.update_artifact("section-001", data={"title": "V3"})
+
+        versions = project.get_artifact_versions("section-001")
+
+        assert len(versions) == 2
+        # Newest first
+        assert versions[0]["version"] == 2
+        assert versions[0]["data"]["title"] == "V2"
+        assert versions[1]["version"] == 1
+        assert versions[1]["data"]["title"] == "V1"
+
+    def test_get_artifact_versions_empty(self, project: Project):
+        """get_artifact_versions returns empty list when no versions."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "Test"},
+        )
+
+        versions = project.get_artifact_versions("section-001")
+        assert versions == []
+
+    def test_get_artifact_at_version(self, project: Project):
+        """get_artifact_at_version retrieves specific version."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "V1", "content": "First"},
+        )
+
+        # Save and update
+        project.save_version("section-001")
+        project.update_artifact("section-001", data={"title": "V2"})
+
+        project.save_version("section-001")
+        project.update_artifact("section-001", data={"title": "V3"})
+
+        # Get version 1
+        v1 = project.get_artifact_at_version("section-001", 1)
+        assert v1 is not None
+        assert v1["data"]["title"] == "V1"
+
+        # Get version 2
+        v2 = project.get_artifact_at_version("section-001", 2)
+        assert v2 is not None
+        assert v2["data"]["title"] == "V2"
+
+        # Non-existent version
+        v99 = project.get_artifact_at_version("section-001", 99)
+        assert v99 is None
+
+    def test_delete_artifact_removes_versions(self, project: Project):
+        """delete_artifact also removes version history."""
+        project.create_artifact(
+            artifact_id="section-001",
+            artifact_type="section",
+            data={"title": "Test"},
+        )
+
+        project.save_version("section-001")
+        project.save_version("section-001")
+
+        # Delete artifact
+        project.delete_artifact("section-001")
+
+        # Version history should be empty
+        versions = project.get_artifact_versions("section-001")
+        assert versions == []
+
+
 class TestListProjects:
     """Tests for list_projects function."""
 

--- a/tests/runtime/storage/test_store_manager.py
+++ b/tests/runtime/storage/test_store_manager.py
@@ -1,0 +1,532 @@
+"""Tests for StoreManager."""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from questfoundry.runtime.models.enums import StoreSemantics
+from questfoundry.runtime.storage.store_manager import (
+    AssetStorageConfig,
+    RetentionPolicy,
+    StoreDefinition,
+    StoreManager,
+    WorkflowIntent,
+)
+
+
+class TestWorkflowIntent:
+    """Tests for WorkflowIntent dataclass."""
+
+    def test_from_dict_none(self):
+        """None input returns None."""
+        assert WorkflowIntent.from_dict(None) is None
+
+    def test_from_dict_empty(self):
+        """Empty dict uses defaults."""
+        intent = WorkflowIntent.from_dict({})
+        assert intent.consumption_guidance == "all"
+        assert intent.production_guidance == "all"
+        assert intent.designated_consumers == []
+        assert intent.designated_producers == []
+
+    def test_from_dict_exclusive(self):
+        """Exclusive production with designated producers."""
+        intent = WorkflowIntent.from_dict(
+            {
+                "consumption_guidance": "all",
+                "production_guidance": "exclusive",
+                "designated_producers": ["lore_weaver"],
+            }
+        )
+        assert intent.is_exclusive
+        assert intent.designated_producers == ["lore_weaver"]
+
+    def test_is_exclusive_false(self):
+        """Non-exclusive intent."""
+        intent = WorkflowIntent(production_guidance="all")
+        assert not intent.is_exclusive
+
+
+class TestRetentionPolicy:
+    """Tests for RetentionPolicy dataclass."""
+
+    def test_from_dict_none(self):
+        """None input returns None."""
+        assert RetentionPolicy.from_dict(None) is None
+
+    def test_from_dict_forever(self):
+        """Forever retention."""
+        policy = RetentionPolicy.from_dict({"type": "forever"})
+        assert policy.type == "forever"
+        assert policy.duration_days is None
+
+    def test_from_dict_count(self):
+        """Count-based retention."""
+        policy = RetentionPolicy.from_dict(
+            {
+                "type": "count",
+                "max_count": 50,
+                "max_versions": 10,
+            }
+        )
+        assert policy.type == "count"
+        assert policy.max_count == 50
+        assert policy.max_versions == 10
+
+
+class TestAssetStorageConfig:
+    """Tests for AssetStorageConfig dataclass."""
+
+    def test_from_dict_none(self):
+        """None input returns None."""
+        assert AssetStorageConfig.from_dict(None) is None
+
+    def test_from_dict_filesystem(self):
+        """Filesystem backend."""
+        config = AssetStorageConfig.from_dict(
+            {
+                "backend": "filesystem",
+                "prefix": "exports",
+            }
+        )
+        assert config.backend == "filesystem"
+        assert config.prefix == "exports"
+
+
+class TestStoreDefinition:
+    """Tests for StoreDefinition dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Minimal store definition."""
+        store = StoreDefinition.from_dict(
+            {
+                "id": "test_store",
+                "name": "Test Store",
+            }
+        )
+        assert store.id == "test_store"
+        assert store.name == "Test Store"
+        assert store.semantics == StoreSemantics.MUTABLE
+        assert store.artifact_types == []
+
+    def test_from_dict_full(self):
+        """Full store definition."""
+        store = StoreDefinition.from_dict(
+            {
+                "id": "canon",
+                "name": "Canon (World Bible)",
+                "description": "Spoiler-level world truth",
+                "semantics": "cold",
+                "artifact_types": ["canon_pack", "section"],
+                "workflow_intent": {
+                    "consumption_guidance": "all",
+                    "production_guidance": "exclusive",
+                    "designated_producers": ["lore_weaver"],
+                },
+                "retention": {"type": "forever"},
+            }
+        )
+        assert store.id == "canon"
+        assert store.semantics == StoreSemantics.COLD
+        assert store.artifact_types == ["canon_pack", "section"]
+        assert store.is_exclusive
+        assert store.exclusive_producers == ["lore_weaver"]
+
+    def test_allows_artifact_type_empty_list(self):
+        """Empty artifact_types list allows any type."""
+        store = StoreDefinition(id="test", name="Test", artifact_types=[])
+        assert store.allows_artifact_type("anything")
+        assert store.allows_artifact_type("section")
+
+    def test_allows_artifact_type_specific(self):
+        """Specific artifact_types list filters."""
+        store = StoreDefinition(
+            id="test",
+            name="Test",
+            artifact_types=["section", "section_brief"],
+        )
+        assert store.allows_artifact_type("section")
+        assert store.allows_artifact_type("section_brief")
+        assert not store.allows_artifact_type("canon_pack")
+
+    def test_allows_updates_mutable(self):
+        """Mutable store allows updates."""
+        store = StoreDefinition(id="test", name="Test", semantics=StoreSemantics.MUTABLE)
+        assert store.allows_updates()
+        assert store.allows_deletes()
+
+    def test_allows_updates_cold(self):
+        """Cold store blocks updates."""
+        store = StoreDefinition(id="test", name="Test", semantics=StoreSemantics.COLD)
+        assert not store.allows_updates()
+        assert not store.allows_deletes()
+
+    def test_allows_updates_append_only(self):
+        """Append-only store blocks updates."""
+        store = StoreDefinition(id="test", name="Test", semantics=StoreSemantics.APPEND_ONLY)
+        assert not store.allows_updates()
+        assert not store.allows_deletes()
+
+    def test_allows_updates_versioned(self):
+        """Versioned store allows updates (with history)."""
+        store = StoreDefinition(id="test", name="Test", semantics=StoreSemantics.VERSIONED)
+        assert store.allows_updates()
+        assert store.allows_deletes()
+
+    def test_requires_version_history(self):
+        """Only versioned store requires history."""
+        assert not StoreDefinition(
+            id="test", name="Test", semantics=StoreSemantics.MUTABLE
+        ).requires_version_history()
+        assert StoreDefinition(
+            id="test", name="Test", semantics=StoreSemantics.VERSIONED
+        ).requires_version_history()
+
+
+class TestStoreManager:
+    """Tests for StoreManager."""
+
+    def test_empty_manager(self):
+        """Empty manager has no stores."""
+        manager = StoreManager()
+        assert manager.list_stores() == []
+        assert manager.get_store("anything") is None
+
+    def test_with_stores(self):
+        """Manager with stores."""
+        stores = {
+            "workspace": StoreDefinition(
+                id="workspace",
+                name="Workspace",
+                semantics=StoreSemantics.MUTABLE,
+            ),
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                semantics=StoreSemantics.COLD,
+                workflow_intent=WorkflowIntent(
+                    production_guidance="exclusive",
+                    designated_producers=["lore_weaver"],
+                ),
+            ),
+        }
+        manager = StoreManager(stores)
+
+        assert len(manager.list_stores()) == 2
+        assert manager.get_store("workspace") is not None
+        assert manager.get_store("canon") is not None
+        assert manager.get_store("unknown") is None
+
+    def test_get_store_ids(self):
+        """Get all store IDs."""
+        stores = {
+            "workspace": StoreDefinition(id="workspace", name="Workspace"),
+            "canon": StoreDefinition(id="canon", name="Canon"),
+        }
+        manager = StoreManager(stores)
+        ids = manager.get_store_ids()
+        assert set(ids) == {"workspace", "canon"}
+
+    def test_get_exclusive_producer(self):
+        """Get exclusive producer for a store."""
+        stores = {
+            "workspace": StoreDefinition(
+                id="workspace",
+                name="Workspace",
+                semantics=StoreSemantics.MUTABLE,
+            ),
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                semantics=StoreSemantics.COLD,
+                workflow_intent=WorkflowIntent(
+                    production_guidance="exclusive",
+                    designated_producers=["lore_weaver"],
+                ),
+            ),
+        }
+        manager = StoreManager(stores)
+
+        assert manager.get_exclusive_producer("workspace") is None
+        assert manager.get_exclusive_producer("canon") == "lore_weaver"
+        assert manager.get_exclusive_producer("unknown") is None
+
+    def test_get_default_store_explicit(self):
+        """Default store from artifact_types list."""
+        stores = {
+            "workspace": StoreDefinition(
+                id="workspace",
+                name="Workspace",
+                artifact_types=["section_brief", "section"],
+            ),
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                artifact_types=["canon_pack"],
+            ),
+        }
+        manager = StoreManager(stores)
+
+        assert manager.get_default_store("section") == "workspace"
+        assert manager.get_default_store("canon_pack") == "canon"
+
+    def test_get_default_store_fallback(self):
+        """Default store falls back to workspace."""
+        stores = {
+            "workspace": StoreDefinition(id="workspace", name="Workspace"),
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                artifact_types=["canon_pack"],
+            ),
+        }
+        manager = StoreManager(stores)
+
+        # Unknown type falls back to workspace
+        assert manager.get_default_store("unknown_type") == "workspace"
+
+    def test_set_default_store(self):
+        """Set default store for artifact type."""
+        stores = {
+            "workspace": StoreDefinition(id="workspace", name="Workspace"),
+            "canon": StoreDefinition(id="canon", name="Canon"),
+        }
+        manager = StoreManager(stores)
+
+        # Set canon as default for section
+        manager.set_default_store("section", "canon")
+        assert manager.get_default_store("section") == "canon"
+
+    def test_get_stores_by_semantics(self):
+        """Get stores by semantics."""
+        stores = {
+            "workspace": StoreDefinition(
+                id="workspace", name="Workspace", semantics=StoreSemantics.MUTABLE
+            ),
+            "canon": StoreDefinition(id="canon", name="Canon", semantics=StoreSemantics.COLD),
+            "codex": StoreDefinition(id="codex", name="Codex", semantics=StoreSemantics.COLD),
+        }
+        manager = StoreManager(stores)
+
+        cold_stores = manager.get_stores_by_semantics(StoreSemantics.COLD)
+        assert len(cold_stores) == 2
+        assert all(s.semantics == StoreSemantics.COLD for s in cold_stores)
+
+    def test_get_exclusive_stores(self):
+        """Get all exclusive stores."""
+        stores = {
+            "workspace": StoreDefinition(
+                id="workspace", name="Workspace", semantics=StoreSemantics.MUTABLE
+            ),
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                workflow_intent=WorkflowIntent(
+                    production_guidance="exclusive",
+                    designated_producers=["lore_weaver"],
+                ),
+            ),
+            "codex": StoreDefinition(
+                id="codex",
+                name="Codex",
+                workflow_intent=WorkflowIntent(
+                    production_guidance="exclusive",
+                    designated_producers=["codex_curator"],
+                ),
+            ),
+        }
+        manager = StoreManager(stores)
+
+        exclusive = manager.get_exclusive_stores()
+        assert len(exclusive) == 2
+        assert all(s.is_exclusive for s in exclusive)
+
+    def test_validate_write_unknown_store(self):
+        """Validate write to unknown store."""
+        manager = StoreManager()
+        allowed, reason = manager.validate_write("unknown", "section")
+        assert not allowed
+        assert "Unknown store" in reason
+
+    def test_validate_write_type_not_allowed(self):
+        """Validate write with wrong artifact type."""
+        stores = {
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                artifact_types=["canon_pack"],
+            ),
+        }
+        manager = StoreManager(stores)
+
+        allowed, reason = manager.validate_write("canon", "section")
+        assert not allowed
+        assert "does not accept" in reason
+
+    def test_validate_write_success(self):
+        """Validate successful write."""
+        stores = {
+            "canon": StoreDefinition(
+                id="canon",
+                name="Canon",
+                artifact_types=["canon_pack", "section"],
+            ),
+        }
+        manager = StoreManager(stores)
+
+        allowed, reason = manager.validate_write("canon", "section")
+        assert allowed
+        assert reason is None
+
+
+class TestStoreManagerFromDomain:
+    """Tests for loading StoreManager from domain directory."""
+
+    def test_from_domain_empty(self):
+        """Load from empty domain."""
+        with TemporaryDirectory() as tmpdir:
+            domain_path = Path(tmpdir)
+            manager = StoreManager.from_domain(domain_path)
+            assert manager.list_stores() == []
+
+    def test_from_domain_with_stores(self):
+        """Load from domain with store files."""
+        with TemporaryDirectory() as tmpdir:
+            domain_path = Path(tmpdir)
+            stores_dir = domain_path / "stores"
+            stores_dir.mkdir()
+
+            # Create workspace store
+            (stores_dir / "workspace.json").write_text(
+                json.dumps(
+                    {
+                        "id": "workspace",
+                        "name": "Workspace",
+                        "semantics": "mutable",
+                        "workflow_intent": {
+                            "consumption_guidance": "all",
+                            "production_guidance": "all",
+                        },
+                    }
+                )
+            )
+
+            # Create canon store
+            (stores_dir / "canon.json").write_text(
+                json.dumps(
+                    {
+                        "id": "canon",
+                        "name": "Canon",
+                        "semantics": "cold",
+                        "artifact_types": ["canon_pack"],
+                        "workflow_intent": {
+                            "production_guidance": "exclusive",
+                            "designated_producers": ["lore_weaver"],
+                        },
+                    }
+                )
+            )
+
+            manager = StoreManager.from_domain(domain_path)
+
+            assert len(manager.list_stores()) == 2
+            assert manager.get_store("workspace") is not None
+            assert manager.get_store("canon") is not None
+
+            # Check semantics loaded correctly
+            workspace = manager.get_store("workspace")
+            assert workspace.semantics == StoreSemantics.MUTABLE
+
+            canon = manager.get_store("canon")
+            assert canon.semantics == StoreSemantics.COLD
+            assert canon.is_exclusive
+            assert manager.get_exclusive_producer("canon") == "lore_weaver"
+
+    def test_from_domain_invalid_json(self):
+        """Load from domain with invalid JSON file."""
+        with TemporaryDirectory() as tmpdir:
+            domain_path = Path(tmpdir)
+            stores_dir = domain_path / "stores"
+            stores_dir.mkdir()
+
+            # Create invalid JSON
+            (stores_dir / "broken.json").write_text("not valid json")
+
+            # Create valid store
+            (stores_dir / "workspace.json").write_text(
+                json.dumps(
+                    {
+                        "id": "workspace",
+                        "name": "Workspace",
+                    }
+                )
+            )
+
+            manager = StoreManager.from_domain(domain_path)
+
+            # Should load valid store, skip broken one
+            assert len(manager.list_stores()) == 1
+            assert manager.get_store("workspace") is not None
+
+
+class TestStoreManagerWithRealDomain:
+    """Tests using real domain-v4 stores."""
+
+    @pytest.fixture
+    def manager(self) -> StoreManager:
+        """Load store manager from real domain."""
+        # tests/runtime/storage/test_store_manager.py -> repo root
+        domain_path = Path(__file__).parent.parent.parent.parent / "domain-v4"
+        if not domain_path.exists():
+            pytest.skip("domain-v4 not found")
+        return StoreManager.from_domain(domain_path)
+
+    def test_loads_all_stores(self, manager: StoreManager):
+        """All domain stores are loaded."""
+        stores = manager.list_stores()
+        store_ids = {s.id for s in stores}
+        assert "workspace" in store_ids
+        assert "canon" in store_ids
+        assert "codex" in store_ids
+        assert "exports" in store_ids
+        assert "audit" in store_ids
+
+    def test_workspace_is_mutable(self, manager: StoreManager):
+        """Workspace has mutable semantics."""
+        workspace = manager.get_store("workspace")
+        assert workspace.semantics == StoreSemantics.MUTABLE
+        assert workspace.allows_updates()
+        assert workspace.allows_deletes()
+
+    def test_canon_is_cold_exclusive(self, manager: StoreManager):
+        """Canon is cold with exclusive producer."""
+        canon = manager.get_store("canon")
+        assert canon.semantics == StoreSemantics.COLD
+        assert not canon.allows_updates()
+        assert canon.is_exclusive
+        assert manager.get_exclusive_producer("canon") == "lore_weaver"
+
+    def test_codex_is_cold_exclusive(self, manager: StoreManager):
+        """Codex is cold with exclusive producer."""
+        codex = manager.get_store("codex")
+        assert codex.semantics == StoreSemantics.COLD
+        assert codex.is_exclusive
+        assert manager.get_exclusive_producer("codex") == "codex_curator"
+
+    def test_exports_is_versioned(self, manager: StoreManager):
+        """Exports has versioned semantics."""
+        exports = manager.get_store("exports")
+        assert exports.semantics == StoreSemantics.VERSIONED
+        assert exports.requires_version_history()
+        assert exports.is_exclusive
+        assert manager.get_exclusive_producer("exports") == "book_binder"
+
+    def test_audit_is_append_only(self, manager: StoreManager):
+        """Audit has append_only semantics."""
+        audit = manager.get_store("audit")
+        assert audit.semantics == StoreSemantics.APPEND_ONLY
+        assert not audit.allows_updates()
+        assert not audit.allows_deletes()
+        assert not audit.is_exclusive

--- a/tests/runtime/storage/test_store_manager.py
+++ b/tests/runtime/storage/test_store_manager.py
@@ -475,13 +475,11 @@ class TestStoreManagerWithRealDomain:
     """Tests using real domain-v4 stores."""
 
     @pytest.fixture
-    def manager(self) -> StoreManager:
+    def manager(self, domain_v4_path: Path) -> StoreManager:
         """Load store manager from real domain."""
-        # tests/runtime/storage/test_store_manager.py -> repo root
-        domain_path = Path(__file__).parent.parent.parent.parent / "domain-v4"
-        if not domain_path.exists():
+        if not domain_v4_path.exists():
             pytest.skip("domain-v4 not found")
-        return StoreManager.from_domain(domain_path)
+        return StoreManager.from_domain(domain_v4_path)
 
     def test_loads_all_stores(self, manager: StoreManager):
         """All domain stores are loaded."""

--- a/tests/runtime/tools/conftest.py
+++ b/tests/runtime/tools/conftest.py
@@ -1,0 +1,130 @@
+"""Shared fixtures for runtime tools tests."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.runtime.models.enums import FieldType
+
+
+def _create_mock_field(
+    name: str,
+    field_type: FieldType,
+    required: bool = False,
+    description: str | None = None,
+) -> MagicMock:
+    """Create a mock field definition."""
+    field = MagicMock()
+    field.name = name
+    field.type = field_type
+    field.required = required
+    field.description = description
+    return field
+
+
+@pytest.fixture
+def mock_artifact_type_factory():
+    """
+    Factory fixture for creating mock artifact types.
+
+    Usage:
+        def test_something(mock_artifact_type_factory):
+            artifact_type = mock_artifact_type_factory()
+            artifact_type = mock_artifact_type_factory(
+                type_id="custom",
+                default_store="workspace",
+                has_lifecycle=True,
+                extra_fields=[("tags", FieldType.ARRAY, False)],
+            )
+    """
+
+    def _factory(
+        type_id: str = "section",
+        name: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        default_store: str | None = None,
+        has_lifecycle: bool = False,
+        initial_state: str = "draft",
+        fields: list[tuple[str, FieldType, bool]] | None = None,
+        extra_fields: list[tuple[str, FieldType, bool]] | None = None,
+        has_validation: bool = False,
+    ) -> MagicMock:
+        """
+        Create a mock artifact type for testing.
+
+        Args:
+            type_id: Artifact type ID
+            name: Display name (defaults to type_id.title())
+            description: Type description
+            category: Type category
+            default_store: Default store ID
+            has_lifecycle: Whether to include lifecycle config
+            initial_state: Initial lifecycle state
+            fields: Override default fields as [(name, type, required), ...]
+            extra_fields: Additional fields to append to defaults
+            has_validation: Whether to include validation rules
+        """
+        artifact_type = MagicMock()
+        artifact_type.id = type_id
+        artifact_type.name = name or type_id.title()
+        artifact_type.description = description
+        artifact_type.category = category
+        artifact_type.default_store = default_store
+
+        # Default fields: title (required string), body (optional text)
+        if fields is not None:
+            artifact_type.fields = [_create_mock_field(f[0], f[1], f[2]) for f in fields]
+        else:
+            artifact_type.fields = [
+                _create_mock_field("title", FieldType.STRING, required=True),
+                _create_mock_field("body", FieldType.TEXT, required=False),
+            ]
+
+        # Add extra fields if specified
+        if extra_fields:
+            for f in extra_fields:
+                artifact_type.fields.append(_create_mock_field(f[0], f[1], f[2]))
+
+        # Lifecycle
+        if has_lifecycle:
+            lifecycle = MagicMock()
+            lifecycle.initial_state = initial_state
+            artifact_type.lifecycle = lifecycle
+        else:
+            artifact_type.lifecycle = None
+
+        # Validation rules
+        if has_validation:
+            validation = MagicMock()
+            validation.required_together = []
+            validation.mutually_exclusive = []
+            artifact_type.validation = validation
+        else:
+            artifact_type.validation = None
+
+        return artifact_type
+
+    return _factory
+
+
+@pytest.fixture
+def mock_tool_definition_factory():
+    """Factory fixture for creating mock tool definitions."""
+
+    def _factory(tool_id: str, timeout_ms: int = 30000) -> MagicMock:
+        definition = MagicMock()
+        definition.id = tool_id
+        definition.timeout_ms = timeout_ms
+        return definition
+
+    return _factory
+
+
+@pytest.fixture
+def mock_artifact_type(mock_artifact_type_factory: Any) -> MagicMock:
+    """Default mock artifact type for simple tests."""
+    return mock_artifact_type_factory()

--- a/tests/runtime/tools/test_lifecycle_transition.py
+++ b/tests/runtime/tools/test_lifecycle_transition.py
@@ -235,7 +235,8 @@ class TestRequestLifecycleTransitionTool:
         assert result.success is True
         assert result.data["transitioned"] is True
         assert result.data["previous_state"] == "draft"
-        assert result.data["current_state"] == "review"
+        assert result.data["new_state"] == "review"
+        assert result.data["result"] == "committed"
         assert mock_project.artifacts["section_001"]["_lifecycle_state"] == "review"
 
     @pytest.mark.asyncio
@@ -299,20 +300,23 @@ class TestRequestLifecycleTransitionTool:
 
         assert result.success is True
         assert result.data["transitioned"] is True
-        assert result.data["current_state"] == "approved"
+        assert result.data["new_state"] == "approved"
+        assert result.data["result"] == "committed"
 
     @pytest.mark.asyncio
-    async def test_requires_validation_returns_pending(self, tool_context):
-        """Return pending status when validations required."""
+    async def test_requires_validation_runs_checks(self, tool_context, mock_project):
+        """Run validations and commit if all pass."""
         tool_context.agent_id = "gatekeeper"
-        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "approved"
+        mock_project.artifacts["section_001"]["_lifecycle_state"] = "approved"
 
         tool = RequestLifecycleTransitionTool(
             MockToolDefinition("request_lifecycle_transition"),
             tool_context,
         )
 
-        # approved -> cold requires validation
+        # approved -> cold requires validation (integrity, style)
+        # Without a full Studio setup, validate_artifact may not find the type
+        # But the tool should still attempt validation
         result = await tool.execute(
             {
                 "artifact_id": "section_001",
@@ -321,16 +325,22 @@ class TestRequestLifecycleTransitionTool:
         )
 
         assert result.success is True
-        assert result.data["transitioned"] is False
-        assert result.data["status"] == "pending_validation"
-        assert "integrity" in result.data["required_validations"]
-        assert "style" in result.data["required_validations"]
+        # Either committed (validations passed) or rejected (validations failed)
+        assert result.data["result"] in ("committed", "rejected")
+
+        if result.data["result"] == "committed":
+            assert result.data["transitioned"] is True
+            assert result.data["new_state"] == "cold"
+            assert mock_project.artifacts["section_001"]["_lifecycle_state"] == "cold"
+        else:
+            assert result.data["transitioned"] is False
+            assert "validation_results" in result.data
 
     @pytest.mark.asyncio
     async def test_force_bypasses_validation(self, tool_context, mock_project):
         """Force=true bypasses validation requirement."""
         tool_context.agent_id = "gatekeeper"
-        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "approved"
+        mock_project.artifacts["section_001"]["_lifecycle_state"] = "approved"
 
         tool = RequestLifecycleTransitionTool(
             MockToolDefinition("request_lifecycle_transition"),
@@ -347,8 +357,92 @@ class TestRequestLifecycleTransitionTool:
 
         assert result.success is True
         assert result.data["transitioned"] is True
-        assert result.data["current_state"] == "cold"
+        assert result.data["new_state"] == "cold"
+        assert result.data["result"] == "committed"
         assert mock_project.artifacts["section_001"]["_lifecycle_state"] == "cold"
+
+    @pytest.mark.asyncio
+    async def test_validation_rejection_with_broken_reference(
+        self, tool_context, mock_project, lifecycle_manager
+    ):
+        """Reject transition when integrity validation fails on broken reference."""
+        from unittest.mock import MagicMock
+
+        # Create a mock artifact type with a reference field
+        section_type = MagicMock()
+        section_type.id = "section"
+
+        # Mock field with reference type
+        ref_field = MagicMock()
+        ref_field.name = "parent_ref"
+        ref_field.type = MagicMock()
+        ref_field.type.value = "reference"
+        ref_field.required = False
+
+        title_field = MagicMock()
+        title_field.name = "title"
+        title_field.type = MagicMock()
+        title_field.type.value = "string"
+        title_field.required = True
+
+        section_type.fields = [title_field, ref_field]
+        section_type.validation = None
+
+        # Set up mock studio with the artifact type
+        tool_context.studio.artifact_types = [section_type]
+
+        # Set up artifact with broken reference
+        tool_context.agent_id = "gatekeeper"
+        mock_project.artifacts["section_with_ref"] = {
+            "_id": "section_with_ref",
+            "_type": "section",
+            "_lifecycle_state": "approved",
+            "title": "Section with broken ref",
+            "parent_ref": "nonexistent_artifact",  # Broken reference
+        }
+
+        # Add lifecycle for this to require integrity validation
+        from questfoundry.runtime.storage.lifecycle import (
+            ArtifactLifecycle,
+            LifecycleState,
+            LifecycleTransition,
+        )
+
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(
+                    from_state="approved",
+                    to_state="cold",
+                    requires_validation=["integrity"],  # Only integrity check
+                ),
+            ],
+            initial_state="approved",
+        )
+        lifecycle_manager.register_lifecycle(section_lifecycle)
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_with_ref",
+                "target_state": "cold",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["result"] == "rejected"
+        assert result.data["transitioned"] is False
+        assert "integrity" in result.data["rejection_reason"].lower()
+        # Artifact should NOT have transitioned
+        assert mock_project.artifacts["section_with_ref"]["_lifecycle_state"] == "approved"
 
     @pytest.mark.asyncio
     async def test_transition_from_terminal_state(self, tool_context):

--- a/tests/runtime/tools/test_lifecycle_transition.py
+++ b/tests/runtime/tools/test_lifecycle_transition.py
@@ -1,0 +1,584 @@
+"""Tests for lifecycle transition tools."""
+
+import pytest
+
+from questfoundry.runtime.storage.lifecycle import (
+    ArtifactLifecycle,
+    LifecycleManager,
+    LifecycleState,
+    LifecycleTransition,
+)
+from questfoundry.runtime.tools.base import ToolContext
+from questfoundry.runtime.tools.lifecycle_transition import (
+    GetLifecycleStateTool,
+    RequestLifecycleTransitionTool,
+)
+
+
+class MockStudio:
+    """Minimal Studio mock."""
+
+    def __init__(self):
+        self.artifact_types = []
+
+
+class MockProject:
+    """Mock project for testing artifact operations."""
+
+    def __init__(self):
+        self.artifacts: dict[str, dict] = {}
+
+    def get_artifact(self, artifact_id: str) -> dict | None:
+        return self.artifacts.get(artifact_id)
+
+    def update_artifact(self, artifact_id: str, data: dict) -> dict | None:
+        if artifact_id not in self.artifacts:
+            return None
+        self.artifacts[artifact_id].update(data)
+        return self.artifacts[artifact_id]
+
+
+class MockToolDefinition:
+    """Minimal Tool definition mock."""
+
+    def __init__(self, tool_id: str = "test_tool"):
+        self.id = tool_id
+        self.name = tool_id
+        self.description = f"Test tool {tool_id}"
+        self.timeout_ms = 30000
+        self.input_schema = None
+
+
+@pytest.fixture
+def mock_project():
+    """Create mock project with test artifacts."""
+    project = MockProject()
+    project.artifacts = {
+        "section_001": {
+            "_id": "section_001",
+            "_type": "section",
+            "_lifecycle_state": "draft",
+            "title": "Test Section",
+        },
+        "section_002": {
+            "_id": "section_002",
+            "_type": "section",
+            "_lifecycle_state": "review",
+            "title": "Section in Review",
+        },
+        "section_003": {
+            "_id": "section_003",
+            "_type": "section",
+            "_lifecycle_state": "cold",
+            "title": "Cold Section",
+        },
+        "note_001": {
+            "_id": "note_001",
+            "_type": "note",
+            # No lifecycle state - defaults to draft
+            "content": "A note",
+        },
+    }
+    return project
+
+
+@pytest.fixture
+def lifecycle_manager():
+    """Create lifecycle manager with section lifecycle."""
+    manager = LifecycleManager()
+
+    section_lifecycle = ArtifactLifecycle(
+        artifact_type_id="section",
+        states={
+            "draft": LifecycleState(id="draft", name="Draft"),
+            "review": LifecycleState(id="review", name="Review"),
+            "gatecheck": LifecycleState(id="gatecheck", name="Gatecheck"),
+            "approved": LifecycleState(id="approved", name="Approved"),
+            "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+        },
+        transitions=[
+            LifecycleTransition(from_state="draft", to_state="review"),
+            LifecycleTransition(from_state="review", to_state="draft"),
+            LifecycleTransition(from_state="review", to_state="gatecheck"),
+            LifecycleTransition(from_state="gatecheck", to_state="draft"),
+            LifecycleTransition(
+                from_state="gatecheck",
+                to_state="approved",
+                allowed_agents=["gatekeeper"],
+            ),
+            LifecycleTransition(
+                from_state="approved",
+                to_state="cold",
+                allowed_agents=["gatekeeper"],
+                requires_validation=["integrity", "style"],
+            ),
+        ],
+        initial_state="draft",
+    )
+    manager.register_lifecycle(section_lifecycle)
+
+    return manager
+
+
+@pytest.fixture
+def tool_context(mock_project, lifecycle_manager):
+    """Create tool context with project and lifecycle manager."""
+    ctx = ToolContext(
+        studio=MockStudio(),
+        project=mock_project,
+        agent_id="scene_smith",
+        lifecycle_manager=lifecycle_manager,
+    )
+    return ctx
+
+
+class TestRequestLifecycleTransitionTool:
+    """Tests for RequestLifecycleTransitionTool."""
+
+    @pytest.mark.asyncio
+    async def test_missing_artifact_id(self, tool_context):
+        """Reject missing artifact_id."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute({"target_state": "review"})
+
+        assert result.success is False
+        assert "artifact_id is required" in result.error
+
+    @pytest.mark.asyncio
+    async def test_missing_target_state(self, tool_context):
+        """Reject missing target_state."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is False
+        assert "target_state is required" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_project(self):
+        """Reject when no project available."""
+        ctx = ToolContext(studio=MockStudio(), project=None)
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "review",
+            }
+        )
+
+        assert result.success is False
+        assert "No project available" in result.error
+
+    @pytest.mark.asyncio
+    async def test_artifact_not_found(self, tool_context):
+        """Reject non-existent artifact."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "nonexistent",
+                "target_state": "review",
+            }
+        )
+
+        assert result.success is False
+        assert "Artifact not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_already_in_target_state(self, tool_context):
+        """Return success with transitioned=False when already in target state."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "draft",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is False
+        assert "already in" in result.data["message"]
+
+    @pytest.mark.asyncio
+    async def test_valid_transition(self, tool_context, mock_project):
+        """Successfully transition artifact."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "review",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["previous_state"] == "draft"
+        assert result.data["current_state"] == "review"
+        assert mock_project.artifacts["section_001"]["_lifecycle_state"] == "review"
+
+    @pytest.mark.asyncio
+    async def test_invalid_transition(self, tool_context):
+        """Reject invalid transition path."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        # draft -> cold is not a valid transition
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "cold",
+            }
+        )
+
+        assert result.success is False
+        assert "Transition not allowed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_agent_not_allowed(self, tool_context):
+        """Reject when agent not in allowed_agents."""
+        # Move section to gatecheck first
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "gatecheck"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        # scene_smith cannot transition gatecheck -> approved (only gatekeeper)
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "approved",
+            }
+        )
+
+        assert result.success is False
+        assert "not allowed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_gatekeeper_can_approve(self, tool_context):
+        """Gatekeeper can transition to approved."""
+        tool_context.agent_id = "gatekeeper"
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "gatecheck"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "approved",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["current_state"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_requires_validation_returns_pending(self, tool_context):
+        """Return pending status when validations required."""
+        tool_context.agent_id = "gatekeeper"
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "approved"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        # approved -> cold requires validation
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "cold",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is False
+        assert result.data["status"] == "pending_validation"
+        assert "integrity" in result.data["required_validations"]
+        assert "style" in result.data["required_validations"]
+
+    @pytest.mark.asyncio
+    async def test_force_bypasses_validation(self, tool_context, mock_project):
+        """Force=true bypasses validation requirement."""
+        tool_context.agent_id = "gatekeeper"
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "approved"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "cold",
+                "force": True,
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["current_state"] == "cold"
+        assert mock_project.artifacts["section_001"]["_lifecycle_state"] == "cold"
+
+    @pytest.mark.asyncio
+    async def test_transition_from_terminal_state(self, tool_context):
+        """Cannot transition from terminal state."""
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        # section_003 is already cold (terminal)
+        result = await tool.execute(
+            {
+                "artifact_id": "section_003",
+                "target_state": "draft",
+            }
+        )
+
+        assert result.success is False
+        assert "terminal" in result.error.lower() or "Transition not allowed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_lifecycle_manager_allows_transition(self, mock_project):
+        """Without lifecycle manager, any transition allowed."""
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=mock_project,
+            agent_id="scene_smith",
+            lifecycle_manager=None,  # No manager
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        # Even draft -> cold works without manager
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "cold",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+
+    @pytest.mark.asyncio
+    async def test_artifact_without_type(self, tool_context, mock_project):
+        """Artifact without _type can still transition (no lifecycle validation)."""
+        mock_project.artifacts["untyped"] = {
+            "_id": "untyped",
+            "_lifecycle_state": "draft",
+            "content": "Untyped artifact",
+        }
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            tool_context,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "untyped",
+                "target_state": "review",
+            }
+        )
+
+        # Without type, lifecycle manager can't validate - transition proceeds
+        assert result.success is True
+        assert result.data["transitioned"] is True
+
+
+class TestGetLifecycleStateTool:
+    """Tests for GetLifecycleStateTool."""
+
+    @pytest.mark.asyncio
+    async def test_missing_artifact_id(self, tool_context):
+        """Reject missing artifact_id."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({})
+
+        assert result.success is False
+        assert "artifact_id is required" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_project(self):
+        """Reject when no project available."""
+        ctx = ToolContext(studio=MockStudio(), project=None)
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            ctx,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is False
+        assert "No project available" in result.error
+
+    @pytest.mark.asyncio
+    async def test_artifact_not_found(self, tool_context):
+        """Reject non-existent artifact."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "nonexistent"})
+
+        assert result.success is False
+        assert "Artifact not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_get_state_basic(self, tool_context):
+        """Get basic lifecycle state."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is True
+        assert result.data["artifact_id"] == "section_001"
+        assert result.data["artifact_type"] == "section"
+        assert result.data["current_state"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_get_state_with_transitions(self, tool_context):
+        """Get state with available transitions."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is True
+        assert "available_transitions" in result.data
+        # draft can go to review
+        transitions = result.data["available_transitions"]
+        assert len(transitions) == 1
+        assert transitions[0]["target_state"] == "review"
+
+    @pytest.mark.asyncio
+    async def test_get_state_terminal(self, tool_context):
+        """Get terminal state info."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "section_003"})
+
+        assert result.success is True
+        assert result.data["current_state"] == "cold"
+        assert result.data["is_terminal"] is True
+        # No transitions from terminal
+        assert result.data["available_transitions"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_state_default_draft(self, tool_context):
+        """Artifact without _lifecycle_state defaults to draft."""
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "note_001"})
+
+        assert result.success is True
+        assert result.data["current_state"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_get_state_no_lifecycle_manager(self, mock_project):
+        """State retrieval works without lifecycle manager."""
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=mock_project,
+            lifecycle_manager=None,
+        )
+
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            ctx,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is True
+        assert result.data["current_state"] == "draft"
+        # No transitions info without manager
+        assert "available_transitions" not in result.data
+
+    @pytest.mark.asyncio
+    async def test_transitions_filtered_by_agent(self, tool_context):
+        """Available transitions filtered by current agent."""
+        # Move to gatecheck
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "gatecheck"
+
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        # scene_smith can only go back to draft
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        transitions = result.data["available_transitions"]
+        targets = {t["target_state"] for t in transitions}
+        assert "draft" in targets
+        assert "approved" not in targets  # Only gatekeeper
+
+    @pytest.mark.asyncio
+    async def test_gatekeeper_sees_more_transitions(self, tool_context):
+        """Gatekeeper sees additional transition options."""
+        tool_context.agent_id = "gatekeeper"
+        tool_context.project.artifacts["section_001"]["_lifecycle_state"] = "gatecheck"
+
+        tool = GetLifecycleStateTool(
+            MockToolDefinition("get_lifecycle_state"),
+            tool_context,
+        )
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        transitions = result.data["available_transitions"]
+        targets = {t["target_state"] for t in transitions}
+        assert "draft" in targets
+        assert "approved" in targets  # Gatekeeper can see this

--- a/tests/runtime/tools/test_save_artifact.py
+++ b/tests/runtime/tools/test_save_artifact.py
@@ -1,0 +1,696 @@
+"""Tests for save_artifact, update_artifact, get_artifact, and list_artifacts tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.runtime.models.enums import FieldType, StoreSemantics
+from questfoundry.runtime.storage import Project, StoreDefinition, StoreManager, WorkflowIntent
+from questfoundry.runtime.tools.base import ToolContext
+from questfoundry.runtime.tools.save_artifact import (
+    DeleteArtifactTool,
+    GetArtifactTool,
+    ListArtifactsTool,
+    SaveArtifactTool,
+    UpdateArtifactTool,
+)
+
+
+def make_mock_artifact_type(
+    type_id: str = "section",
+    default_store: str | None = None,
+    has_lifecycle: bool = False,
+):
+    """Create a mock artifact type for testing."""
+    artifact_type = MagicMock()
+    artifact_type.id = type_id
+    artifact_type.name = type_id.title()
+    artifact_type.default_store = default_store
+
+    # Fields
+    field1 = MagicMock()
+    field1.name = "title"
+    field1.type = FieldType.STRING
+    field1.required = True
+
+    field2 = MagicMock()
+    field2.name = "body"
+    field2.type = FieldType.TEXT
+    field2.required = False
+
+    artifact_type.fields = [field1, field2]
+
+    # Lifecycle
+    if has_lifecycle:
+        lifecycle = MagicMock()
+        lifecycle.initial_state = "draft"
+        artifact_type.lifecycle = lifecycle
+    else:
+        artifact_type.lifecycle = None
+
+    return artifact_type
+
+
+def make_mock_definition(tool_id: str):
+    """Create mock tool definition."""
+    definition = MagicMock()
+    definition.id = tool_id
+    definition.name = tool_id.replace("_", " ").title()
+    definition.description = f"Mock {tool_id}"
+    definition.timeout_ms = 30000
+    definition.input_schema = None
+    return definition
+
+
+def make_store_manager():
+    """Create a store manager with test stores."""
+    stores = {
+        "workspace": StoreDefinition(
+            id="workspace",
+            name="Workspace",
+            semantics=StoreSemantics.MUTABLE,
+            artifact_types=["section", "section_brief"],
+        ),
+        "canon": StoreDefinition(
+            id="canon",
+            name="Canon",
+            semantics=StoreSemantics.COLD,
+            artifact_types=["canon_pack"],
+            workflow_intent=WorkflowIntent(
+                production_guidance="exclusive",
+                designated_producers=["lore_weaver"],
+            ),
+        ),
+    }
+    return StoreManager(stores)
+
+
+class TestSaveArtifactTool:
+    """Tests for SaveArtifactTool."""
+
+    @pytest.fixture
+    def project(self):
+        """Create a temporary project."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            yield project
+            project.close()
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_success(self, project: Project):
+        """Successfully save an artifact."""
+        artifact_type = make_mock_artifact_type()
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+            agent_id="scene_smith",
+            store_manager=store_manager,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "data": {"title": "Opening Scene"},
+            }
+        )
+
+        assert result.success is True
+        assert "artifact" in result.data
+        assert "artifact_id" in result.data
+        assert result.data["store"] == "workspace"
+
+        # Verify artifact was saved
+        artifact_id = result.data["artifact_id"]
+        saved = project.get_artifact(artifact_id)
+        assert saved is not None
+        assert saved["title"] == "Opening Scene"
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_with_explicit_id(self, project: Project):
+        """Save artifact with explicit ID."""
+        artifact_type = make_mock_artifact_type()
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+            agent_id="scene_smith",
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "artifact_id": "section_001",
+                "data": {"title": "Custom ID Section"},
+            }
+        )
+
+        assert result.success is True
+        assert result.data["artifact_id"] == "section_001"
+
+        saved = project.get_artifact("section_001")
+        assert saved is not None
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_unknown_type(self, project: Project):
+        """Reject unknown artifact type."""
+        studio = MagicMock()
+        studio.artifact_types = []  # No types
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "unknown_type",
+                "data": {"title": "Test"},
+            }
+        )
+
+        assert result.success is False
+        assert "Unknown artifact type" in result.error
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_validation_failure(self, project: Project):
+        """Reject artifact with missing required fields."""
+        artifact_type = make_mock_artifact_type()
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "data": {},  # Missing required 'title'
+            }
+        )
+
+        assert result.success is False
+        assert "validation_errors" in result.data
+        assert len(result.data["validation_errors"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_wrong_store(self, project: Project):
+        """Reject artifact for wrong store."""
+        artifact_type = make_mock_artifact_type()
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+            store_manager=store_manager,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "store": "canon",  # canon only accepts canon_pack
+                "data": {"title": "Test"},
+            }
+        )
+
+        assert result.success is False
+        assert "does not accept" in result.error
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_exclusive_writer_warning(self, project: Project):
+        """Log warning for exclusive writer violation."""
+        # Create canon_pack artifact type
+        artifact_type = make_mock_artifact_type(type_id="canon_pack")
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+            agent_id="scene_smith",  # NOT lore_weaver
+            store_manager=store_manager,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        # Should succeed with warning (open floor principle)
+        result = await tool.execute(
+            {
+                "artifact_type": "canon_pack",
+                "store": "canon",
+                "data": {"title": "Test Canon"},
+            }
+        )
+
+        # Should succeed but include workflow warning in result
+        assert result.success is True
+        assert "workflow_warning" in result.data
+        assert "scene_smith" in result.data["workflow_warning"]
+        assert "lore_weaver" in result.data["workflow_warning"]
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_no_project(self):
+        """Reject when no project available."""
+        artifact_type = make_mock_artifact_type()
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=None,  # No project
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "data": {"title": "Test"},
+            }
+        )
+
+        assert result.success is False
+        assert "No project available" in result.error
+
+
+class TestUpdateArtifactTool:
+    """Tests for UpdateArtifactTool."""
+
+    @pytest.fixture
+    def project_with_artifact(self):
+        """Create a project with an existing artifact."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            # Create initial artifact
+            project.create_artifact(
+                artifact_id="section_001",
+                artifact_type="section",
+                data={"title": "Original Title", "body": "Original body"},
+                store="workspace",
+            )
+            yield project
+            project.close()
+
+    @pytest.mark.asyncio
+    async def test_update_artifact_success(self, project_with_artifact: Project):
+        """Successfully update an artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("update_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = UpdateArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "data": {"title": "Updated Title"},
+            }
+        )
+
+        assert result.success is True
+
+        # Verify update
+        updated = project_with_artifact.get_artifact("section_001")
+        assert updated["title"] == "Updated Title"
+        assert updated["body"] == "Original body"  # Preserved
+        assert updated["_version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_update_artifact_not_found(self, project_with_artifact: Project):
+        """Reject update for non-existent artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("update_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = UpdateArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_id": "nonexistent",
+                "data": {"title": "Test"},
+            }
+        )
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_update_artifact_cold_store_blocked(self, project_with_artifact: Project):
+        """Block update to cold store artifact."""
+        # Create artifact in cold store
+        project_with_artifact.create_artifact(
+            artifact_id="canon_001",
+            artifact_type="canon_pack",
+            data={"title": "Canon Entry"},
+            store="canon",
+        )
+
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("update_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+            store_manager=store_manager,
+        )
+        tool = UpdateArtifactTool(definition, context)
+
+        result = await tool.execute(
+            {
+                "artifact_id": "canon_001",
+                "data": {"title": "Updated"},
+            }
+        )
+
+        assert result.success is False
+        assert "does not allow updates" in result.error
+
+
+class TestGetArtifactTool:
+    """Tests for GetArtifactTool."""
+
+    @pytest.fixture
+    def project_with_artifact(self):
+        """Create a project with an existing artifact."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            project.create_artifact(
+                artifact_id="section_001",
+                artifact_type="section",
+                data={"title": "Test Section", "body": "Content"},
+                store="workspace",
+            )
+            yield project
+            project.close()
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_success(self, project_with_artifact: Project):
+        """Successfully retrieve an artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("get_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = GetArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is True
+        assert result.data["artifact"]["title"] == "Test Section"
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_not_found(self, project_with_artifact: Project):
+        """Return error for non-existent artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("get_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = GetArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "nonexistent"})
+
+        assert result.success is False
+        assert "not found" in result.error
+
+
+class TestListArtifactsTool:
+    """Tests for ListArtifactsTool."""
+
+    @pytest.fixture
+    def project_with_artifacts(self):
+        """Create a project with multiple artifacts."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            # Create multiple artifacts
+            project.create_artifact(
+                artifact_id="section_001",
+                artifact_type="section",
+                data={"title": "Section 1"},
+                store="workspace",
+            )
+            project.create_artifact(
+                artifact_id="section_002",
+                artifact_type="section",
+                data={"title": "Section 2"},
+                store="workspace",
+            )
+            project.create_artifact(
+                artifact_id="brief_001",
+                artifact_type="section_brief",
+                data={"title": "Brief 1"},
+                store="workspace",
+            )
+            yield project
+            project.close()
+
+    @pytest.mark.asyncio
+    async def test_list_all_artifacts(self, project_with_artifacts: Project):
+        """List all artifacts."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("list_artifacts")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifacts,
+        )
+        tool = ListArtifactsTool(definition, context)
+
+        result = await tool.execute({})
+
+        assert result.success is True
+        assert result.data["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_list_artifacts_by_type(self, project_with_artifacts: Project):
+        """List artifacts filtered by type."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("list_artifacts")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifacts,
+        )
+        tool = ListArtifactsTool(definition, context)
+
+        result = await tool.execute({"artifact_type": "section"})
+
+        assert result.success is True
+        assert result.data["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_artifacts_with_limit(self, project_with_artifacts: Project):
+        """List artifacts with limit."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("list_artifacts")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifacts,
+        )
+        tool = ListArtifactsTool(definition, context)
+
+        result = await tool.execute({"limit": 1})
+
+        assert result.success is True
+        assert result.data["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_artifacts_summary_view(self, project_with_artifacts: Project):
+        """List returns summary view without full data."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("list_artifacts")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifacts,
+        )
+        tool = ListArtifactsTool(definition, context)
+
+        result = await tool.execute({})
+
+        assert result.success is True
+        artifacts = result.data["artifacts"]
+        assert len(artifacts) > 0
+
+        # Should have system fields but not full data
+        first = artifacts[0]
+        assert "_id" in first
+        assert "_type" in first
+        assert "_version" in first
+        assert "title" not in first  # Data fields excluded from summary
+
+
+class TestDeleteArtifactTool:
+    """Tests for DeleteArtifactTool."""
+
+    @pytest.fixture
+    def project_with_artifact(self):
+        """Create a project with an existing artifact."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            # Create artifact in mutable store
+            project.create_artifact(
+                artifact_id="section_001",
+                artifact_type="section",
+                data={"title": "Test Section", "body": "Content"},
+                store="workspace",
+            )
+            yield project
+            project.close()
+
+    @pytest.mark.asyncio
+    async def test_delete_artifact_success(self, project_with_artifact: Project):
+        """Successfully delete an artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("delete_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+            store_manager=store_manager,
+        )
+        tool = DeleteArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is True
+        assert result.data["deleted"] is True
+        assert result.data["artifact_id"] == "section_001"
+
+        # Verify artifact was deleted
+        assert project_with_artifact.get_artifact("section_001") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_artifact_not_found(self, project_with_artifact: Project):
+        """Return error for non-existent artifact."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("delete_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = DeleteArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "nonexistent"})
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_delete_artifact_cold_store_blocked(self, project_with_artifact: Project):
+        """Block deletion from cold store artifact."""
+        # Create artifact in cold store
+        project_with_artifact.create_artifact(
+            artifact_id="canon_001",
+            artifact_type="canon_pack",
+            data={"title": "Canon Entry"},
+            store="canon",
+        )
+
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        store_manager = make_store_manager()
+
+        definition = make_mock_definition("delete_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+            store_manager=store_manager,
+        )
+        tool = DeleteArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "canon_001"})
+
+        assert result.success is False
+        assert "does not allow deletions" in result.error
+
+        # Verify artifact was NOT deleted
+        assert project_with_artifact.get_artifact("canon_001") is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_artifact_no_project(self):
+        """Reject when no project available."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("delete_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=None,
+        )
+        tool = DeleteArtifactTool(definition, context)
+
+        result = await tool.execute({"artifact_id": "section_001"})
+
+        assert result.success is False
+        assert "No project available" in result.error


### PR DESCRIPTION
## Summary
Implements Phase 4 of the V4 Runtime Cleanroom Rebuild (Issue #148): Storage &amp; Lifecycle management.

**All Steps Completed:**
- ✅ Step 1: StoreManager - load store definitions from domain-v4/stores/*.json
- ✅ Step 2: save_artifact tool - agents persist artifacts with schema validation
- ✅ Step 3: Store semantics enforcement - block updates/deletes on cold/append_only stores
- ✅ Step 4: Exclusive writer tracking - warn on workflow deviations (configurable)
- ✅ Step 5: ArtifactLifecycle - state machine loading from artifact type definitions
- ✅ Step 6: request_lifecycle_transition tool - agents request state changes
- ✅ Step 7: Lifecycle transition handler - validates `requires_validation` quality bars, commit/reject
- ✅ Step 8: Version history for versioned stores - auto-saves before updates
- ✅ Step 9: CLI integration - `qf artifacts list/show/versions` commands

**Key Features:**

### Storage Layer
- **StoreManager** loads and validates store definitions from domain
- **Store semantics**: `mutable`, `cold`, `append_only`, `versioned`
- Exclusive writer policy with "open floor" principle (warn, don't block)
- `ExclusiveWriterPolicy` enum for optional hard-block mode

### Artifact Tools
- `save_artifact` - Create artifacts with schema validation
- `update_artifact` - Update with version history for versioned stores
- `get_artifact` - Retrieve by ID
- `list_artifacts` - Query with filters (type, store, lifecycle state)
- `delete_artifact` - Delete with store semantics enforcement

### Lifecycle Management
- **LifecycleManager** loads state machines from artifact type definitions
- `request_lifecycle_transition` tool validates:
  - Transition is defined in state machine
  - Current agent is allowed (`allowed_agents`)
  - Quality bars pass (`requires_validation`)
- `get_lifecycle_state` tool returns current state and valid transitions
- Transitions with `requires_validation` run quality bar checks via `validate_artifact`
- Commit/reject pattern: rejected transitions return guidance for fixes

### Version History
- Project stores version snapshots before updates for versioned stores
- `save_version()`, `get_artifact_versions()`, `get_artifact_at_version()`
- CLI: `qf artifacts versions &lt;project&gt; &lt;artifact&gt;`

### CLI Commands
- `qf artifacts list &lt;project&gt;` - List with filters (--type, --store, --state)
- `qf artifacts show &lt;project&gt; &lt;artifact&gt;` - Show artifact details
- `qf artifacts show &lt;project&gt; &lt;artifact&gt; --version N` - Show specific version
- `qf artifacts versions &lt;project&gt; &lt;artifact&gt;` - Show version history

**Tests:** 476 passing

## Test plan
- [x] Run `uv run pytest --tb=short -q` - All 476 tests pass
- [x] Test CLI commands with sample project
- [ ] Integration test with full workflow

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)