### PR TITLE
fix(phase7): address PR #165 review feedback

### DIFF
--- a/docs/design/PHASE7_PROMPT_TOOL_ARCHITECTURE.md
+++ b/docs/design/PHASE7_PROMPT_TOOL_ARCHITECTURE.md
@@ -25,12 +25,14 @@ This phase implements the v4 design goals: **smaller, more structured prompts** 
 **Decision**: Orchestrator agents (Showrunner) must produce all output via tool calls. No raw prose allowed.
 
 **Rationale**:
+
 - Enforcement becomes trivial (no tool call = incomplete turn)
 - All output is structured and typed
 - Runtime controls presentation, not the agent
 - Consistent with delegation pattern (specialists also return structured results)
 
 **Implementation**:
+
 ```
 Human → Runtime → Showrunner
                       ↓
@@ -46,11 +48,13 @@ Human sees: "Starting scene generation..."
 **Decision**: Add `terminates_turn: boolean` to tool-definition schema.
 
 **Rationale**:
+
 - Makes stop-tool behavior explicit in domain, not hardcoded in runtime
 - Runtime can generically enforce "orchestrators must end with terminating tool"
 - New tools can declare their turn-ending behavior
 
 **Tools with `terminates_turn: true`**:
+
 - `delegate` — hands off to another agent
 - `communicate` — sends message to human (may block for questions)
 
@@ -59,6 +63,7 @@ Human sees: "Starting scene generation..."
 **Decision**: Replace `request_clarification` with a unified `communicate` tool.
 
 **Rationale**:
+
 - Single channel for all human-facing communication
 - Structured message types enable runtime formatting
 - Questions are just one type of communication
@@ -84,6 +89,7 @@ Human sees: "Starting scene generation..."
 | `lookup` | Never shown | Via `consult_knowledge` only |
 
 **Rationale**:
+
 - Prompt size predictable and capped
 - Critical guidance always available
 - Detailed guidance accessible on demand
@@ -104,6 +110,7 @@ Human sees: "Starting scene generation..."
 ```
 
 **Rationale**:
+
 - Menu can show meaningful summaries
 - Full content retrieved via `consult_knowledge`
 - Authors control what appears inline vs on-demand
@@ -170,23 +177,25 @@ Human sees: "Starting scene generation..."
 
 ### Schema Changes (meta/)
 
-| File | Change |
-|------|--------|
-| `meta/schemas/core/tool-definition.schema.json` | Add `terminates_turn` |
-| `meta/schemas/knowledge/knowledge-entry.schema.json` | Add `summary`, `inline_budget_tokens` |
-| `meta/docs/tool-patterns.md` | New: document tools-only pattern |
-| `meta/docs/knowledge-patterns.md` | New: document menu+consult pattern |
+| File | Change | Status |
+|------|--------|--------|
+| `meta/schemas/core/tool-definition.schema.json` | Add `terminates_turn` | ✅ Done |
+| `meta/schemas/knowledge/knowledge-entry.schema.json` | (future) Add `inline_budget_tokens` | Pending |
+| `meta/docs/tool-patterns.md` | New: document tools-only pattern | ✅ Done |
+| `meta/docs/knowledge-patterns.md` | New: document menu+consult pattern | ✅ Done |
+
+Note: `summary` field already exists in knowledge-entry schema.
 
 ### Domain Changes (domain-v4/)
 
-| File | Change |
-|------|--------|
-| `domain-v4/tools/communicate.json` | New tool |
-| `domain-v4/tools/consult_knowledge.json` | New tool |
-| `domain-v4/tools/request_clarification.json` | Delete |
-| `domain-v4/tools/delegate.json` | Add `terminates_turn: true` |
-| `domain-v4/agents/showrunner.json` | Update capabilities, knowledge_requirements |
-| `domain-v4/knowledge/*.json` | Add `summary` to all entries |
+| File | Change | Status |
+|------|--------|--------|
+| `domain-v4/tools/communicate.json` | New tool | ✅ Done |
+| `domain-v4/tools/consult_knowledge.json` | New tool | ✅ Done |
+| `domain-v4/tools/request_clarification.json` | Delete | ✅ Done |
+| `domain-v4/tools/delegate.json` | Add `terminates_turn: true` | ✅ Done |
+| `domain-v4/agents/showrunner.json` | Update capabilities, constraints | ✅ Done |
+| `domain-v4/knowledge/*.json` | (already have summaries) | N/A |
 
 ### Runtime Changes (src/questfoundry/runtime/)
 
@@ -200,6 +209,7 @@ Human sees: "Starting scene generation..."
 ## Acceptance Criteria
 
 ### Tools-Only Enforcement
+
 ```python
 # Orchestrator without tool call → rejected
 response = LLMResponse(content="I'll help!", tool_calls=[])
@@ -211,6 +221,7 @@ assert validator.is_turn_complete(showrunner, response)
 ```
 
 ### Communicate Tool
+
 ```python
 # Status update
 communicate(type="status", message="Starting...")
@@ -222,6 +233,7 @@ communicate(type="question", message="What tone?", options=[...])
 ```
 
 ### Knowledge Consultation
+
 ```python
 # Prompt shows menu
 prompt = builder.build_prompt(showrunner)
@@ -234,6 +246,7 @@ assert len(result["content"]) > 500  # Full content
 ```
 
 ### Prompt Size
+
 ```python
 # Showrunner prompt under budget
 prompt = builder.build_prompt(showrunner)

--- a/meta/docs/knowledge-patterns.md
+++ b/meta/docs/knowledge-patterns.md
@@ -215,27 +215,36 @@ Agents retrieve full knowledge content via this tool.
 
 ## Agent Knowledge Requirements
 
-Each agent declares what knowledge it needs:
+Each agent declares what knowledge it needs via the `knowledge_requirements` field:
 
 ```json
 {
   "knowledge_requirements": {
     "constitution": true,
     "must_know": ["spoiler_hygiene", "runtime_guidelines"],
-    "should_know": ["delegation_patterns", "quality_bars_overview"],
-    "role_specific": ["showrunner_operating_principles"]
+    "role_specific": ["showrunner_operating_principles"],
+    "can_lookup": ["accessibility_guidelines"]
   }
 }
 ```
 
-### Override Behavior
+### Schema Fields
 
-An agent's list can **override** the entry's default layer:
+| Field | Type | Purpose |
+|-------|------|---------|
+| `constitution` | boolean | Whether to include studio constitution (usually `true`) |
+| `must_know` | array | Entry IDs to inline up to budget, overflow to menu |
+| `role_specific` | array | Entry IDs shown in menu for this agent's role |
+| `can_lookup` | array | Entry IDs accessible via `consult_knowledge` tool |
+
+### Layer vs Agent Override
+
+Knowledge entries have a default `layer` property. Agents can **override** injection behavior by placing entries in different lists:
 
 | Entry Layer | In Agent's List | Result |
 |-------------|-----------------|--------|
 | `should_know` | `must_know[]` | Inlined (budget permitting) |
-| `must_know` | `should_know[]` | Menu only |
+| `must_know` | `role_specific[]` | Menu only |
 | `role_specific` | `must_know[]` | Inlined (budget permitting) |
 
 This allows agents to promote important entries to always-inline or demote less critical ones to menu-only.

--- a/tests/runtime/domain/test_loader.py
+++ b/tests/runtime/domain/test_loader.py
@@ -131,8 +131,8 @@ class TestLoadStudio:
 
         assert result.success
         assert (
-            len(result.studio.tools) == 15
-        )  # Updated: +3 list tools (list_artifact_types, list_stores, list_agents)
+            len(result.studio.tools) == 16
+        )  # Phase 7: +communicate, +consult_knowledge, -request_clarification = net +1
 
     async def test_load_studio_resolves_playbook_refs(self, domain_v4_path: Path):
         """load_studio resolves playbook file references."""


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #165 (Phase 7: Tools-Only Orchestrators & Knowledge Patterns).

## Changes

- **Markdown lint fixes**: Add blank lines around lists, headings, and code blocks in `PHASE7_PROMPT_TOOL_ARCHITECTURE.md`
- **Test fix**: Update expected tool count from 15 to 16 (we added communicate and consult_knowledge, removed request_clarification = net +1)
- **Design doc accuracy**: Add status column to File Changes tables, clarify what was actually included vs planned
- **Schema alignment**: Update `knowledge-patterns.md` to match actual agent schema fields (`constitution`, `must_know`, `role_specific`, `can_lookup`) instead of referencing non-existent `should_know` field

## Related Issues

- Fixes review comments on #165
- Part of #159 (Phase 7 tracking)

## Test plan

- [x] `test_load_studio_resolves_tool_refs` passes locally
- [x] Pre-commit hooks pass (including markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)