### PR TITLE
feat(runtime): implement consult_knowledge tool and KnowledgeContextBuilder

### DIFF
--- a/src/questfoundry/runtime/agent/__init__.py
+++ b/src/questfoundry/runtime/agent/__init__.py
@@ -5,9 +5,16 @@ This module provides the core runtime for activating agents:
 - AgentRuntime: Main runtime class
 - ContextBuilder: Gathers knowledge for agents
 - PromptBuilder: Constructs system prompts
+- KnowledgeContextBuilder: Budget-aware knowledge injection
 """
 
 from questfoundry.runtime.agent.context import AgentContext, ContextBuilder, build_context
+from questfoundry.runtime.agent.knowledge import (
+    KnowledgeBudgetConfig,
+    KnowledgeContext,
+    KnowledgeContextBuilder,
+    build_knowledge_context,
+)
 from questfoundry.runtime.agent.prompt import (
     BuiltPrompt,
     PromptBuilder,
@@ -31,6 +38,11 @@ __all__ = [
     "ContextBuilder",
     "AgentContext",
     "build_context",
+    # Knowledge
+    "KnowledgeContextBuilder",
+    "KnowledgeBudgetConfig",
+    "KnowledgeContext",
+    "build_knowledge_context",
     # Prompt
     "PromptBuilder",
     "PromptSection",

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.runtime.models.base import KnowledgeContent
+
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, KnowledgeEntry, Playbook, Studio
 
@@ -281,7 +283,7 @@ class ContextBuilder:
                     content = entry.content.get("text", "")
             elif isinstance(entry.content, str):
                 content = entry.content
-            elif hasattr(entry.content, "type") and entry.content.type == "inline":
+            elif isinstance(entry.content, KnowledgeContent) and entry.content.type == "inline":
                 # KnowledgeContent model
                 content = entry.content.text or ""
 

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -276,11 +276,14 @@ class ContextBuilder:
 
         if entry.content:
             if isinstance(entry.content, dict):
-                # Inline content
+                # Dict-style inline content
                 if entry.content.get("type") == "inline":
                     content = entry.content.get("text", "")
             elif isinstance(entry.content, str):
                 content = entry.content
+            elif hasattr(entry.content, "type") and entry.content.type == "inline":
+                # KnowledgeContent model
+                content = entry.content.text or ""
 
         return {
             "id": entry.id,

--- a/src/questfoundry/runtime/agent/knowledge.py
+++ b/src/questfoundry/runtime/agent/knowledge.py
@@ -1,0 +1,276 @@
+"""
+Knowledge context builder for agent prompts.
+
+Implements budget-aware knowledge injection following the menu+consult pattern
+from meta/docs/knowledge-patterns.md.
+
+Knowledge layers:
+- constitution: Always inline (inviolable principles)
+- must_know: Inline up to budget, overflow to menu
+- should_know: Menu only (summary with consult hint)
+- role_specific: Menu only (specialist reference)
+- lookup: Never shown (query via tool only)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models import Agent, KnowledgeEntry, Studio
+
+
+@dataclass
+class KnowledgeBudgetConfig:
+    """Budget configuration for knowledge injection."""
+
+    # Total token budget for all knowledge in system prompt
+    total_prompt_budget_tokens: int = 4000
+
+    # Budget for constitution (always inline)
+    constitution_tokens: int = 500
+
+    # Budget for must_know entries
+    must_know_tokens: int = 1500
+
+    # Budget for menu section
+    menu_tokens: int = 500
+
+    # Chars per token estimate (rough approximation)
+    chars_per_token: int = 4
+
+
+@dataclass
+class KnowledgeContext:
+    """Result of knowledge context building."""
+
+    # Full context text for injection into prompt
+    context_text: str
+
+    # Separate sections for flexible injection
+    constitution_section: str | None = None
+    must_know_section: str | None = None
+    menu_section: str | None = None
+
+    # Tracking
+    entries_inlined: list[str] = field(default_factory=list)
+    entries_in_menu: list[str] = field(default_factory=list)
+    tokens_used: int = 0
+
+
+class KnowledgeContextBuilder:
+    """
+    Builds budget-aware knowledge context for agent prompts.
+
+    Implements the layered knowledge injection strategy:
+    1. Constitution always inlined
+    2. Must-know inlined up to budget, overflow to menu
+    3. Should-know and role-specific shown in menu only
+    4. Lookup entries not shown (available via consult_knowledge tool)
+
+    Usage:
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(agent, studio)
+        # Use context.context_text in system prompt
+    """
+
+    def __init__(self, config: KnowledgeBudgetConfig | None = None) -> None:
+        """Initialize with optional budget configuration."""
+        self.config = config or KnowledgeBudgetConfig()
+
+    def build_context(self, agent: Agent, studio: Studio) -> KnowledgeContext:
+        """
+        Build knowledge context for an agent.
+
+        Args:
+            agent: Agent definition with knowledge_requirements
+            studio: Studio with knowledge entries
+
+        Returns:
+            KnowledgeContext with formatted text and tracking info
+        """
+        sections: list[str] = []
+        menu_items: list[dict[str, str]] = []
+        entries_inlined: list[str] = []
+        entries_in_menu: list[str] = []
+        used_tokens = 0
+
+        knowledge_req = agent.knowledge_requirements
+
+        # 1. Constitution - always inline
+        constitution_section = None
+        if knowledge_req and knowledge_req.constitution:
+            constitution_text = self._get_constitution_text(studio)
+            if constitution_text:
+                constitution_section = self._format_constitution(constitution_text)
+                sections.append(constitution_section)
+                used_tokens += self._count_tokens(constitution_section)
+
+        # 2. Must-know - inline up to budget, overflow to menu
+        must_know_section = None
+        if knowledge_req and knowledge_req.must_know:
+            must_know_lines: list[str] = []
+            must_know_budget = self.config.must_know_tokens
+
+            for entry_id in knowledge_req.must_know:
+                entry = studio.knowledge.get(entry_id)
+                if not entry:
+                    continue
+
+                content = self._get_entry_content(entry)
+                if not content:
+                    # No content - add to menu instead
+                    menu_items.append(self._format_menu_item(entry))
+                    entries_in_menu.append(entry_id)
+                    continue
+
+                entry_tokens = self._count_tokens(content)
+
+                # Check if fits in budget
+                if used_tokens + entry_tokens <= must_know_budget:
+                    must_know_lines.append(self._format_inline_entry(entry, content))
+                    entries_inlined.append(entry_id)
+                    used_tokens += entry_tokens
+                else:
+                    # Over budget - add to menu instead
+                    menu_items.append(self._format_menu_item(entry))
+                    entries_in_menu.append(entry_id)
+
+            if must_know_lines:
+                must_know_section = "## Critical Knowledge\n\n" + "\n\n".join(must_know_lines)
+                sections.append(must_know_section)
+
+        # 3. Should-know - menu only
+        if knowledge_req and knowledge_req.should_know:
+            for entry_id in knowledge_req.should_know:
+                entry = studio.knowledge.get(entry_id)
+                if entry:
+                    menu_items.append(self._format_menu_item(entry))
+                    entries_in_menu.append(entry_id)
+
+        # 4. Role-specific - menu only
+        if knowledge_req and knowledge_req.role_specific:
+            for entry_id in knowledge_req.role_specific:
+                entry = studio.knowledge.get(entry_id)
+                if entry:
+                    menu_items.append(self._format_menu_item(entry))
+                    entries_in_menu.append(entry_id)
+
+        # 5. Build menu section
+        menu_section = None
+        if menu_items:
+            menu_section = self._format_menu(menu_items)
+            sections.append(menu_section)
+            used_tokens += self._count_tokens(menu_section)
+
+        # Assemble final context
+        context_text = "\n\n".join(sections)
+
+        return KnowledgeContext(
+            context_text=context_text,
+            constitution_section=constitution_section,
+            must_know_section=must_know_section,
+            menu_section=menu_section,
+            entries_inlined=entries_inlined,
+            entries_in_menu=entries_in_menu,
+            tokens_used=used_tokens,
+        )
+
+    def _get_constitution_text(self, studio: Studio) -> str | None:
+        """Get constitution text from studio.
+
+        Constitution is typically stored in a separate file referenced
+        by constitution_ref, but may also be in knowledge entries.
+        """
+        # TODO: Load from constitution_ref if available
+        # For now, look for a 'constitution' knowledge entry
+        entry = studio.knowledge.get("constitution")
+        if entry:
+            return self._get_entry_content(entry)
+        return None
+
+    def _get_entry_content(self, entry: KnowledgeEntry) -> str | None:
+        """Extract text content from a knowledge entry."""
+        content = entry.content
+        if content is None:
+            return None
+
+        # Handle dict content (raw from JSON)
+        if isinstance(content, dict):
+            content_type = content.get("type", "inline")
+            if content_type == "inline":
+                return content.get("text")
+            elif content_type == "structured":
+                import json
+
+                return json.dumps(content.get("data", {}), indent=2)
+            return content.get("text")
+
+        # Handle KnowledgeContent model
+        if hasattr(content, "type"):
+            if content.type == "inline":
+                return content.text
+            elif content.type == "structured":
+                import json
+
+                return json.dumps(content.data or {}, indent=2)
+
+        return str(content) if content else None
+
+    def _format_constitution(self, text: str) -> str:
+        """Format constitution for prompt injection."""
+        return f"## Constitution (Inviolable Principles)\n\n{text}"
+
+    def _format_inline_entry(self, entry: KnowledgeEntry, content: str) -> str:
+        """Format a knowledge entry for inline injection."""
+        name = entry.name or entry.id
+        return f"### {name}\n\n{content}"
+
+    def _format_menu_item(self, entry: KnowledgeEntry) -> dict[str, str]:
+        """Format a knowledge entry for the menu."""
+        return {
+            "id": entry.id,
+            "name": entry.name or entry.id,
+            "summary": entry.summary or "(No summary)",
+        }
+
+    def _format_menu(self, items: list[dict[str, str]]) -> str:
+        """Format the knowledge menu section."""
+        lines = [
+            "## Knowledge Menu\n",
+            "Use `consult_knowledge(entry_id)` for full details.\n",
+        ]
+
+        for item in items:
+            lines.append(f"- **{item['name']}** (`{item['id']}`): {item['summary']}")
+
+        return "\n".join(lines)
+
+    def _count_tokens(self, text: str) -> int:
+        """Estimate token count from text.
+
+        Uses a simple chars/token ratio. For more accuracy,
+        use a proper tokenizer like tiktoken.
+        """
+        return len(text) // self.config.chars_per_token
+
+
+def build_knowledge_context(
+    agent: Agent,
+    studio: Studio,
+    config: KnowledgeBudgetConfig | None = None,
+) -> KnowledgeContext:
+    """
+    Convenience function to build knowledge context for an agent.
+
+    Args:
+        agent: Agent definition
+        studio: Studio with knowledge entries
+        config: Optional budget configuration
+
+    Returns:
+        KnowledgeContext with formatted text
+    """
+    builder = KnowledgeContextBuilder(config)
+    return builder.build_context(agent, studio)

--- a/src/questfoundry/runtime/agent/knowledge.py
+++ b/src/questfoundry/runtime/agent/knowledge.py
@@ -14,11 +14,14 @@ Knowledge layers:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, KnowledgeEntry, Studio
+
+from questfoundry.runtime.models.base import KnowledgeContent
 
 
 @dataclass
@@ -112,6 +115,7 @@ class KnowledgeContextBuilder:
         if knowledge_req and knowledge_req.must_know:
             must_know_lines: list[str] = []
             must_know_budget = self.config.must_know_tokens
+            must_know_tokens_used = 0
 
             for entry_id in knowledge_req.must_know:
                 entry = studio.knowledge.get(entry_id)
@@ -120,38 +124,45 @@ class KnowledgeContextBuilder:
 
                 content = self._get_entry_content(entry)
                 if not content:
-                    # No content - add to menu instead
-                    menu_items.append(self._format_menu_item(entry))
-                    entries_in_menu.append(entry_id)
+                    # No content - add to menu instead (if not already there)
+                    if entry_id not in entries_in_menu:
+                        menu_items.append(self._format_menu_item(entry))
+                        entries_in_menu.append(entry_id)
                     continue
 
                 entry_tokens = self._count_tokens(content)
 
-                # Check if fits in budget
-                if used_tokens + entry_tokens <= must_know_budget:
+                # Check if fits in must_know budget
+                if must_know_tokens_used + entry_tokens <= must_know_budget:
                     must_know_lines.append(self._format_inline_entry(entry, content))
                     entries_inlined.append(entry_id)
                     used_tokens += entry_tokens
+                    must_know_tokens_used += entry_tokens
                 else:
-                    # Over budget - add to menu instead
-                    menu_items.append(self._format_menu_item(entry))
-                    entries_in_menu.append(entry_id)
+                    # Over budget - add to menu instead (if not already there)
+                    if entry_id not in entries_in_menu:
+                        menu_items.append(self._format_menu_item(entry))
+                        entries_in_menu.append(entry_id)
 
             if must_know_lines:
                 must_know_section = "## Critical Knowledge\n\n" + "\n\n".join(must_know_lines)
                 sections.append(must_know_section)
 
-        # 3. Should-know - menu only
+        # 3. Should-know - menu only (skip if already in menu)
         if knowledge_req and knowledge_req.should_know:
             for entry_id in knowledge_req.should_know:
+                if entry_id in entries_in_menu:
+                    continue
                 entry = studio.knowledge.get(entry_id)
                 if entry:
                     menu_items.append(self._format_menu_item(entry))
                     entries_in_menu.append(entry_id)
 
-        # 4. Role-specific - menu only
+        # 4. Role-specific - menu only (skip if already in menu)
         if knowledge_req and knowledge_req.role_specific:
             for entry_id in knowledge_req.role_specific:
+                if entry_id in entries_in_menu:
+                    continue
                 entry = studio.knowledge.get(entry_id)
                 if entry:
                     menu_items.append(self._format_menu_item(entry))
@@ -202,18 +213,14 @@ class KnowledgeContextBuilder:
             if content_type == "inline":
                 return content.get("text")
             elif content_type == "structured":
-                import json
-
                 return json.dumps(content.get("data", {}), indent=2)
             return content.get("text")
 
         # Handle KnowledgeContent model
-        if hasattr(content, "type"):
+        if isinstance(content, KnowledgeContent):
             if content.type == "inline":
                 return content.text
             elif content.type == "structured":
-                import json
-
                 return json.dumps(content.data or {}, indent=2)
 
         return str(content) if content else None

--- a/src/questfoundry/runtime/domain/loader.py
+++ b/src/questfoundry/runtime/domain/loader.py
@@ -28,6 +28,7 @@ from questfoundry.runtime.models.base import (
     Agent,
     ArtifactType,
     AssetType,
+    KnowledgeEntry,
     Playbook,
     QualityCriteria,
     Store,
@@ -246,7 +247,71 @@ async def _resolve_all_refs(
                 )
             )
 
+    # Load knowledge entries from knowledge/ directory
+    knowledge_dir = base_path / "knowledge"
+    knowledge_entries: dict[str, Any] = {}
+    if knowledge_dir.exists() and knowledge_dir.is_dir():
+        knowledge_entries, knowledge_errors = _load_knowledge_entries(knowledge_dir)
+        errors.extend(knowledge_errors)
+    resolved["knowledge"] = knowledge_entries
+
     return resolved, errors
+
+
+def _load_knowledge_entries(
+    knowledge_dir: Path,
+) -> tuple[dict[str, Any], list[LoadError]]:
+    """
+    Load all knowledge entries from subdirectories of knowledge/.
+
+    Knowledge entries are stored in subdirectories by layer:
+        knowledge/
+            must_know/
+                spoiler_hygiene.json
+                sources_of_truth.json
+            role_specific/
+                showrunner_operating_principles.json
+            lookup/
+                accessibility_guidelines.json
+
+    Returns a dict mapping entry_id -> entry_data.
+    """
+    errors: list[LoadError] = []
+    entries: dict[str, Any] = {}
+
+    # Recursively find all .json files in knowledge directory
+    # Skip layers.json which is the config file
+    for json_file in knowledge_dir.rglob("*.json"):
+        if json_file.name == "layers.json":
+            continue
+
+        try:
+            content = json.loads(json_file.read_text())
+            entry_id = content.get("id")
+            if not entry_id:
+                errors.append(
+                    LoadError(
+                        path=str(json_file),
+                        message=f"Knowledge entry missing 'id' field: {json_file.name}",
+                        severity="warning",
+                    )
+                )
+                continue
+
+            # Strip $schema field
+            content = _strip_schema_field(content)
+            entries[entry_id] = content
+
+        except json.JSONDecodeError as e:
+            errors.append(
+                LoadError(
+                    path=str(json_file),
+                    message=f"Invalid JSON in knowledge entry: {e}",
+                    severity="error",
+                )
+            )
+
+    return entries, errors
 
 
 def _build_studio(resolved: dict[str, Any]) -> Studio:
@@ -298,10 +363,18 @@ def _build_studio(resolved: dict[str, Any]) -> Studio:
         qc_data = _strip_schema_field(qc_data)
         quality_criteria.append(QualityCriteria.model_validate(qc_data))
 
+    # Build knowledge entries dict
+    knowledge: dict[str, KnowledgeEntry] = {}
+    for entry_id, entry_data in resolved.get("knowledge", {}).items():
+        try:
+            knowledge[entry_id] = KnowledgeEntry.model_validate(entry_data)
+        except Exception as e:
+            logger.warning("Failed to parse knowledge entry '%s': %s", entry_id, e)
+
     # Build Studio
     studio_data = _strip_schema_field(dict(resolved))
 
-    # Replace resolved arrays
+    # Replace resolved arrays/dicts
     studio_data["agents"] = agents
     studio_data["stores"] = stores
     studio_data["tools"] = tools
@@ -309,6 +382,7 @@ def _build_studio(resolved: dict[str, Any]) -> Studio:
     studio_data["artifact_types"] = artifact_types
     studio_data["asset_types"] = asset_types
     studio_data["quality_criteria"] = quality_criteria
+    studio_data["knowledge"] = knowledge
 
     return Studio.model_validate(studio_data)
 

--- a/src/questfoundry/runtime/domain/loader.py
+++ b/src/questfoundry/runtime/domain/loader.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from pydantic import ValidationError
+
 from questfoundry.runtime.models.base import (
     Agent,
     ArtifactType,
@@ -300,6 +302,17 @@ def _load_knowledge_entries(
 
             # Strip $schema field
             content = _strip_schema_field(content)
+
+            # Warn about duplicate entry IDs
+            if entry_id in entries:
+                errors.append(
+                    LoadError(
+                        path=str(json_file),
+                        message=f"Duplicate knowledge entry_id '{entry_id}' - overwriting previous entry",
+                        severity="warning",
+                    )
+                )
+
             entries[entry_id] = content
 
         except json.JSONDecodeError as e:
@@ -368,7 +381,7 @@ def _build_studio(resolved: dict[str, Any]) -> Studio:
     for entry_id, entry_data in resolved.get("knowledge", {}).items():
         try:
             knowledge[entry_id] = KnowledgeEntry.model_validate(entry_data)
-        except Exception as e:
+        except ValidationError as e:
             logger.warning("Failed to parse knowledge entry '%s': %s", entry_id, e)
 
     # Build Studio

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -309,6 +309,29 @@ class QualityCriteria(BaseModel):
     failure_guidance: str | None = None
 
 
+class KnowledgeContent(BaseModel):
+    """Knowledge content definition."""
+
+    type: str = "inline"  # inline, file_ref, structured, corpus
+    text: str | None = None  # For inline type
+    file_path: str | None = None  # For file_ref type
+    format: str = "markdown"  # markdown, json, yaml, plain
+    data: dict[str, Any] | None = None  # For structured type
+    schema_ref: str | None = None  # For structured type
+    corpus_ref: dict[str, Any] | None = None  # For corpus type
+
+    model_config = {"extra": "allow"}
+
+
+class KnowledgeApplicability(BaseModel):
+    """What a knowledge entry applies to."""
+
+    archetypes: list[str] = Field(default_factory=list)
+    agents: list[str] = Field(default_factory=list)
+    playbooks: list[str] = Field(default_factory=list)
+    artifact_types: list[str] = Field(default_factory=list)
+
+
 class KnowledgeEntry(BaseModel):
     """Knowledge entry from knowledge-entry.schema.json."""
 
@@ -317,8 +340,20 @@ class KnowledgeEntry(BaseModel):
     summary: str | None = None
     layer: KnowledgeLayer = KnowledgeLayer.LOOKUP
 
-    content: dict[str, Any] | None = None
-    applicable_to: dict[str, Any] | None = None
+    # Discovery fields
+    keywords: list[str] = Field(default_factory=list)
+    triggers: list[str] = Field(default_factory=list)
+    discriminators: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+    # Content - can be dict or structured model
+    content: KnowledgeContent | dict[str, Any] | None = None
+    applicable_to: KnowledgeApplicability | dict[str, Any] | None = None
+    related_entries: list[str] = Field(default_factory=list)
+
+    # Versioning
+    version: str | None = None
+    last_updated: str | None = None
 
 
 class Playbook(BaseModel):
@@ -384,8 +419,9 @@ class Studio(BaseModel):
     asset_types: list[AssetType] = Field(default_factory=list)
     quality_criteria: list[QualityCriteria] = Field(default_factory=list)
 
-    # Knowledge (resolved separately)
-    knowledge_config: dict[str, Any] | None = None
+    # Knowledge system
+    knowledge_config: dict[str, Any] | None = None  # Layer configuration from layers.json
+    knowledge: dict[str, KnowledgeEntry] = Field(default_factory=dict)  # Entries by ID
 
     # References
     constitution_ref: str | None = None

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -7,7 +7,7 @@ They are used by the domain loader to hydrate loaded JSON into typed objects.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -312,10 +312,10 @@ class QualityCriteria(BaseModel):
 class KnowledgeContent(BaseModel):
     """Knowledge content definition."""
 
-    type: str = "inline"  # inline, file_ref, structured, corpus
+    type: Literal["inline", "file_ref", "structured", "corpus"] = "inline"
     text: str | None = None  # For inline type
     file_path: str | None = None  # For file_ref type
-    format: str = "markdown"  # markdown, json, yaml, plain
+    format: Literal["markdown", "json", "yaml", "plain"] = "markdown"
     data: dict[str, Any] | None = None  # For structured type
     schema_ref: str | None = None  # For structured type
     corpus_ref: dict[str, Any] | None = None  # For corpus type

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -21,6 +21,7 @@ Usage:
 from questfoundry.runtime.tools import (
     communicate,  # noqa: F401  # Phase 7: unified human communication
     consult_corpus,  # noqa: F401
+    consult_knowledge,  # noqa: F401  # Phase 7: knowledge menu+consult pattern
     consult_playbook,  # noqa: F401
     consult_schema,  # noqa: F401
     delegate,  # noqa: F401

--- a/src/questfoundry/runtime/tools/consult_knowledge.py
+++ b/src/questfoundry/runtime/tools/consult_knowledge.py
@@ -7,11 +7,16 @@ Implements the menu+consult pattern from meta/docs/knowledge-patterns.md.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
+from questfoundry.runtime.models.base import KnowledgeContent
 from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
 from questfoundry.runtime.tools.registry import register_tool
+
+# Pre-compiled regex for markdown header extraction
+_HEADER_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$")
 
 
 @register_tool("consult_knowledge")
@@ -111,8 +116,6 @@ class ConsultKnowledgeTool(BaseTool):
                 return f"(Content in file: {content.get('file_path')})"
             elif content_type == "structured":
                 # Return JSON representation of structured data
-                import json
-
                 data = content.get("data", {})
                 return json.dumps(data, indent=2)
             elif content_type == "corpus":
@@ -122,15 +125,13 @@ class ConsultKnowledgeTool(BaseTool):
                 return content.get("text")
 
         # Handle KnowledgeContent model
-        if hasattr(content, "type"):
+        if isinstance(content, KnowledgeContent):
             if content.type == "inline":
                 text = content.text
                 return str(text) if text else None
             elif content.type == "file_ref":
                 return f"(Content in file: {content.file_path})"
             elif content.type == "structured":
-                import json
-
                 return json.dumps(content.data or {}, indent=2)
             elif content.type == "corpus":
                 return "(This is a corpus entry. Use consult_corpus tool to search.)"
@@ -148,11 +149,8 @@ class ConsultKnowledgeTool(BaseTool):
         section_level = 0
         section_lines: list[str] = []
 
-        # Pattern to match markdown headers
-        header_pattern = re.compile(r"^(#{1,6})\s+(.+)$")
-
         for line in lines:
-            match = header_pattern.match(line)
+            match = _HEADER_PATTERN.match(line)
             if match:
                 level = len(match.group(1))
                 title = match.group(2).strip()

--- a/src/questfoundry/runtime/tools/consult_knowledge.py
+++ b/src/questfoundry/runtime/tools/consult_knowledge.py
@@ -1,0 +1,187 @@
+"""
+Consult Knowledge tool implementation.
+
+Retrieves full knowledge content from the studio knowledge base.
+Implements the menu+consult pattern from meta/docs/knowledge-patterns.md.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
+from questfoundry.runtime.tools.registry import register_tool
+
+
+@register_tool("consult_knowledge")
+class ConsultKnowledgeTool(BaseTool):
+    """
+    Retrieve detailed guidance from the studio knowledge base.
+
+    Use this when you need full content for entries shown in your Knowledge Menu.
+    The Knowledge Menu shows summaries; this tool retrieves complete content
+    including examples, procedures, and detailed guidance.
+
+    Common uses:
+    - Get detailed examples when summary is insufficient
+    - Retrieve full procedures or checklists
+    - Access domain-specific guidance for specialized tasks
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute knowledge lookup."""
+        entry_id = args.get("entry_id")
+        section = args.get("section")
+
+        if not entry_id:
+            # List available knowledge entries
+            available = list(self._context.studio.knowledge.keys())
+            return ToolResult(
+                success=True,
+                data={
+                    "message": (
+                        "You called consult_knowledge without specifying an entry_id. "
+                        "Available knowledge entries:"
+                    ),
+                    "available_entries": available,
+                    "hint": "Specify entry_id from your Knowledge Menu to get full content.",
+                },
+            )
+
+        # Find entry in studio knowledge
+        entry = self._context.studio.knowledge.get(entry_id)
+
+        if not entry:
+            available = list(self._context.studio.knowledge.keys())
+            return ToolResult(
+                success=False,
+                data={"available_entries": available},
+                error=f"Knowledge entry not found: {entry_id}",
+            )
+
+        # Extract content
+        content_text = self._extract_content(entry)
+
+        # If section requested, extract just that section
+        if section and content_text:
+            section_text = self._extract_section(content_text, section)
+            if section_text:
+                content_text = section_text
+            else:
+                # Section not found - return full content with warning
+                return ToolResult(
+                    success=True,
+                    data={
+                        "entry_id": entry_id,
+                        "name": entry.name or entry_id,
+                        "layer": entry.layer.value
+                        if hasattr(entry.layer, "value")
+                        else str(entry.layer),
+                        "content": content_text,
+                        "related_entries": entry.related_entries or [],
+                        "warning": f"Section '{section}' not found. Returning full content.",
+                    },
+                )
+
+        # Build result
+        result_data: dict[str, Any] = {
+            "entry_id": entry_id,
+            "name": entry.name or entry_id,
+            "layer": entry.layer.value if hasattr(entry.layer, "value") else str(entry.layer),
+            "content": content_text or "(No content available)",
+            "related_entries": entry.related_entries or [],
+        }
+
+        return ToolResult(success=True, data=result_data)
+
+    def _extract_content(self, entry: Any) -> str | None:
+        """Extract text content from a knowledge entry."""
+        content = entry.content
+        if content is None:
+            return None
+
+        # Handle dict content (raw from JSON)
+        if isinstance(content, dict):
+            content_type = content.get("type", "inline")
+            if content_type == "inline":
+                return content.get("text")
+            elif content_type == "file_ref":
+                # TODO: Load from file
+                return f"(Content in file: {content.get('file_path')})"
+            elif content_type == "structured":
+                # Return JSON representation of structured data
+                import json
+
+                data = content.get("data", {})
+                return json.dumps(data, indent=2)
+            elif content_type == "corpus":
+                # Corpus entries are searched via consult_corpus tool
+                return "(This is a corpus entry. Use consult_corpus tool to search.)"
+            else:
+                return content.get("text")
+
+        # Handle KnowledgeContent model
+        if hasattr(content, "type"):
+            if content.type == "inline":
+                text = content.text
+                return str(text) if text else None
+            elif content.type == "file_ref":
+                return f"(Content in file: {content.file_path})"
+            elif content.type == "structured":
+                import json
+
+                return json.dumps(content.data or {}, indent=2)
+            elif content.type == "corpus":
+                return "(This is a corpus entry. Use consult_corpus tool to search.)"
+
+        return str(content) if content else None
+
+    def _extract_section(self, content: str, section_name: str) -> str | None:
+        """Extract a specific section from markdown content.
+
+        Looks for headers matching the section name and returns content
+        until the next header of the same or higher level.
+        """
+        lines = content.split("\n")
+        in_section = False
+        section_level = 0
+        section_lines: list[str] = []
+
+        # Pattern to match markdown headers
+        header_pattern = re.compile(r"^(#{1,6})\s+(.+)$")
+
+        for line in lines:
+            match = header_pattern.match(line)
+            if match:
+                level = len(match.group(1))
+                title = match.group(2).strip()
+
+                if in_section:
+                    # Check if we've hit a same-level or higher header
+                    if level <= section_level:
+                        break
+                    section_lines.append(line)
+                elif title.lower() == section_name.lower():
+                    # Found the section
+                    in_section = True
+                    section_level = level
+                    section_lines.append(line)
+            elif in_section:
+                section_lines.append(line)
+
+        if section_lines:
+            return "\n".join(section_lines).strip()
+        return None
+
+    def validate_input(self, args: dict[str, Any]) -> None:
+        """Validate input arguments."""
+        super().validate_input(args)
+
+        entry_id = args.get("entry_id")
+        if entry_id is not None and not isinstance(entry_id, str):
+            raise ToolValidationError("entry_id must be a string")
+
+        section = args.get("section")
+        if section is not None and not isinstance(section, str):
+            raise ToolValidationError("section must be a string")

--- a/tests/runtime/agent/test_knowledge.py
+++ b/tests/runtime/agent/test_knowledge.py
@@ -1,0 +1,474 @@
+"""
+Tests for KnowledgeContextBuilder.
+
+Implements budget-aware knowledge injection following the menu+consult pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.runtime.agent.knowledge import (
+    KnowledgeBudgetConfig,
+    KnowledgeContext,
+    KnowledgeContextBuilder,
+    build_knowledge_context,
+)
+from questfoundry.runtime.models.base import (
+    Agent,
+    KnowledgeEntry,
+    KnowledgeRequirements,
+    Studio,
+)
+from questfoundry.runtime.models.enums import KnowledgeLayer
+
+
+@pytest.fixture
+def mock_knowledge_entries() -> dict[str, KnowledgeEntry]:
+    """Create mock knowledge entries for testing."""
+    return {
+        "constitution": KnowledgeEntry(
+            id="constitution",
+            name="Studio Constitution",
+            layer=KnowledgeLayer.CONSTITUTION,
+            summary="Inviolable principles.",
+            content={
+                "type": "inline",
+                "text": "## Constitution\n\n1. Never harm users.\n2. Always be helpful.",
+            },
+        ),
+        "spoiler_hygiene": KnowledgeEntry(
+            id="spoiler_hygiene",
+            name="Spoiler Hygiene",
+            layer=KnowledgeLayer.MUST_KNOW,
+            summary="Never reveal future plot points.",
+            content={
+                "type": "inline",
+                "text": "## Spoiler Hygiene\n\nNever reveal future plot points. Keep secrets safe.",
+            },
+        ),
+        "runtime_guidelines": KnowledgeEntry(
+            id="runtime_guidelines",
+            name="Runtime Guidelines",
+            layer=KnowledgeLayer.MUST_KNOW,
+            summary="Guidelines for runtime behavior.",
+            content={
+                "type": "inline",
+                "text": "## Runtime Guidelines\n\nAlways use tools for actions. Handle errors gracefully.",
+            },
+        ),
+        "quality_bars": KnowledgeEntry(
+            id="quality_bars",
+            name="Quality Bars Overview",
+            layer=KnowledgeLayer.SHOULD_KNOW,
+            summary="Overview of the 8 quality criteria.",
+            content={
+                "type": "inline",
+                "text": "## Quality Bars\n\nDetailed quality criteria information...",
+            },
+        ),
+        "showrunner_heuristics": KnowledgeEntry(
+            id="showrunner_heuristics",
+            name="Showrunner Heuristics",
+            layer=KnowledgeLayer.ROLE_SPECIFIC,
+            summary="Heuristics for the showrunner role.",
+            content={
+                "type": "inline",
+                "text": "## Showrunner Heuristics\n\nDelegate early and often...",
+            },
+        ),
+        "accessibility_guidelines": KnowledgeEntry(
+            id="accessibility_guidelines",
+            name="Accessibility Guidelines",
+            layer=KnowledgeLayer.LOOKUP,
+            summary="Guidelines for accessibility.",
+            content={
+                "type": "inline",
+                "text": "## Accessibility\n\nVery long content that should never be inlined...",
+            },
+        ),
+    }
+
+
+@pytest.fixture
+def mock_studio(mock_knowledge_entries: dict[str, KnowledgeEntry]) -> MagicMock:
+    """Create mock studio with knowledge entries."""
+    studio = MagicMock(spec=Studio)
+    studio.knowledge = mock_knowledge_entries
+    return studio
+
+
+@pytest.fixture
+def mock_agent_with_requirements() -> MagicMock:
+    """Create mock agent with knowledge requirements."""
+    agent = MagicMock(spec=Agent)
+    agent.id = "showrunner"
+    agent.name = "Showrunner"
+    agent.knowledge_requirements = KnowledgeRequirements(
+        constitution=True,
+        must_know=["spoiler_hygiene", "runtime_guidelines"],
+        should_know=["quality_bars"],
+        role_specific=["showrunner_heuristics"],
+        can_lookup=["accessibility_guidelines"],
+    )
+    return agent
+
+
+@pytest.fixture
+def mock_agent_no_requirements() -> MagicMock:
+    """Create mock agent without knowledge requirements."""
+    agent = MagicMock(spec=Agent)
+    agent.id = "simple_agent"
+    agent.name = "Simple Agent"
+    agent.knowledge_requirements = None
+    return agent
+
+
+class TestKnowledgeBudgetConfig:
+    """Tests for KnowledgeBudgetConfig."""
+
+    def test_default_values(self):
+        """Config should have sensible defaults."""
+        config = KnowledgeBudgetConfig()
+
+        assert config.total_prompt_budget_tokens == 4000
+        assert config.constitution_tokens == 500
+        assert config.must_know_tokens == 1500
+        assert config.menu_tokens == 500
+        assert config.chars_per_token == 4
+
+    def test_custom_values(self):
+        """Config should accept custom values."""
+        config = KnowledgeBudgetConfig(
+            total_prompt_budget_tokens=8000,
+            must_know_tokens=3000,
+            chars_per_token=3,
+        )
+
+        assert config.total_prompt_budget_tokens == 8000
+        assert config.must_know_tokens == 3000
+        assert config.chars_per_token == 3
+
+
+class TestKnowledgeContext:
+    """Tests for KnowledgeContext dataclass."""
+
+    def test_has_required_attributes(self):
+        """KnowledgeContext should have all required attributes."""
+        context = KnowledgeContext(
+            context_text="test",
+            constitution_section="constitution",
+            must_know_section="must_know",
+            menu_section="menu",
+            entries_inlined=["a", "b"],
+            entries_in_menu=["c", "d"],
+            tokens_used=100,
+        )
+
+        assert context.context_text == "test"
+        assert context.constitution_section == "constitution"
+        assert context.must_know_section == "must_know"
+        assert context.menu_section == "menu"
+        assert context.entries_inlined == ["a", "b"]
+        assert context.entries_in_menu == ["c", "d"]
+        assert context.tokens_used == 100
+
+
+class TestKnowledgeContextBuilderInit:
+    """Tests for KnowledgeContextBuilder initialization."""
+
+    def test_default_config(self):
+        """Builder should use default config if none provided."""
+        builder = KnowledgeContextBuilder()
+
+        assert builder.config is not None
+        assert builder.config.total_prompt_budget_tokens == 4000
+
+    def test_custom_config(self):
+        """Builder should accept custom config."""
+        config = KnowledgeBudgetConfig(total_prompt_budget_tokens=8000)
+        builder = KnowledgeContextBuilder(config=config)
+
+        assert builder.config.total_prompt_budget_tokens == 8000
+
+
+class TestKnowledgeContextBuilderConstitution:
+    """Tests for constitution handling."""
+
+    def test_constitution_inlined_when_requested(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Constitution should be inlined when agent requests it."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert context.constitution_section is not None
+        assert "Constitution" in context.constitution_section
+        assert "Inviolable Principles" in context.constitution_section
+
+    def test_constitution_not_inlined_when_not_requested(
+        self, mock_agent_no_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Constitution should not appear if not requested."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_no_requirements, mock_studio)
+
+        assert context.constitution_section is None
+
+
+class TestKnowledgeContextBuilderMustKnow:
+    """Tests for must_know handling."""
+
+    def test_must_know_entries_inlined(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Must-know entries should be inlined."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert context.must_know_section is not None
+        assert "Critical Knowledge" in context.must_know_section
+        assert "spoiler_hygiene" in context.entries_inlined
+        assert "runtime_guidelines" in context.entries_inlined
+
+    def test_must_know_overflow_to_menu(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Must-know entries exceeding budget should overflow to menu."""
+        # Use very small budget to force overflow
+        config = KnowledgeBudgetConfig(must_know_tokens=10)
+        builder = KnowledgeContextBuilder(config=config)
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # With tiny budget, entries should overflow to menu
+        assert len(context.entries_in_menu) > 0
+
+
+class TestKnowledgeContextBuilderShouldKnow:
+    """Tests for should_know handling."""
+
+    def test_should_know_in_menu_only(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Should-know entries should only appear in menu."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert "quality_bars" in context.entries_in_menu
+        assert "quality_bars" not in context.entries_inlined
+
+
+class TestKnowledgeContextBuilderRoleSpecific:
+    """Tests for role_specific handling."""
+
+    def test_role_specific_in_menu_only(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Role-specific entries should only appear in menu."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert "showrunner_heuristics" in context.entries_in_menu
+        assert "showrunner_heuristics" not in context.entries_inlined
+
+
+class TestKnowledgeContextBuilderLookup:
+    """Tests for lookup (can_lookup) handling."""
+
+    def test_lookup_not_shown(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Lookup entries should not appear in context at all."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # can_lookup entries should not be in menu or inlined
+        assert "accessibility_guidelines" not in context.entries_inlined
+        assert "accessibility_guidelines" not in context.entries_in_menu
+
+
+class TestKnowledgeContextBuilderMenu:
+    """Tests for menu generation."""
+
+    def test_menu_section_generated(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Menu section should be generated when entries are in menu."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert context.menu_section is not None
+        assert "Knowledge Menu" in context.menu_section
+        assert "consult_knowledge" in context.menu_section
+
+    def test_menu_contains_entry_ids(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Menu should contain entry IDs for tool calls."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # Menu entries should include ID for consult_knowledge
+        assert "quality_bars" in context.menu_section
+        assert "showrunner_heuristics" in context.menu_section
+
+    def test_menu_contains_summaries(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Menu should contain summaries."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # Should include summaries
+        assert "8 quality criteria" in context.menu_section
+        assert "showrunner role" in context.menu_section
+
+
+class TestKnowledgeContextBuilderTokenCounting:
+    """Tests for token counting."""
+
+    def test_tokens_used_tracked(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Builder should track tokens used."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        assert context.tokens_used > 0
+
+    def test_token_count_reasonable(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Token count should be reasonable for content."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # Token count should be roughly chars / 4
+        expected_tokens = len(context.context_text) // 4
+        # Allow some variance
+        assert abs(context.tokens_used - expected_tokens) < 100
+
+
+class TestKnowledgeContextBuilderContextText:
+    """Tests for final context text assembly."""
+
+    def test_context_text_assembled(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Context text should contain all sections."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # Should contain constitution
+        assert "Constitution" in context.context_text
+        # Should contain must_know
+        assert "Critical Knowledge" in context.context_text
+        # Should contain menu
+        assert "Knowledge Menu" in context.context_text
+
+    def test_context_text_for_agent_without_requirements(
+        self, mock_agent_no_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Agent without requirements should get empty context."""
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(mock_agent_no_requirements, mock_studio)
+
+        assert context.context_text == ""
+        assert context.constitution_section is None
+        assert context.must_know_section is None
+        assert context.menu_section is None
+
+
+class TestKnowledgeContextBuilderMissingEntries:
+    """Tests for handling missing entries."""
+
+    def test_missing_entry_skipped(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Missing entries should be skipped without error."""
+        # Add reference to nonexistent entry
+        mock_agent_with_requirements.knowledge_requirements.must_know.append("nonexistent")
+
+        builder = KnowledgeContextBuilder()
+        # Should not raise
+        context = builder.build_context(mock_agent_with_requirements, mock_studio)
+
+        # Other entries should still be processed
+        assert "spoiler_hygiene" in context.entries_inlined
+
+
+class TestBuildKnowledgeContextFunction:
+    """Tests for convenience function."""
+
+    def test_builds_context(self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock):
+        """Convenience function should build context."""
+        context = build_knowledge_context(mock_agent_with_requirements, mock_studio)
+
+        assert isinstance(context, KnowledgeContext)
+        assert context.context_text != ""
+
+    def test_accepts_custom_config(
+        self, mock_agent_with_requirements: MagicMock, mock_studio: MagicMock
+    ):
+        """Convenience function should accept custom config."""
+        config = KnowledgeBudgetConfig(must_know_tokens=10)
+        context = build_knowledge_context(mock_agent_with_requirements, mock_studio, config=config)
+
+        assert isinstance(context, KnowledgeContext)
+
+
+class TestKnowledgeContextBuilderIntegration:
+    """Integration tests with real domain data."""
+
+    @pytest.fixture
+    def domain_v4_path(self):
+        """Return path to domain-v4 for integration tests."""
+        from pathlib import Path
+
+        return Path(__file__).parent.parent.parent.parent / "domain-v4"
+
+    async def test_with_real_domain(self, domain_v4_path):
+        """Test with actual domain-v4 data."""
+        from questfoundry.runtime.domain.loader import load_studio
+
+        result = await load_studio(domain_v4_path)
+        if not result.success:
+            pytest.skip(f"Could not load domain: {result.errors}")
+
+        studio = result.studio
+
+        # Find showrunner agent
+        showrunner = next((a for a in studio.agents if a.id == "showrunner"), None)
+        if not showrunner:
+            pytest.skip("Showrunner agent not found")
+
+        # Build context
+        builder = KnowledgeContextBuilder()
+        context = builder.build_context(showrunner, studio)
+
+        # Should have content
+        assert context.context_text != ""
+        assert context.tokens_used > 0
+
+        # Should include must_know entries
+        if showrunner.knowledge_requirements and showrunner.knowledge_requirements.must_know:
+            # At least some must_know should be inlined
+            assert len(context.entries_inlined) > 0
+
+    async def test_all_agents_get_context(self, domain_v4_path):
+        """All agents should be able to get knowledge context."""
+        from questfoundry.runtime.domain.loader import load_studio
+
+        result = await load_studio(domain_v4_path)
+        if not result.success:
+            pytest.skip(f"Could not load domain: {result.errors}")
+
+        studio = result.studio
+        builder = KnowledgeContextBuilder()
+
+        # Build context for each agent - should not raise
+        for agent in studio.agents:
+            context = builder.build_context(agent, studio)
+            assert isinstance(context, KnowledgeContext)

--- a/tests/runtime/tools/test_consult_knowledge.py
+++ b/tests/runtime/tools/test_consult_knowledge.py
@@ -1,0 +1,327 @@
+"""
+Tests for consult_knowledge tool.
+
+This tool retrieves full knowledge content from the studio knowledge base,
+implementing the menu+consult pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.runtime.models.base import KnowledgeEntry
+from questfoundry.runtime.models.enums import KnowledgeLayer
+from questfoundry.runtime.tools import TOOL_IMPLEMENTATIONS, ToolContext, ToolValidationError
+from questfoundry.runtime.tools.consult_knowledge import ConsultKnowledgeTool
+
+
+@pytest.fixture
+def mock_knowledge_entries() -> dict[str, KnowledgeEntry]:
+    """Create mock knowledge entries for testing."""
+    return {
+        "spoiler_hygiene": KnowledgeEntry(
+            id="spoiler_hygiene",
+            name="Spoiler Hygiene",
+            layer=KnowledgeLayer.MUST_KNOW,
+            summary="Never reveal future plot points.",
+            content={
+                "type": "inline",
+                "text": "## Spoiler Hygiene\n\n### Core Principle\n\nNever reveal future plot points.\n\n### Examples\n\nWRONG: The detective will discover the butler did it.\nCORRECT: The detective examines the clues carefully.",
+            },
+            related_entries=["sources_of_truth", "diegetic_gates"],
+        ),
+        "runtime_guidelines": KnowledgeEntry(
+            id="runtime_guidelines",
+            name="Runtime Guidelines",
+            layer=KnowledgeLayer.MUST_KNOW,
+            summary="Guidelines for runtime behavior.",
+            content={
+                "type": "inline",
+                "text": "## Runtime Guidelines\n\n### Tool Usage\n\nAlways use tools for actions.\n\n### Error Handling\n\nHandle errors gracefully.",
+            },
+        ),
+        "empty_entry": KnowledgeEntry(
+            id="empty_entry",
+            name="Empty Entry",
+            layer=KnowledgeLayer.SHOULD_KNOW,
+            summary="Entry with no content.",
+            content=None,
+        ),
+        "structured_entry": KnowledgeEntry(
+            id="structured_entry",
+            name="Structured Entry",
+            layer=KnowledgeLayer.ROLE_SPECIFIC,
+            summary="Entry with structured data.",
+            content={
+                "type": "structured",
+                "data": {"key": "value", "nested": {"inner": "data"}},
+            },
+        ),
+        "corpus_entry": KnowledgeEntry(
+            id="corpus_entry",
+            name="Corpus Entry",
+            layer=KnowledgeLayer.LOOKUP,
+            summary="Entry pointing to corpus.",
+            content={
+                "type": "corpus",
+                "corpus_ref": {"store_ref": "reference_library", "path_pattern": "guides/**"},
+            },
+        ),
+    }
+
+
+@pytest.fixture
+def mock_studio(mock_knowledge_entries: dict[str, KnowledgeEntry]) -> MagicMock:
+    """Create mock studio with knowledge entries."""
+    studio = MagicMock()
+    studio.knowledge = mock_knowledge_entries
+    return studio
+
+
+@pytest.fixture
+def tool_context(mock_studio: MagicMock) -> ToolContext:
+    """Create tool context with mock studio."""
+    context = MagicMock(spec=ToolContext)
+    context.studio = mock_studio
+    context.agent_id = "test_agent"
+    context.broker = None
+    return context
+
+
+@pytest.fixture
+def consult_knowledge_tool(tool_context: ToolContext) -> ConsultKnowledgeTool:
+    """Create ConsultKnowledgeTool instance for testing."""
+    # Get the tool definition from domain
+    definition = MagicMock()
+    definition.id = "consult_knowledge"
+    definition.name = "Consult Knowledge"
+    definition.input_schema = MagicMock()
+    definition.input_schema.properties = {
+        "entry_id": {"type": "string"},
+        "section": {"type": "string"},
+    }
+    definition.input_schema.required = ["entry_id"]
+
+    tool = ConsultKnowledgeTool(definition=definition, context=tool_context)
+    return tool
+
+
+class TestConsultKnowledgeToolRegistration:
+    """Tests for tool registration."""
+
+    def test_tool_is_registered(self):
+        """consult_knowledge should be registered in TOOL_IMPLEMENTATIONS."""
+        assert "consult_knowledge" in TOOL_IMPLEMENTATIONS
+
+    def test_tool_class_is_correct(self):
+        """Registered tool should be ConsultKnowledgeTool."""
+        assert TOOL_IMPLEMENTATIONS["consult_knowledge"] is ConsultKnowledgeTool
+
+
+class TestConsultKnowledgeNoEntryId:
+    """Tests for calling without entry_id."""
+
+    async def test_no_entry_id_returns_available_entries(
+        self, consult_knowledge_tool: ConsultKnowledgeTool
+    ):
+        """Calling without entry_id should list available entries."""
+        result = await consult_knowledge_tool.execute({})
+
+        assert result.success is True
+        assert "available_entries" in result.data
+        assert "spoiler_hygiene" in result.data["available_entries"]
+        assert "runtime_guidelines" in result.data["available_entries"]
+
+    async def test_no_entry_id_includes_hint(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Response should include hint about how to use the tool."""
+        result = await consult_knowledge_tool.execute({})
+
+        assert result.success is True
+        assert "hint" in result.data
+        assert "entry_id" in result.data["hint"].lower()
+
+
+class TestConsultKnowledgeSuccess:
+    """Tests for successful knowledge retrieval."""
+
+    async def test_retrieves_entry_by_id(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Should retrieve full content for valid entry_id."""
+        result = await consult_knowledge_tool.execute({"entry_id": "spoiler_hygiene"})
+
+        assert result.success is True
+        assert result.data["entry_id"] == "spoiler_hygiene"
+        assert result.data["name"] == "Spoiler Hygiene"
+        assert result.data["layer"] == "must_know"
+        assert "Spoiler Hygiene" in result.data["content"]
+
+    async def test_includes_related_entries(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Should include related_entries in response."""
+        result = await consult_knowledge_tool.execute({"entry_id": "spoiler_hygiene"})
+
+        assert result.success is True
+        assert "related_entries" in result.data
+        assert "sources_of_truth" in result.data["related_entries"]
+        assert "diegetic_gates" in result.data["related_entries"]
+
+    async def test_empty_related_entries(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Entry without related entries should return empty list."""
+        result = await consult_knowledge_tool.execute({"entry_id": "runtime_guidelines"})
+
+        assert result.success is True
+        assert result.data["related_entries"] == []
+
+
+class TestConsultKnowledgeSectionExtraction:
+    """Tests for section extraction from content."""
+
+    async def test_extracts_specific_section(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Should extract content from specified section."""
+        result = await consult_knowledge_tool.execute(
+            {
+                "entry_id": "runtime_guidelines",
+                "section": "Tool Usage",
+            }
+        )
+
+        assert result.success is True
+        assert "Tool Usage" in result.data["content"]
+        assert "Error Handling" not in result.data["content"]
+
+    async def test_section_not_found_returns_full_content(
+        self, consult_knowledge_tool: ConsultKnowledgeTool
+    ):
+        """Section not found should return full content with warning."""
+        result = await consult_knowledge_tool.execute(
+            {
+                "entry_id": "spoiler_hygiene",
+                "section": "Nonexistent Section",
+            }
+        )
+
+        assert result.success is True
+        assert "warning" in result.data
+        assert "Nonexistent Section" in result.data["warning"]
+        # Should still have full content
+        assert "Core Principle" in result.data["content"]
+
+
+class TestConsultKnowledgeNotFound:
+    """Tests for entry not found."""
+
+    async def test_unknown_entry_returns_error(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Unknown entry_id should return error."""
+        result = await consult_knowledge_tool.execute({"entry_id": "nonexistent"})
+
+        assert result.success is False
+        assert "nonexistent" in result.error
+        assert "available_entries" in result.data
+
+
+class TestConsultKnowledgeContentTypes:
+    """Tests for different content types."""
+
+    async def test_inline_content(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Inline content should return text directly."""
+        result = await consult_knowledge_tool.execute({"entry_id": "spoiler_hygiene"})
+
+        assert result.success is True
+        assert "Core Principle" in result.data["content"]
+
+    async def test_structured_content(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Structured content should return JSON representation."""
+        result = await consult_knowledge_tool.execute({"entry_id": "structured_entry"})
+
+        assert result.success is True
+        assert "key" in result.data["content"]
+        assert "value" in result.data["content"]
+
+    async def test_corpus_content(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Corpus content should indicate to use consult_corpus tool."""
+        result = await consult_knowledge_tool.execute({"entry_id": "corpus_entry"})
+
+        assert result.success is True
+        assert "corpus" in result.data["content"].lower()
+        assert "consult_corpus" in result.data["content"]
+
+    async def test_empty_content(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Entry without content should indicate no content available."""
+        result = await consult_knowledge_tool.execute({"entry_id": "empty_entry"})
+
+        assert result.success is True
+        assert "No content" in result.data["content"]
+
+
+class TestConsultKnowledgeValidation:
+    """Tests for input validation."""
+
+    async def test_entry_id_must_be_string(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """entry_id must be a string."""
+        with pytest.raises(ToolValidationError, match="entry_id.*must be a string"):
+            consult_knowledge_tool.validate_input({"entry_id": 123})
+
+    async def test_section_must_be_string(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """section must be a string."""
+        with pytest.raises(ToolValidationError, match="section.*must be a string"):
+            consult_knowledge_tool.validate_input(
+                {
+                    "entry_id": "test",
+                    "section": ["invalid"],
+                }
+            )
+
+    async def test_valid_input_passes(self, consult_knowledge_tool: ConsultKnowledgeTool):
+        """Valid input should pass validation."""
+        # Should not raise
+        consult_knowledge_tool.validate_input(
+            {
+                "entry_id": "spoiler_hygiene",
+                "section": "Core Principle",
+            }
+        )
+
+
+class TestConsultKnowledgeIntegration:
+    """Integration tests with real domain data."""
+
+    @pytest.fixture
+    def domain_v4_path(self):
+        """Return path to domain-v4 for integration tests."""
+        from pathlib import Path
+
+        return Path(__file__).parent.parent.parent.parent / "domain-v4"
+
+    async def test_with_real_domain(self, domain_v4_path):
+        """Test with actual domain-v4 knowledge entries."""
+        from questfoundry.runtime.domain.loader import load_studio
+
+        result = await load_studio(domain_v4_path)
+        if not result.success:
+            pytest.skip(f"Could not load domain: {result.errors}")
+
+        studio = result.studio
+
+        # Should have knowledge entries
+        assert len(studio.knowledge) > 0
+        assert "spoiler_hygiene" in studio.knowledge
+
+        # Create tool context with real studio
+        context = MagicMock(spec=ToolContext)
+        context.studio = studio
+        context.agent_id = "test_agent"
+        context.broker = None
+
+        definition = MagicMock()
+        definition.id = "consult_knowledge"
+        definition.name = "Consult Knowledge"
+        definition.input_schema = MagicMock()
+        definition.input_schema.properties = {}
+        definition.input_schema.required = []
+
+        tool = ConsultKnowledgeTool(definition=definition, context=context)
+
+        # Test retrieval
+        result = await tool.execute({"entry_id": "spoiler_hygiene"})
+        assert result.success is True
+        assert "Spoiler" in result.data["content"]


### PR DESCRIPTION
## Summary

Implements issue #162 - Knowledge Layers & consult_knowledge Tool

### consult_knowledge Tool
- Retrieve full knowledge content from studio knowledge base
- Section extraction from markdown content  
- Handles inline, structured, file_ref, and corpus content types
- Lists available entries when called without entry_id

### KnowledgeContextBuilder
- Budget-aware knowledge injection for agent prompts
- Follows menu+consult pattern from `meta/docs/knowledge-patterns.md`
- Knowledge layers:
  - `constitution`: Always inline (inviolable principles)
  - `must_know`: Inline up to budget, overflow to menu
  - `should_know`: Menu only (summary with consult hint)
  - `role_specific`: Menu only (specialist reference)
  - `lookup`: Never shown (query via tool only)
- Token counting with chars/4 approximation

### Domain Loader Updates
- Load knowledge entries from `knowledge/` directory
- Enhanced KnowledgeEntry model with KnowledgeContent
- Support for KnowledgeApplicability

### Files Changed
- `src/questfoundry/runtime/tools/consult_knowledge.py` (NEW)
- `src/questfoundry/runtime/agent/knowledge.py` (NEW)
- `src/questfoundry/runtime/models/base.py` (MODIFIED)
- `src/questfoundry/runtime/domain/loader.py` (MODIFIED)
- `src/questfoundry/runtime/agent/context.py` (MODIFIED)
- `tests/runtime/tools/test_consult_knowledge.py` (NEW)
- `tests/runtime/agent/test_knowledge.py` (NEW)

## Test plan
- [x] 42 new tests covering all functionality
- [x] Integration tests with real domain-v4 data
- [x] All 592 runtime tests pass
- [ ] CI passes

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)