### PR TITLE
ci: use --extra dev instead of --all-extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Run ruff check
         run: uv run ruff check src/ tests/
@@ -45,7 +45,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Run mypy
         run: uv run mypy src/
@@ -69,7 +69,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Run pytest
         run: uv run pytest --cov=questfoundry --cov-report=xml --cov-report=term
@@ -111,6 +111,6 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
## Summary

- Replace `uv sync --all-extras` with `uv sync --extra dev` in all CI jobs
- Avoids installing `rag-local` extra which pulls in `sentence-transformers` → `torch` (~2GB)
- CI only needs dev dependencies (pytest, ruff, mypy) for linting, type checking, and testing

## Impact

Should significantly speed up the "Install dependencies" step (previously 12+ minutes on Python 3.12 due to torch installation).

## Test plan

- [x] Verified locally: `uv sync --extra dev` installs all needed dependencies
- [x] All 360 tests pass with dev extra only
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)