### PR TITLE
feat(domain): rebalance Showrunner knowledge for prompt size reduction (#163)

### DIFF
--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -126,7 +126,8 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene", "sources_of_truth", "quality_bars_overview", "showrunner_operating_principles", "runtime_guidelines"],
+    "must_know": ["runtime_guidelines_core"],
+    "should_know": ["spoiler_hygiene", "sources_of_truth", "quality_bars_overview", "showrunner_operating_principles", "runtime_guidelines"],
     "role_specific": []
   },
 

--- a/domain-v4/knowledge/must_know/runtime_guidelines_core.json
+++ b/domain-v4/knowledge/must_know/runtime_guidelines_core.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "runtime_guidelines_core",
+  "name": "Runtime Guidelines (Core)",
+  "layer": "must_know",
+
+  "summary": "Essential orchestrator rules: tools-only output, no prose generation.",
+
+  "keywords": ["runtime", "tools", "orchestrator", "rules"],
+
+  "triggers": [
+    "how to behave",
+    "core rules",
+    "what not to do"
+  ],
+
+  "content": {
+    "type": "inline",
+    "format": "markdown",
+    "text": "## Core Orchestrator Rules\n\n1. **All output via tools** - Use delegate(), communicate(), terminate()\n2. **Never generate story prose** - If writing narrative, STOP and delegate\n3. **Coordinate specialists, don't create** - You orchestrate, they produce\n4. **Consult knowledge for details** - Use consult_knowledge for detailed guidance\n\n### Stop Conditions\n- Terminate when all artifacts validated and promoted to canon\n- Do NOT terminate while content awaits validation\n\n### Critical Anti-Pattern\nIf your response contains more than 2-3 sentences that aren't a tool call, you're doing it wrong. Delegate instead."
+  },
+
+  "applicable_to": {
+    "archetypes": ["orchestrator"]
+  },
+
+  "related_entries": ["runtime_guidelines"],
+
+  "tags": ["runtime", "tools", "orchestrator", "core"]
+}

--- a/meta/schemas/core/agent.schema.json
+++ b/meta/schemas/core/agent.schema.json
@@ -105,6 +105,12 @@
           "default": [],
           "description": "IDs of must-know knowledge entries to include in system prompt"
         },
+        "should_know": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "IDs of should-know knowledge entries shown in menu with summary, full content via consult_knowledge tool"
+        },
         "role_specific": {
           "type": "array",
           "items": { "type": "string" },


### PR DESCRIPTION
## Summary

- Create `runtime_guidelines_core.json` with essential orchestrator rules
- Rebalance Showrunner's `must_know` from 5 entries to 1 (runtime_guidelines_core)
- Add `should_know` for consultable entries (menu+consult pattern)

## Changes

**New file:** `domain-v4/knowledge/must_know/runtime_guidelines_core.json`
- Contains only the 4 core orchestrator rules
- ~320 tokens vs ~800 tokens for full `runtime_guidelines.json`

**Modified:** `domain-v4/agents/showrunner.json`
- `must_know`: `["runtime_guidelines_core"]` (was 5 entries)
- Added `should_know`: spoiler_hygiene, sources_of_truth, quality_bars_overview, showrunner_operating_principles, runtime_guidelines

## Token Savings

| Component | Before | After |
|-----------|--------|-------|
| must_know entries | ~5000 tokens | ~320 tokens |
| Total inline | ~7500 tokens | ~3320 tokens |

## Notes

- All knowledge entries already had `summary` fields (no changes needed)
- Other agents (plotwright, scene_smith) have 3 must_know entries but totaling ~7KB which is more manageable
- Full `runtime_guidelines.json` remains available via `consult_knowledge` tool

Closes #163

## Test plan

- [x] All 626 tests pass
- [x] Domain loader validates all JSON
- [x] No breaking changes to runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)