### PR TITLE
feat(runtime): implement communicate tool for Phase 7

### DIFF
--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -19,6 +19,7 @@ Usage:
 
 # Import tool implementations to trigger registration
 from questfoundry.runtime.tools import (
+    communicate,  # noqa: F401  # Phase 7: unified human communication
     consult_corpus,  # noqa: F401
     consult_playbook,  # noqa: F401
     consult_schema,  # noqa: F401
@@ -27,7 +28,7 @@ from questfoundry.runtime.tools import (
     list_agents,  # noqa: F401
     list_artifact_types,  # noqa: F401
     list_stores,  # noqa: F401
-    request_clarification,  # noqa: F401
+    request_clarification,  # noqa: F401  # Legacy: to be removed after migration
     save_artifact,  # noqa: F401  # Phase 4: artifact persistence
     search_workspace,  # noqa: F401
     stubs,  # noqa: F401

--- a/src/questfoundry/runtime/tools/communicate.py
+++ b/src/questfoundry/runtime/tools/communicate.py
@@ -1,0 +1,240 @@
+"""
+Communicate tool implementation.
+
+Unified communication channel for orchestrator-to-human interaction.
+This replaces request_clarification with a more comprehensive tool
+that handles all types of human-facing communication.
+
+Message types:
+- status: Brief progress update (non-blocking)
+- question: Need input from customer (blocks until answered)
+- notification: Deliverable ready or milestone reached (non-blocking)
+- error: Something failed or needs attention (may block depending on severity)
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Any
+
+from questfoundry.runtime.messaging import create_message
+from questfoundry.runtime.messaging.types import MessageType
+from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
+from questfoundry.runtime.tools.registry import register_tool
+
+logger = logging.getLogger(__name__)
+
+
+class CommunicationType(str, Enum):
+    """Types of communication with the customer."""
+
+    STATUS = "status"
+    QUESTION = "question"
+    NOTIFICATION = "notification"
+    ERROR = "error"
+
+
+class ErrorSeverity(str, Enum):
+    """Severity levels for error communications."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+# Map communicate types to message types
+_COMMUNICATE_TO_MESSAGE_TYPE = {
+    CommunicationType.STATUS: MessageType.PROGRESS_UPDATE,
+    CommunicationType.QUESTION: MessageType.CLARIFICATION_REQUEST,
+    CommunicationType.NOTIFICATION: MessageType.COMPLETION_SIGNAL,
+    CommunicationType.ERROR: MessageType.ESCALATION,
+}
+
+
+@register_tool("communicate")
+class CommunicateTool(BaseTool):
+    """
+    Send a message to the human customer.
+
+    This is the ONLY way orchestrators communicate with humans.
+    All output must go through this tool.
+
+    This tool has terminates_turn: true, meaning calling it ends the
+    agent's turn. Orchestrators must end every turn with either
+    this tool or delegate.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """
+        Create and route a communication message.
+
+        For questions, the response will be provided in the agent's
+        next activation. For other types, the message is delivered
+        and execution continues.
+        """
+        comm_type_str = args.get("type")
+        message_text = args.get("message")
+        context = args.get("context")
+        options = args.get("options", [])
+        default_option = args.get("default_option")
+        artifacts = args.get("artifacts", [])
+        severity_str = args.get("severity", "info")
+
+        # Validate required fields
+        if not comm_type_str:
+            raise ToolValidationError("Communication type is required")
+        if not message_text:
+            raise ToolValidationError("Message is required")
+
+        # Parse and validate type
+        try:
+            comm_type = CommunicationType(comm_type_str)
+        except ValueError:
+            valid_types = [t.value for t in CommunicationType]
+            raise ToolValidationError(
+                f"Invalid communication type '{comm_type_str}'. Valid types: {valid_types}"
+            ) from None
+
+        # Parse severity for errors
+        try:
+            severity = ErrorSeverity(severity_str)
+        except ValueError:
+            severity = ErrorSeverity.INFO
+
+        # Build payload
+        payload: dict[str, Any] = {
+            "communication_type": comm_type.value,
+            "message": message_text,
+        }
+
+        if context:
+            payload["context"] = context
+
+        # Type-specific payload fields
+        if comm_type == CommunicationType.QUESTION:
+            if options:
+                payload["options"] = options
+            if default_option:
+                payload["default_option"] = default_option
+            payload["blocking"] = True
+
+        elif comm_type == CommunicationType.NOTIFICATION:
+            if artifacts:
+                payload["artifacts"] = artifacts
+            payload["blocking"] = False
+
+        elif comm_type == CommunicationType.ERROR:
+            payload["severity"] = severity.value
+            # Errors with 'error' severity may need human intervention
+            payload["blocking"] = severity == ErrorSeverity.ERROR
+
+        elif comm_type == CommunicationType.STATUS:
+            payload["blocking"] = False
+
+        # Get the appropriate message type
+        message_type = _COMMUNICATE_TO_MESSAGE_TYPE[comm_type]
+
+        # Create the message
+        message = create_message(
+            message_type=message_type,
+            from_agent=self._context.agent_id or "unknown",
+            to_agent="customer",  # Special agent ref for human
+            payload=payload,
+        )
+
+        # Route via broker if available
+        delivered = False
+        if self._context.broker:
+            await self._context.broker.send(message)
+            delivered = True
+            logger.info(
+                "Communication %s [%s]: %s sends '%s'",
+                message.id,
+                comm_type.value,
+                self._context.agent_id,
+                message_text[:50] + "..." if len(message_text) > 50 else message_text,
+            )
+        else:
+            logger.warning(
+                "No broker available - communication %s created but not routed",
+                message.id,
+            )
+
+        # Build result
+        result_data: dict[str, Any] = {
+            "message_id": message.id,
+            "type": comm_type.value,
+            "delivered": delivered,
+            "blocking": payload.get("blocking", False),
+        }
+
+        # For questions, indicate that response will be provided later
+        if comm_type == CommunicationType.QUESTION:
+            result_data["status"] = "awaiting_response"
+            result_data["message"] = message_text
+            if options:
+                result_data["options"] = [opt.get("id") for opt in options]
+            if default_option:
+                result_data["default_option"] = default_option
+
+        # For notifications, include artifact refs
+        elif comm_type == CommunicationType.NOTIFICATION:
+            result_data["status"] = "delivered" if delivered else "pending"
+            if artifacts:
+                result_data["artifacts"] = artifacts
+
+        # For errors, include severity
+        elif comm_type == CommunicationType.ERROR:
+            result_data["status"] = "reported"
+            result_data["severity"] = severity.value
+            if severity == ErrorSeverity.ERROR:
+                result_data["awaiting_decision"] = True
+
+        # For status, simple acknowledgment
+        else:
+            result_data["status"] = "delivered" if delivered else "pending"
+
+        return ToolResult(
+            success=True,
+            data=result_data,
+        )
+
+    def validate_input(self, args: dict[str, Any]) -> None:
+        """Validate input with type-specific rules."""
+        # First do base validation
+        super().validate_input(args)
+
+        comm_type = args.get("type")
+        options = args.get("options", [])
+        default_option = args.get("default_option")
+
+        # Validate options structure if provided
+        if options:
+            if not isinstance(options, list):
+                raise ToolValidationError("Options must be an array")
+
+            for i, opt in enumerate(options):
+                if not isinstance(opt, dict):
+                    raise ToolValidationError(f"Option {i} must be an object")
+                if "id" not in opt:
+                    raise ToolValidationError(f"Option {i} missing required 'id' field")
+                if "description" not in opt:
+                    raise ToolValidationError(f"Option {i} missing required 'description' field")
+
+        # If default_option provided, it should match an option id (if options exist)
+        if default_option and options:
+            option_ids = [opt.get("id") for opt in options]
+            if default_option not in option_ids:
+                raise ToolValidationError(
+                    f"default_option '{default_option}' not found in options: {option_ids}"
+                )
+
+        # Validate severity for errors
+        if comm_type == "error":
+            severity = args.get("severity", "info")
+            valid_severities = [s.value for s in ErrorSeverity]
+            if severity not in valid_severities:
+                raise ToolValidationError(
+                    f"Invalid severity '{severity}'. Valid values: {valid_severities}"
+                )

--- a/src/questfoundry/runtime/tools/communicate.py
+++ b/src/questfoundry/runtime/tools/communicate.py
@@ -60,8 +60,8 @@ class CommunicateTool(BaseTool):
     This is the ONLY way orchestrators communicate with humans.
     All output must go through this tool.
 
-    This tool has terminates_turn: true, meaning calling it ends the
-    agent's turn. Orchestrators must end every turn with either
+    This tool has terminates_turn set to true, meaning calling it ends
+    the agent's turn. Orchestrators must end every turn with either
     this tool or delegate.
     """
 
@@ -100,6 +100,12 @@ class CommunicateTool(BaseTool):
         try:
             severity = ErrorSeverity(severity_str)
         except ValueError:
+            # For error type, invalid severity is an error; for others, default to INFO
+            if comm_type == CommunicationType.ERROR:
+                valid_severities = [s.value for s in ErrorSeverity]
+                raise ToolValidationError(
+                    f"Invalid severity '{severity_str}'. Valid values: {valid_severities}"
+                ) from None
             severity = ErrorSeverity.INFO
 
         # Build payload
@@ -224,7 +230,8 @@ class CommunicateTool(BaseTool):
 
         # If default_option provided, it should match an option id (if options exist)
         if default_option and options:
-            option_ids = [opt.get("id") for opt in options]
+            # After validation above, we know all options have "id" field
+            option_ids = [opt["id"] for opt in options]
             if default_option not in option_ids:
                 raise ToolValidationError(
                     f"default_option '{default_option}' not found in options: {option_ids}"

--- a/tests/runtime/tools/test_communicate.py
+++ b/tests/runtime/tools/test_communicate.py
@@ -1,0 +1,570 @@
+"""
+Tests for the communicate tool.
+
+Tests the unified communication channel for orchestrator-to-human interaction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.runtime.messaging.types import MessageType
+from questfoundry.runtime.tools.base import ToolContext, ToolValidationError
+from questfoundry.runtime.tools.communicate import (
+    CommunicateTool,
+    CommunicationType,
+    ErrorSeverity,
+)
+
+
+@pytest.fixture
+def mock_studio() -> MagicMock:
+    """Create a mock studio."""
+    studio = MagicMock()
+    studio.id = "test_studio"
+    return studio
+
+
+@pytest.fixture
+def mock_broker() -> AsyncMock:
+    """Create a mock message broker."""
+    broker = AsyncMock()
+    broker.send = AsyncMock()
+    return broker
+
+
+@pytest.fixture
+def mock_tool_definition() -> MagicMock:
+    """Create a mock tool definition for communicate."""
+    definition = MagicMock()
+    definition.id = "communicate"
+    definition.name = "Communicate with Customer"
+    definition.description = "Send a message to the human customer."
+    definition.timeout_ms = 30000
+    definition.input_schema = MagicMock()
+    definition.input_schema.required = ["type", "message"]
+    definition.input_schema.properties = {
+        "type": {"type": "string", "enum": ["status", "question", "notification", "error"]},
+        "message": {"type": "string"},
+        "context": {"type": "string"},
+        "options": {"type": "array"},
+        "default_option": {"type": "string"},
+        "artifacts": {"type": "array"},
+        "severity": {"type": "string"},
+    }
+    return definition
+
+
+@pytest.fixture
+def tool_context(mock_studio: MagicMock, mock_broker: AsyncMock) -> ToolContext:
+    """Create a tool context with broker."""
+    return ToolContext(
+        studio=mock_studio,
+        agent_id="showrunner",
+        session_id="test_session",
+        broker=mock_broker,
+    )
+
+
+@pytest.fixture
+def tool_context_no_broker(mock_studio: MagicMock) -> ToolContext:
+    """Create a tool context without broker."""
+    return ToolContext(
+        studio=mock_studio,
+        agent_id="showrunner",
+        session_id="test_session",
+        broker=None,
+    )
+
+
+@pytest.fixture
+def communicate_tool(
+    mock_tool_definition: MagicMock,
+    tool_context: ToolContext,
+) -> CommunicateTool:
+    """Create a communicate tool instance."""
+    return CommunicateTool(mock_tool_definition, tool_context)
+
+
+@pytest.fixture
+def communicate_tool_no_broker(
+    mock_tool_definition: MagicMock,
+    tool_context_no_broker: ToolContext,
+) -> CommunicateTool:
+    """Create a communicate tool instance without broker."""
+    return CommunicateTool(mock_tool_definition, tool_context_no_broker)
+
+
+class TestCommunicateToolValidation:
+    """Tests for input validation."""
+
+    async def test_missing_type_raises_error(self, communicate_tool: CommunicateTool) -> None:
+        """Missing type should raise validation error."""
+        with pytest.raises(ToolValidationError, match="type is required"):
+            await communicate_tool.execute({"message": "Hello"})
+
+    async def test_missing_message_raises_error(self, communicate_tool: CommunicateTool) -> None:
+        """Missing message should raise validation error."""
+        with pytest.raises(ToolValidationError, match="Message is required"):
+            await communicate_tool.execute({"type": "status"})
+
+    async def test_invalid_type_raises_error(self, communicate_tool: CommunicateTool) -> None:
+        """Invalid communication type should raise validation error."""
+        with pytest.raises(ToolValidationError, match="Invalid communication type"):
+            await communicate_tool.execute({"type": "invalid", "message": "Hello"})
+
+    def test_options_must_be_array(self, communicate_tool: CommunicateTool) -> None:
+        """Options must be an array if provided."""
+        with pytest.raises(ToolValidationError, match="must be an array"):
+            communicate_tool.validate_input(
+                {
+                    "type": "question",
+                    "message": "Choose one",
+                    "options": "not an array",
+                }
+            )
+
+    def test_option_must_have_id(self, communicate_tool: CommunicateTool) -> None:
+        """Each option must have an id field."""
+        with pytest.raises(ToolValidationError, match="missing required 'id' field"):
+            communicate_tool.validate_input(
+                {
+                    "type": "question",
+                    "message": "Choose one",
+                    "options": [{"description": "Option without id"}],
+                }
+            )
+
+    def test_option_must_have_description(self, communicate_tool: CommunicateTool) -> None:
+        """Each option must have a description field."""
+        with pytest.raises(ToolValidationError, match="missing required 'description' field"):
+            communicate_tool.validate_input(
+                {
+                    "type": "question",
+                    "message": "Choose one",
+                    "options": [{"id": "opt1"}],
+                }
+            )
+
+    def test_default_option_must_match(self, communicate_tool: CommunicateTool) -> None:
+        """default_option must match an option id."""
+        with pytest.raises(ToolValidationError, match="not found in options"):
+            communicate_tool.validate_input(
+                {
+                    "type": "question",
+                    "message": "Choose one",
+                    "options": [
+                        {"id": "a", "description": "Option A"},
+                        {"id": "b", "description": "Option B"},
+                    ],
+                    "default_option": "nonexistent",
+                }
+            )
+
+    def test_valid_options_pass(self, communicate_tool: CommunicateTool) -> None:
+        """Valid options should pass validation."""
+        # Should not raise
+        communicate_tool.validate_input(
+            {
+                "type": "question",
+                "message": "Choose one",
+                "options": [
+                    {"id": "a", "description": "Option A"},
+                    {"id": "b", "description": "Option B"},
+                ],
+                "default_option": "a",
+            }
+        )
+
+    def test_invalid_severity_raises_error(self, communicate_tool: CommunicateTool) -> None:
+        """Invalid severity for errors should raise validation error."""
+        with pytest.raises(ToolValidationError, match="Invalid severity"):
+            communicate_tool.validate_input(
+                {
+                    "type": "error",
+                    "message": "Something broke",
+                    "severity": "critical",  # not valid
+                }
+            )
+
+
+class TestCommunicateToolStatusMessage:
+    """Tests for status message type."""
+
+    async def test_status_message_success(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Status message should be delivered and return success."""
+        result = await communicate_tool.execute(
+            {
+                "type": "status",
+                "message": "Starting story generation...",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "status"
+        assert result.data["delivered"] is True
+        assert result.data["blocking"] is False
+        assert result.data["status"] == "delivered"
+
+        # Verify broker was called
+        mock_broker.send.assert_called_once()
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.payload["communication_type"] == "status"
+        assert sent_message.payload["message"] == "Starting story generation..."
+
+    async def test_status_with_context(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Status message can include context."""
+        result = await communicate_tool.execute(
+            {
+                "type": "status",
+                "message": "Delegating to Plotwright",
+                "context": "Story structure needs to be planned first",
+            }
+        )
+
+        assert result.success is True
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.payload["context"] == "Story structure needs to be planned first"
+
+
+class TestCommunicateToolQuestionMessage:
+    """Tests for question message type."""
+
+    async def test_question_basic(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Question message should be blocking and await response."""
+        result = await communicate_tool.execute(
+            {
+                "type": "question",
+                "message": "What tone do you prefer?",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "question"
+        assert result.data["blocking"] is True
+        assert result.data["status"] == "awaiting_response"
+        assert result.data["message"] == "What tone do you prefer?"
+
+    async def test_question_with_options(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Question with options should include option ids in result."""
+        result = await communicate_tool.execute(
+            {
+                "type": "question",
+                "message": "What tone do you prefer?",
+                "options": [
+                    {"id": "dark", "description": "Dark and serious"},
+                    {"id": "light", "description": "Light and fun"},
+                ],
+                "default_option": "light",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["options"] == ["dark", "light"]
+        assert result.data["default_option"] == "light"
+
+        # Check broker message
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.CLARIFICATION_REQUEST
+        assert len(sent_message.payload["options"]) == 2
+
+    async def test_question_with_context(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Question should include context explaining why input is needed."""
+        result = await communicate_tool.execute(
+            {
+                "type": "question",
+                "message": "How many chapters?",
+                "context": "This determines the story's scope and pacing",
+            }
+        )
+
+        assert result.success is True
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.payload["context"] == "This determines the story's scope and pacing"
+
+
+class TestCommunicateToolNotificationMessage:
+    """Tests for notification message type."""
+
+    async def test_notification_basic(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Notification should be non-blocking."""
+        result = await communicate_tool.execute(
+            {
+                "type": "notification",
+                "message": "Chapter 1 draft is ready.",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "notification"
+        assert result.data["blocking"] is False
+        assert result.data["status"] == "delivered"
+
+    async def test_notification_with_artifacts(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Notification can include artifact references."""
+        result = await communicate_tool.execute(
+            {
+                "type": "notification",
+                "message": "Chapter 1 draft is ready for review.",
+                "artifacts": [
+                    "workspace:section:chapter_1_v1",
+                    "workspace:section:chapter_1_notes",
+                ],
+            }
+        )
+
+        assert result.success is True
+        assert result.data["artifacts"] == [
+            "workspace:section:chapter_1_v1",
+            "workspace:section:chapter_1_notes",
+        ]
+
+        # Check broker message
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.COMPLETION_SIGNAL
+        assert sent_message.payload["artifacts"] == [
+            "workspace:section:chapter_1_v1",
+            "workspace:section:chapter_1_notes",
+        ]
+
+
+class TestCommunicateToolErrorMessage:
+    """Tests for error message type."""
+
+    async def test_error_info_severity(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Error with info severity should be non-blocking."""
+        result = await communicate_tool.execute(
+            {
+                "type": "error",
+                "message": "Minor issue encountered.",
+                "severity": "info",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "error"
+        assert result.data["severity"] == "info"
+        assert result.data["blocking"] is False
+        assert "awaiting_decision" not in result.data
+
+    async def test_error_warning_severity(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Error with warning severity should be non-blocking."""
+        result = await communicate_tool.execute(
+            {
+                "type": "error",
+                "message": "Could not reach external service.",
+                "context": "Web search failed, using cached data.",
+                "severity": "warning",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["severity"] == "warning"
+        assert result.data["blocking"] is False
+
+    async def test_error_error_severity(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Error with error severity should be blocking."""
+        result = await communicate_tool.execute(
+            {
+                "type": "error",
+                "message": "Critical failure in story generation.",
+                "context": "Cannot proceed without user decision.",
+                "severity": "error",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["severity"] == "error"
+        assert result.data["blocking"] is True
+        assert result.data["awaiting_decision"] is True
+
+    async def test_error_default_severity(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Error without severity should default to info."""
+        result = await communicate_tool.execute(
+            {
+                "type": "error",
+                "message": "Something happened.",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["severity"] == "info"
+        assert result.data["blocking"] is False
+
+
+class TestCommunicateToolMessageRouting:
+    """Tests for message routing behavior."""
+
+    async def test_message_routed_to_customer(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """All messages should be routed to 'customer' agent."""
+        await communicate_tool.execute(
+            {
+                "type": "status",
+                "message": "Test message",
+            }
+        )
+
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.to_agent == "customer"
+
+    async def test_message_from_agent(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Messages should be from the current agent."""
+        await communicate_tool.execute(
+            {
+                "type": "status",
+                "message": "Test message",
+            }
+        )
+
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.from_agent == "showrunner"
+
+    async def test_no_broker_still_succeeds(
+        self,
+        communicate_tool_no_broker: CommunicateTool,
+    ) -> None:
+        """Tool should succeed even without broker (just not delivered)."""
+        result = await communicate_tool_no_broker.execute(
+            {
+                "type": "status",
+                "message": "Test message",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["delivered"] is False
+        assert result.data["status"] == "pending"
+
+    async def test_question_no_broker(
+        self,
+        communicate_tool_no_broker: CommunicateTool,
+    ) -> None:
+        """Question without broker should still return awaiting_response."""
+        result = await communicate_tool_no_broker.execute(
+            {
+                "type": "question",
+                "message": "What do you think?",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["delivered"] is False
+        assert result.data["status"] == "awaiting_response"
+
+
+class TestCommunicateToolMessageTypes:
+    """Tests for message type mapping."""
+
+    async def test_status_uses_progress_update_type(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Status should map to PROGRESS_UPDATE message type."""
+        await communicate_tool.execute({"type": "status", "message": "Test"})
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.PROGRESS_UPDATE
+
+    async def test_question_uses_clarification_request_type(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Question should map to CLARIFICATION_REQUEST message type."""
+        await communicate_tool.execute({"type": "question", "message": "Test?"})
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.CLARIFICATION_REQUEST
+
+    async def test_notification_uses_completion_signal_type(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Notification should map to COMPLETION_SIGNAL message type."""
+        await communicate_tool.execute({"type": "notification", "message": "Done"})
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.COMPLETION_SIGNAL
+
+    async def test_error_uses_escalation_type(
+        self,
+        communicate_tool: CommunicateTool,
+        mock_broker: AsyncMock,
+    ) -> None:
+        """Error should map to ESCALATION message type."""
+        await communicate_tool.execute({"type": "error", "message": "Failed"})
+        sent_message = mock_broker.send.call_args[0][0]
+        assert sent_message.type == MessageType.ESCALATION
+
+
+class TestCommunicationTypeEnum:
+    """Tests for the CommunicationType enum."""
+
+    def test_all_types_defined(self) -> None:
+        """All expected communication types should be defined."""
+        assert CommunicationType.STATUS.value == "status"
+        assert CommunicationType.QUESTION.value == "question"
+        assert CommunicationType.NOTIFICATION.value == "notification"
+        assert CommunicationType.ERROR.value == "error"
+
+    def test_parse_from_string(self) -> None:
+        """Should parse from string value."""
+        assert CommunicationType("status") == CommunicationType.STATUS
+        assert CommunicationType("question") == CommunicationType.QUESTION
+
+
+class TestErrorSeverityEnum:
+    """Tests for the ErrorSeverity enum."""
+
+    def test_all_severities_defined(self) -> None:
+        """All expected severity levels should be defined."""
+        assert ErrorSeverity.INFO.value == "info"
+        assert ErrorSeverity.WARNING.value == "warning"
+        assert ErrorSeverity.ERROR.value == "error"

--- a/tests/runtime/tools/test_communicate.py
+++ b/tests/runtime/tools/test_communicate.py
@@ -52,7 +52,7 @@ def mock_tool_definition() -> MagicMock:
         "options": {"type": "array"},
         "default_option": {"type": "string"},
         "artifacts": {"type": "array"},
-        "severity": {"type": "string"},
+        "severity": {"type": "string", "enum": ["info", "warning", "error"], "default": "info"},
     }
     return definition
 
@@ -430,6 +430,37 @@ class TestCommunicateToolErrorMessage:
         assert result.success is True
         assert result.data["severity"] == "info"
         assert result.data["blocking"] is False
+
+    async def test_error_invalid_severity_raises(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Error with invalid severity should raise validation error."""
+        with pytest.raises(ToolValidationError, match="Invalid severity"):
+            await communicate_tool.execute(
+                {
+                    "type": "error",
+                    "message": "Something broke.",
+                    "severity": "critical",  # not a valid severity
+                }
+            )
+
+    async def test_status_invalid_severity_defaults_to_info(
+        self,
+        communicate_tool: CommunicateTool,
+    ) -> None:
+        """Non-error types with invalid severity should default to info."""
+        # For non-error types, invalid severity is silently ignored
+        result = await communicate_tool.execute(
+            {
+                "type": "status",
+                "message": "Progress update",
+                "severity": "critical",  # invalid but ignored for status
+            }
+        )
+
+        assert result.success is True
+        # Status doesn't use severity in output, so just verify success
 
 
 class TestCommunicateToolMessageRouting:


### PR DESCRIPTION
## Summary

Implements the **communicate tool** (#161) as part of Phase 7 (#159). This is the unified human communication channel for orchestrators, replacing `request_clarification` with a more comprehensive tool.

### Changes

- **New file**: `src/questfoundry/runtime/tools/communicate.py`
  - `CommunicateTool` class with four message types
  - `CommunicationType` and `ErrorSeverity` enums
  - Message type mapping to existing `MessageType` enum
  
- **New file**: `tests/runtime/tools/test_communicate.py`
  - 31 tests covering all message types and edge cases
  
- **Modified**: `src/questfoundry/runtime/tools/__init__.py`
  - Added communicate import for registration

### Message Types

| Type | Purpose | Blocking |
|------|---------|----------|
| `status` | Progress updates | No |
| `question` | Need human input | Yes |
| `notification` | Deliverable ready | No |
| `error` | Something failed | Depends on severity |

### Key Features

- Validates options structure for questions (id, description required)
- Supports artifact references for notifications
- Configurable severity for errors (info, warning, error)
- Maps to existing message protocol (PROGRESS_UPDATE, CLARIFICATION_REQUEST, etc.)

## Test plan

- [x] All 31 new tests pass
- [x] Full test suite (548 tests) passes
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

## Related

- Part of #159 (Phase 7: Prompt & Tool Architecture)
- Implements #161 (Communicate Tool)
- Domain definition already merged: `domain-v4/tools/communicate.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
