### PR TITLE
fix(runtime): handle communicate tool in non-interactive mode

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -904,7 +904,8 @@ async def _handle_clarification_requests(
 
     for request in clarification_requests:
         payload = request.payload
-        question = payload.get("question", "")
+        # communicate tool uses "message" field for the question text
+        question = payload.get("message", "") or payload.get("question", "")
         context = payload.get("context")
         options = payload.get("options", [])
         default_option = payload.get("default_option")

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -584,9 +584,8 @@ class AgentRuntime:
                 if isinstance(result, dict) and result.get("success", True):
                     # For communicate tool, only stop if it's blocking (question type)
                     # Non-blocking types (status, notification, error with low severity) continue
-                    if tc.tool_id == "communicate" and not result.get("data", {}).get(
-                        "blocking", False
-                    ):
+                    # Note: tc.result is already result.data, not the full ToolResult
+                    if tc.tool_id == "communicate" and not result.get("blocking", False):
                         continue  # Non-blocking communicate, don't stop
                     return tc.tool_id, result
         return None, None

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -88,7 +88,8 @@ STOP_TOOL_NAMES = frozenset(
         "delegate",  # Delegation to another agent
         "terminate",  # End workflow
         "return_to_orchestrator",  # Delegatee returns to orchestrator
-        "request_clarification",  # Ask human for clarification
+        "request_clarification",  # Ask human for clarification (legacy)
+        "communicate",  # Human communication (questions are blocking)
     }
 )
 
@@ -581,6 +582,12 @@ class AgentRuntime:
                 # Parse result to check if it actually succeeded
                 result = tc.result
                 if isinstance(result, dict) and result.get("success", True):
+                    # For communicate tool, only stop if it's blocking (question type)
+                    # Non-blocking types (status, notification, error with low severity) continue
+                    if tc.tool_id == "communicate" and not result.get("data", {}).get(
+                        "blocking", False
+                    ):
+                        continue  # Non-blocking communicate, don't stop
                     return tc.tool_id, result
         return None, None
 

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -94,6 +94,9 @@ class ToolContext:
     # Additional context that may be needed
     domain_path: Path | None = None  # Path to domain directory
 
+    # Interactive mode flag - tools requiring human input should check this
+    interactive: bool = True
+
 
 class BaseTool(ABC):
     """

--- a/src/questfoundry/runtime/tools/communicate.py
+++ b/src/questfoundry/runtime/tools/communicate.py
@@ -96,6 +96,39 @@ class CommunicateTool(BaseTool):
                 f"Invalid communication type '{comm_type_str}'. Valid types: {valid_types}"
             ) from None
 
+        # In non-interactive mode, questions cannot be asked
+        if comm_type == CommunicationType.QUESTION and not self._context.interactive:
+            logger.warning(
+                "Question communication blocked in non-interactive mode: %s",
+                message_text[:50] + "..." if len(message_text) > 50 else message_text,
+            )
+            # If default_option is provided, auto-select it
+            if default_option:
+                logger.info(
+                    "Auto-selecting default option '%s' in non-interactive mode", default_option
+                )
+                return ToolResult(
+                    success=True,
+                    data={
+                        "type": comm_type.value,
+                        "status": "auto_answered",
+                        "message": message_text,
+                        "response": {"selected": default_option},
+                        "non_interactive": True,
+                    },
+                )
+            # No default - return error
+            return ToolResult(
+                success=False,
+                data={
+                    "type": comm_type.value,
+                    "status": "blocked",
+                    "message": message_text,
+                    "non_interactive": True,
+                },
+                error="Cannot ask questions in non-interactive mode (no default_option provided)",
+            )
+
         # Parse severity for errors
         try:
             severity = ErrorSeverity(severity_str)

--- a/src/questfoundry/runtime/tools/registry.py
+++ b/src/questfoundry/runtime/tools/registry.py
@@ -50,8 +50,11 @@ def register_tool(tool_id: str) -> Callable[[type[BaseTool]], type[BaseTool]]:
     return decorator
 
 
-# Tools that require interactive mode (human input via terminal)
-INTERACTIVE_ONLY_TOOLS = frozenset({"request_clarification"})
+# Tools that are completely disabled in non-interactive mode.
+# Note: The 'communicate' tool handles non-interactive mode internally:
+# - status, notification, error types still work
+# - question type auto-selects default_option or returns error
+INTERACTIVE_ONLY_TOOLS = frozenset({"request_clarification"})  # Deprecated, replaced by communicate
 
 
 class ToolRegistry:
@@ -138,6 +141,7 @@ class ToolRegistry:
             session_id=session_id,
             domain_path=self._domain_path,
             broker=self._broker,
+            interactive=self._interactive,
         )
 
         # Get implementation class

--- a/tests/runtime/tools/test_communicate.py
+++ b/tests/runtime/tools/test_communicate.py
@@ -599,3 +599,135 @@ class TestErrorSeverityEnum:
         assert ErrorSeverity.INFO.value == "info"
         assert ErrorSeverity.WARNING.value == "warning"
         assert ErrorSeverity.ERROR.value == "error"
+
+
+class TestCommunicateToolNonInteractiveMode:
+    """Tests for non-interactive mode behavior."""
+
+    @pytest.fixture
+    def non_interactive_context(
+        self, mock_studio: MagicMock, mock_broker: AsyncMock
+    ) -> ToolContext:
+        """Create a non-interactive tool context."""
+        return ToolContext(
+            studio=mock_studio,
+            agent_id="showrunner",
+            session_id="test_session",
+            broker=mock_broker,
+            interactive=False,
+        )
+
+    @pytest.fixture
+    def non_interactive_tool(
+        self, mock_tool_definition: MagicMock, non_interactive_context: ToolContext
+    ) -> CommunicateTool:
+        """Create a communicate tool in non-interactive mode."""
+        return CommunicateTool(mock_tool_definition, non_interactive_context)
+
+    async def test_question_blocked_without_default(
+        self, non_interactive_tool: CommunicateTool
+    ) -> None:
+        """Question without default_option should fail in non-interactive mode."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "question",
+                "message": "What tone do you prefer?",
+            }
+        )
+
+        assert result.success is False
+        assert result.data["type"] == "question"
+        assert result.data["status"] == "blocked"
+        assert result.data["non_interactive"] is True
+        assert "Cannot ask questions in non-interactive mode" in result.error
+
+    async def test_question_auto_answered_with_default(
+        self, non_interactive_tool: CommunicateTool
+    ) -> None:
+        """Question with default_option should auto-select in non-interactive mode."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "question",
+                "message": "What tone do you prefer?",
+                "options": [
+                    {"id": "dark", "description": "Dark and serious"},
+                    {"id": "light", "description": "Light and fun"},
+                ],
+                "default_option": "light",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "question"
+        assert result.data["status"] == "auto_answered"
+        assert result.data["response"]["selected"] == "light"
+        assert result.data["non_interactive"] is True
+
+    async def test_status_still_works(
+        self, non_interactive_tool: CommunicateTool, mock_broker: AsyncMock
+    ) -> None:
+        """Status messages should still work in non-interactive mode."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "status",
+                "message": "Processing request...",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "status"
+        assert result.data["delivered"] is True
+        mock_broker.send.assert_called_once()
+
+    async def test_notification_still_works(
+        self, non_interactive_tool: CommunicateTool, mock_broker: AsyncMock
+    ) -> None:
+        """Notification messages should still work in non-interactive mode."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "notification",
+                "message": "Chapter 1 complete.",
+                "artifacts": ["workspace:section:chapter_1"],
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "notification"
+        assert result.data["delivered"] is True
+        mock_broker.send.assert_called_once()
+
+    async def test_error_still_works(
+        self, non_interactive_tool: CommunicateTool, mock_broker: AsyncMock
+    ) -> None:
+        """Error messages should still work in non-interactive mode."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "error",
+                "message": "Failed to connect.",
+                "severity": "warning",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["type"] == "error"
+        assert result.data["delivered"] is True
+        mock_broker.send.assert_called_once()
+
+    async def test_question_blocked_with_options_no_default(
+        self, non_interactive_tool: CommunicateTool
+    ) -> None:
+        """Question with options but no default should still fail."""
+        result = await non_interactive_tool.execute(
+            {
+                "type": "question",
+                "message": "Choose a theme",
+                "options": [
+                    {"id": "fantasy", "description": "Fantasy world"},
+                    {"id": "scifi", "description": "Science fiction"},
+                ],
+            }
+        )
+
+        assert result.success is False
+        assert result.data["status"] == "blocked"
+        assert "no default_option provided" in result.error

--- a/tests/runtime/tools/test_registry.py
+++ b/tests/runtime/tools/test_registry.py
@@ -226,3 +226,41 @@ class TestBuildAgentTools:
         tool_ids = {t.id for t in tools}
         assert "consult_schema" in tool_ids
         assert "delegate" in tool_ids
+
+
+class TestToolRegistryInteractiveMode:
+    """Tests for interactive mode handling in ToolRegistry."""
+
+    def test_default_interactive_mode(self):
+        """Registry should default to interactive mode."""
+        studio, _ = make_mock_studio_with_tools()
+        registry = ToolRegistry(studio)
+
+        tool = registry.get_tool("consult_schema")
+        assert tool.context.interactive is True
+
+    def test_non_interactive_mode_passed_to_tool(self):
+        """Non-interactive flag should be passed to tool context."""
+        studio, _ = make_mock_studio_with_tools()
+        registry = ToolRegistry(studio, interactive=False)
+
+        tool = registry.get_tool("consult_schema")
+        assert tool.context.interactive is False
+
+    def test_interactive_mode_passed_to_tool(self):
+        """Interactive flag should be passed to tool context."""
+        studio, _ = make_mock_studio_with_tools()
+        registry = ToolRegistry(studio, interactive=True)
+
+        tool = registry.get_tool("consult_schema")
+        assert tool.context.interactive is True
+
+    def test_non_interactive_mode_for_agent_tools(self):
+        """Non-interactive flag should be passed to all agent tools."""
+        studio, agent = make_mock_studio_with_tools()
+        registry = ToolRegistry(studio, interactive=False)
+
+        tools = registry.get_agent_tools(agent)
+
+        for tool in tools:
+            assert tool.context.interactive is False


### PR DESCRIPTION
## Summary

Multiple bug fixes for the communicate tool and non-interactive mode:

### Fix 1: Non-interactive mode for communicate tool
The communicate tool now properly handles `--no-interactive` mode:
- Question types are blocked (return error if no `default_option`)
- If `default_option` provided, auto-select it and return success
- Status, notification, and error types still work (useful for logging)

### Fix 2: CLI field name mismatch
The CLI handler for clarification requests was looking for `"question"` field but the communicate tool sends `"message"`. Fixed to check both fields.

### Fix 3: Communicate not a stop tool
The `communicate` tool was missing from `STOP_TOOL_NAMES`, so questions didn't pause the runtime to wait for user input. Added `communicate` to stop tools with a check that only blocks for `blocking=True` (question type).

## Changes

**Runtime tools:**
- Add `interactive` flag to `ToolContext` (base.py)
- Pass `interactive` flag from `ToolRegistry` to `ToolContext`
- Update communicate tool to check interactive mode for questions
- Add comprehensive tests for non-interactive mode behavior

**Runtime agent:**
- Add `communicate` to `STOP_TOOL_NAMES`
- Check `blocking` flag to only stop for questions, not status/notification/error

**CLI:**
- Fix field name lookup in `_handle_clarification_requests` to read `"message"` field

## Test plan

- [x] All 626 runtime tests pass
- [x] Non-interactive mode test: `qf ask --no-interactive` completes without prompts
- [ ] Interactive mode test: `qf ask --interactive` should show questions and wait for input

Test command:
```bash
uv run qf ask -v -p ollama --interactive --log --no-stream test2 "ask the customer for a genre and a length. then make a plot for that"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)