### PR TITLE
feat(runtime): implement Secretary pattern for context management

### DIFF
--- a/domain-v4/tools/assemble_export.json
+++ b/domain-v4/tools/assemble_export.json
@@ -4,6 +4,8 @@
   "name": "Assemble Export",
   "description": "Assemble a player-safe export bundle from a Canon snapshot. Compiles manuscript, codex, and optional assets into distributable formats (MD/HTML/EPUB/PDF). Validates link integrity, generates navigation, and stamps front matter.\n\nThis tool does NOT edit content - it packages what exists. If integrity issues are found, they're reported for upstream fixes.",
 
+  "summarization_policy": "preserve",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/communicate.json
+++ b/domain-v4/tools/communicate.json
@@ -5,6 +5,7 @@
   "description": "Send a message to the human customer. This is the ONLY way orchestrators communicate with humans - all output must go through this tool.\n\nMessage types:\n- status: Brief progress update (non-blocking)\n- question: Need input from customer (blocks until answered)\n- notification: Deliverable ready or milestone reached (non-blocking)\n- error: Something failed or needs attention (may block depending on severity)\n\nOrchestrators must end every turn with either this tool or delegate.",
 
   "terminates_turn": true,
+  "summarization_policy": "preserve",
 
   "input_schema": {
     "type": "object",

--- a/domain-v4/tools/consult_corpus.json
+++ b/domain-v4/tools/consult_corpus.json
@@ -4,6 +4,9 @@
   "name": "Consult Corpus",
   "description": "Search the craft corpus for writing guidance and genre conventions. Use this for prose techniques, choice architecture, diegetic interface patterns, world consistency, genre conventions (fantasy/mystery/horror), and common pitfalls to avoid. Returns relevant excerpts with source attribution.\n\nPattern: consult-corpus - agent searches internal craft knowledge, NOT external web facts.",
 
+  "summarization_policy": "drop",
+  "summary_template": "Retrieved {excerpt_count} excerpts from corpus",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/consult_knowledge.json
+++ b/domain-v4/tools/consult_knowledge.json
@@ -4,6 +4,9 @@
   "name": "Consult Knowledge",
   "description": "Retrieve detailed guidance from the studio knowledge base. Use this when you need full content for entries shown in your Knowledge Menu.\n\nThe Knowledge Menu in your system prompt shows summaries of available knowledge. Use this tool to get the complete content when you need detailed guidance, examples, or procedures.\n\nCommon uses:\n- Get detailed examples when summary is insufficient\n- Retrieve full procedures or checklists\n- Access domain-specific guidance for specialized tasks",
 
+  "summarization_policy": "drop",
+  "summary_template": "Retrieved knowledge: {name}",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/consult_playbook.json
+++ b/domain-v4/tools/consult_playbook.json
@@ -4,6 +4,9 @@
   "name": "Consult Playbook",
   "description": "Retrieve full details for a playbook/workflow. REQUIRED: You MUST provide the playbook_id parameter (e.g., 'story_spark'). Returns the sequence of phases and steps, which agents handle each step, input/output artifacts, completion criteria, and quality checkpoints. Use this to understand how to orchestrate a workflow.",
 
+  "summarization_policy": "drop",
+  "summary_template": "Retrieved playbook: {name}",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/consult_schema.json
+++ b/domain-v4/tools/consult_schema.json
@@ -4,6 +4,9 @@
   "name": "Consult Schema",
   "description": "Retrieve the schema definition for an artifact type. Returns the field definitions, validation rules, and lifecycle states for the specified artifact type. Use this to understand the structure of artifacts before creating or validating them.\n\nPattern: consult-schema - agent asks for schema, gets both structure and documentation.",
 
+  "summarization_policy": "drop",
+  "summary_template": "Schema for {artifact_type_id} retrieved",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/delegate.json
+++ b/domain-v4/tools/delegate.json
@@ -5,6 +5,8 @@
   "description": "Formally assign work to another agent. Creates a delegation request with context, expected outputs, and quality criteria. The receiving agent will be notified and can accept, request clarification, or report completion.\n\nDelegation is the primary mechanism for work distribution in the studio. The Showrunner uses this extensively to route work to specialized agents.\n\nSee: delegation.schema.json for the full delegation protocol.",
 
   "terminates_turn": true,
+  "summarization_policy": "ultra_concise",
+  "summary_template": "Delegated to {assigned_to}: {task}",
 
   "input_schema": {
     "type": "object",

--- a/domain-v4/tools/generate_audio.json
+++ b/domain-v4/tools/generate_audio.json
@@ -4,6 +4,9 @@
   "name": "Generate Audio",
   "description": "Generate an audio asset from an Audio Plan. Consults Style Guide for sonic aesthetic. Returns an audio asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Audio Plans should exist for ALL worthy moments, but generation is selective based on priority.\n\nRuntime provides implementation (TTS, music generation, sound library, commission queue, etc.).",
 
+  "summarization_policy": "ultra_concise",
+  "summary_template": "Generated audio from {source_plan}",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/generate_image.json
+++ b/domain-v4/tools/generate_image.json
@@ -4,6 +4,9 @@
   "name": "Generate Image",
   "description": "Generate an illustration from an Art Plan. Consults Reference Sheets for visual consistency of recurring elements (characters, locations, objects). Returns an image asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Art Plans should exist for ALL worthy scenes, but generation is selective based on priority.\n\nRuntime provides implementation (DALL-E, Stable Diffusion, commission queue, etc.).",
 
+  "summarization_policy": "ultra_concise",
+  "summary_template": "Generated image from {source_plan}",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/list_agents.json
+++ b/domain-v4/tools/list_agents.json
@@ -4,6 +4,9 @@
   "name": "List Agents",
   "description": "List all agents available for delegation. Use this to discover what specialist agents exist and their archetypes before delegating work. Returns a compact list with id, name, archetypes, and brief description.",
 
+  "summarization_policy": "drop",
+  "summary_template": "Listed {count} agents",
+
   "input_schema": {
     "type": "object",
     "properties": {},

--- a/domain-v4/tools/list_artifact_types.json
+++ b/domain-v4/tools/list_artifact_types.json
@@ -4,6 +4,9 @@
   "name": "List Artifact Types",
   "description": "List all available artifact types with brief descriptions. Use this to discover what artifact types exist before consulting their full schemas. Returns a compact list with id, name, category, and brief description for each type.",
 
+  "summarization_policy": "drop",
+  "summary_template": "Listed {count} artifact types",
+
   "input_schema": {
     "type": "object",
     "properties": {},

--- a/domain-v4/tools/list_stores.json
+++ b/domain-v4/tools/list_stores.json
@@ -4,6 +4,9 @@
   "name": "List Stores",
   "description": "List all available stores with their semantics and descriptions. Use this to discover what stores exist and understand their access patterns (hot, cold, versioned, ephemeral).",
 
+  "summarization_policy": "drop",
+  "summary_template": "Listed {count} stores",
+
   "input_schema": {
     "type": "object",
     "properties": {},

--- a/domain-v4/tools/search_workspace.json
+++ b/domain-v4/tools/search_workspace.json
@@ -4,6 +4,9 @@
   "name": "Search Workspace",
   "description": "Search for artifacts in the Hot SoT (workspace store). Supports filtering by artifact type, lifecycle state, and text search within fields. Returns matching artifacts with their current state.\n\nUse this to find:\n- Drafts in progress\n- Section briefs ready for implementation\n- Hooks awaiting triage\n- Related artifacts for context",
 
+  "summarization_policy": "concise",
+  "summary_template": "Found {total_count} artifacts matching query",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/validate_artifact.json
+++ b/domain-v4/tools/validate_artifact.json
@@ -4,6 +4,8 @@
   "name": "Validate Artifact",
   "description": "Validate an artifact against its type schema and the 8 quality bars. Returns validation results with specific errors and suggested fixes.\n\nQuality Bars checked:\n1. Integrity - No contradictions or dead links\n2. Reachability - Critical content accessible\n3. Nonlinearity - Branches matter\n4. Gateways - Conditions enforceable\n5. Style - Voice consistent\n6. Determinism - Reproducible where promised\n7. Presentation - Spoiler-safe\n8. Accessibility - Navigation clear\n\nPattern: validate-with-feedback - strict validation, clear rejection messages with remediation guidance.",
 
+  "summarization_policy": "preserve",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/web_fetch.json
+++ b/domain-v4/tools/web_fetch.json
@@ -5,7 +5,7 @@
   "description": "Fetch and extract content from a specific URL. Returns cleaned text content from the page, suitable for reading and analysis. Handles HTML cleanup, removes navigation/ads, and extracts main content.\n\nBest for: deep-diving a specific source, reading full articles, extracting detailed information.\nFor discovering sources, use web_search first.",
 
   "summarization_policy": "concise",
-  "summary_template": "Fetched '{title}' ({word_count} words)",
+  "summary_template": "Fetched content from {url}",
 
   "input_schema": {
     "type": "object",

--- a/domain-v4/tools/web_fetch.json
+++ b/domain-v4/tools/web_fetch.json
@@ -4,6 +4,9 @@
   "name": "Web Fetch",
   "description": "Fetch and extract content from a specific URL. Returns cleaned text content from the page, suitable for reading and analysis. Handles HTML cleanup, removes navigation/ads, and extracts main content.\n\nBest for: deep-diving a specific source, reading full articles, extracting detailed information.\nFor discovering sources, use web_search first.",
 
+  "summarization_policy": "concise",
+  "summary_template": "Fetched '{title}' ({word_count} words)",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/domain-v4/tools/web_search.json
+++ b/domain-v4/tools/web_search.json
@@ -5,7 +5,7 @@
   "description": "Search the web for factual information. Returns a list of relevant results with titles, snippets, and URLs. Use this to find sources for verification, corroborate claims, or discover current information.\n\nBest for: broad queries, finding multiple sources, discovering what exists.\nFor deep-diving a specific page, use web_fetch instead.",
 
   "summarization_policy": "concise",
-  "summary_template": "Web search for '{query_used}': found results",
+  "summary_template": "Web search for '{query}': found results",
 
   "input_schema": {
     "type": "object",

--- a/domain-v4/tools/web_search.json
+++ b/domain-v4/tools/web_search.json
@@ -4,6 +4,9 @@
   "name": "Web Search",
   "description": "Search the web for factual information. Returns a list of relevant results with titles, snippets, and URLs. Use this to find sources for verification, corroborate claims, or discover current information.\n\nBest for: broad queries, finding multiple sources, discovering what exists.\nFor deep-diving a specific page, use web_fetch instead.",
 
+  "summarization_policy": "concise",
+  "summary_template": "Web search for '{query_used}': found results",
+
   "input_schema": {
     "type": "object",
     "properties": {

--- a/meta/schemas/core/tool-definition.schema.json
+++ b/meta/schemas/core/tool-definition.schema.json
@@ -70,6 +70,16 @@
       "type": "boolean",
       "default": false,
       "description": "If true, calling this tool ends the agent's turn. Runtime enforces: orchestrator agents MUST end every turn with a terminating tool call (e.g., delegate, communicate). Non-orchestrators may use prose output."
+    },
+
+    "summarization_policy": {
+      "$ref": "#/$defs/summarization_policy",
+      "description": "How to summarize this tool's result when context needs to be compressed. Used by the Secretary pattern to manage context growth."
+    },
+
+    "summary_template": {
+      "type": "string",
+      "description": "Template for concise/ultra_concise summaries. Variables in {braces} are replaced from tool result. Example: 'Delegated to {to_agent}' or 'Schema for {artifact_type} retrieved'."
     }
   },
 
@@ -177,6 +187,13 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "summarization_policy": {
+      "type": "string",
+      "enum": ["drop", "ultra_concise", "concise", "preserve"],
+      "default": "preserve",
+      "description": "Policy for summarizing tool results when compressing context:\n- drop: Remove from summarized context (tool can be re-called if needed, e.g., schema lookups)\n- ultra_concise: Single-line summary using summary_template (e.g., 'Delegated to Plotwright')\n- concise: Brief multi-line summary preserving key facts\n- preserve: Keep full result in context (default, for critical data)"
     }
   }
 }

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -29,19 +29,31 @@ if TYPE_CHECKING:
     from questfoundry.runtime.session import Session
     from questfoundry.runtime.storage import Project
 from rich.console import Console
-from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.table import Table
+
+from questfoundry.cli_output import StatusReporter, create_log_handler
 
 # Global verbosity level (set by callback)
 _verbosity: int = 0
 
+# Main output console (stdout)
 console = Console()
+
+# Log console (stderr) - for logs, separated from user output
+log_console = Console(stderr=True)
+
+# Status reporter for structured output
+_status_reporter: StatusReporter | None = None
 
 
 def _configure_logging(verbosity: int) -> None:
-    """Configure logging based on verbosity level."""
-    global _verbosity
+    """Configure logging based on verbosity level.
+
+    Routes all logs to stderr via log_console, keeping stdout clean
+    for structured status output.
+    """
+    global _verbosity, _status_reporter
     _verbosity = verbosity
 
     if verbosity == 0:
@@ -51,17 +63,28 @@ def _configure_logging(verbosity: int) -> None:
     else:  # 2+
         level = logging.DEBUG
 
-    # Configure root logger with Rich handler
+    # Configure root logger with Rich handler on STDERR
+    # This keeps stdout clean for structured status output
+    handler = create_log_handler(log_console, verbosity)
     logging.basicConfig(
         level=level,
         format="%(message)s",
         datefmt="[%X]",
-        handlers=[RichHandler(console=console, rich_tracebacks=True, show_path=verbosity >= 2)],
+        handlers=[handler],
         force=True,
     )
 
     # Also set questfoundry logger
     logging.getLogger("questfoundry").setLevel(level)
+
+    # Filter noisy libraries at lower verbosities
+    if verbosity < 2:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
+        logging.getLogger("langsmith").setLevel(logging.WARNING)
+
+    # Create status reporter
+    _status_reporter = StatusReporter(verbosity=verbosity, show_summary=True)
 
 
 def _verbosity_callback(_ctx: typer.Context, value: int) -> int:
@@ -759,7 +782,25 @@ async def _stream_response(
 
     duration_ms = (time.time() - start_time) * 1000
 
-    # Show token usage at -v+
+    # Get turn number from session (turn was created during streaming)
+    turn_number = session.turn_count
+
+    # Build usage from streaming chunk for turn completion
+    from questfoundry.runtime.session import TokenUsage
+
+    usage = None
+    if final_usage:
+        usage = TokenUsage(
+            prompt_tokens=final_usage.prompt_tokens,
+            completion_tokens=final_usage.completion_tokens,
+            total_tokens=final_usage.total_tokens,
+        )
+
+    # Report turn completion via status reporter
+    if _status_reporter:
+        _status_reporter.turn_complete(usage=usage, duration_ms=duration_ms)
+
+    # Show token usage at -v+ (to stderr)
     if _verbosity >= 1 and final_usage:
         tokens_info = []
         if final_usage.prompt_tokens:
@@ -769,30 +810,32 @@ async def _stream_response(
         if final_usage.total_tokens:
             tokens_info.append(f"total: {final_usage.total_tokens}")
         if tokens_info:
-            console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
+            log_console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
 
-    # Show timing at -vv+
+    # Show timing at -vv+ (to stderr)
     if _verbosity >= 2:
-        console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
+        log_console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
         logger.debug(f"Response generated in {duration_ms:.0f}ms")
 
     # Process any pending delegations
     if process_delegations:
         delegation_results = await runtime.process_pending_delegations(session)
         if delegation_results:
-            console.print()
-            console.print(f"[dim]── Processed {len(delegation_results)} delegation(s) ──[/dim]")
-            for result in delegation_results:
-                status = "[green]✓[/green]" if result.get("success") else "[red]✗[/red]"
-                to_agent = result.get("to_agent", "unknown")
-                task_preview = result.get("task", "")[:40]
-                console.print(f"  {status} {to_agent}: {task_preview}...")
-                if result.get("success") and _verbosity >= 2:
-                    # Show delegatee response at -vv+
-                    response_preview = str(result.get("result", ""))[:200]
-                    console.print(f"    [dim]{response_preview}...[/dim]")
-                elif not result.get("success"):
-                    console.print(f"    [red]{result.get('error', 'Unknown error')}[/red]")
+            for dr in delegation_results:
+                to_agent = dr.get("to_agent", "unknown")
+                task = dr.get("task", "")
+                success = dr.get("success", False)
+
+                # Report via status reporter
+                if _status_reporter:
+                    _status_reporter.delegation_complete(
+                        from_agent=agent.id,
+                        to_agent=to_agent,
+                        task=task,
+                        success=success,
+                        turn_number=turn_number,
+                        error=dr.get("error") if not success else None,
+                    )
 
     return full_content
 
@@ -838,7 +881,31 @@ async def _invoke_response(
 
     duration_ms = (time.time() - start_time) * 1000
 
-    # Show token usage at -v+
+    # Report tool calls and artifacts via StatusReporter
+    if _status_reporter and result.tool_calls:
+        for tc in result.tool_calls:
+            _status_reporter.tool_call(
+                tool_id=tc.tool_id,
+                success=tc.success,
+                agent_id=agent.id,
+                turn_number=result.turn.turn_number,
+                execution_time_ms=tc.execution_time_ms,
+            )
+            # Check if this was a save_artifact call
+            if tc.tool_id == "save_artifact" and tc.success and tc.result:
+                _status_reporter.artifact_created(
+                    artifact_id=tc.result.get("artifact_id", "unknown"),
+                    artifact_type=tc.result.get("artifact", {}).get("_type", "unknown"),
+                    store=tc.result.get("store", "unknown"),
+                    created_by=agent.id,
+                    turn_number=result.turn.turn_number,
+                )
+
+    # Report turn completion
+    if _status_reporter:
+        _status_reporter.turn_complete(usage=result.usage, duration_ms=duration_ms)
+
+    # Show token usage at -v+ (also goes to log_console now)
     if _verbosity >= 1 and result.usage:
         tokens_info = []
         if result.usage.prompt_tokens:
@@ -848,29 +915,32 @@ async def _invoke_response(
         if result.usage.total_tokens:
             tokens_info.append(f"total: {result.usage.total_tokens}")
         if tokens_info:
-            console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
+            log_console.print(f"[dim]tokens: {', '.join(tokens_info)}[/dim]")
 
     # Show timing at -vv+
     if _verbosity >= 2:
-        console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
+        log_console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
         logger.debug(f"Response generated in {duration_ms:.0f}ms")
 
     # Process any pending delegations
     if process_delegations:
         delegation_results = await runtime.process_pending_delegations(session)
         if delegation_results:
-            console.print()
-            console.print(f"[dim]── Processed {len(delegation_results)} delegation(s) ──[/dim]")
             for dr in delegation_results:
-                status = "[green]✓[/green]" if dr.get("success") else "[red]✗[/red]"
                 to_agent = dr.get("to_agent", "unknown")
-                task_preview = dr.get("task", "")[:40]
-                console.print(f"  {status} {to_agent}: {task_preview}...")
-                if dr.get("success") and _verbosity >= 2:
-                    response_preview = str(dr.get("result", ""))[:200]
-                    console.print(f"    [dim]{response_preview}...[/dim]")
-                elif not dr.get("success"):
-                    console.print(f"    [red]{dr.get('error', 'Unknown error')}[/red]")
+                task = dr.get("task", "")
+                success = dr.get("success", False)
+
+                # Report via status reporter
+                if _status_reporter:
+                    _status_reporter.delegation_complete(
+                        from_agent=agent.id,
+                        to_agent=to_agent,
+                        task=task,
+                        success=success,
+                        turn_number=result.turn.turn_number,
+                        error=dr.get("error") if not success else None,
+                    )
 
     return full_content
 
@@ -1056,6 +1126,16 @@ async def _ask_single(
     # Select response function based on streaming preference
     respond = _stream_response if stream else _invoke_response
 
+    # Report session start via status reporter
+    if _status_reporter:
+        _status_reporter.session_start(
+            session_id=session.id,
+            project_id=project_id,
+            agent_name=agent.name,
+            agent_id=agent.id,
+            model=runtime._model,
+        )
+
     # Wrap execution in LangSmith session tracing
     with (
         tracing_manager.session(session.id, agent.id, project_id)
@@ -1063,7 +1143,14 @@ async def _ask_single(
         else nullcontext()
     ):
         try:
-            console.print(f"[dim]{agent.name}:[/dim]")
+            # Report turn start
+            if _status_reporter:
+                _status_reporter.turn_start(
+                    turn_number=session.turn_count + 1,
+                    agent_id=agent.id,
+                    agent_name=agent.name,
+                )
+
             await respond(runtime, agent, prompt, session)
             console.print()
 
@@ -1099,7 +1186,11 @@ async def _ask_single(
             # Log session end and flush
             if event_logger:
                 event_logger.session_complete(session_id=session.id, turn_count=session.turn_count)
-                console.print(f"[dim]Events logged to: {log_path}[/dim]")
+                if _verbosity >= 1:
+                    log_console.print(f"[dim]Events logged to: {log_path}[/dim]")
+            # Report session end with summary
+            if _status_reporter:
+                _status_reporter.session_end(turn_count=session.turn_count)
             await provider.close()
             project.close()
 
@@ -1141,15 +1232,28 @@ async def _ask_repl(
         from_checkpoint,
     )
 
-    # Print header
-    console.print()
-    console.print("[bold]QuestFoundry Interactive Session[/bold]")
-    console.print(f"Project: [cyan]{project_id}[/cyan]")
-    console.print(f"Agent: [green]{agent.name}[/green] ({agent.id})")
-    if log_path:
-        console.print(f"Logging: [dim]{log_path}[/dim]")
-    if tracing_manager:
-        console.print("[dim]LangSmith tracing: enabled[/dim]")
+    # Report session start via status reporter
+    if _status_reporter:
+        _status_reporter.session_start(
+            session_id=session.id,
+            project_id=project_id,
+            agent_name=agent.name,
+            agent_id=agent.id,
+            model=runtime._model,
+        )
+    else:
+        # Fallback to old-style header if no status reporter
+        console.print()
+        console.print("[bold]QuestFoundry Interactive Session[/bold]")
+        console.print(f"Project: [cyan]{project_id}[/cyan]")
+        console.print(f"Agent: [green]{agent.name}[/green] ({agent.id})")
+
+    # Show extra debug info
+    if _verbosity >= 1:
+        if log_path:
+            log_console.print(f"[dim]Logging: {log_path}[/dim]")
+        if tracing_manager:
+            log_console.print("[dim]LangSmith tracing: enabled[/dim]")
     console.print("[dim]Type 'exit' or Ctrl+D to quit[/dim]")
     console.print()
 
@@ -1172,8 +1276,15 @@ async def _ask_repl(
                     if not user_input.strip():
                         continue
 
+                    # Report turn start
+                    if _status_reporter:
+                        _status_reporter.turn_start(
+                            turn_number=session.turn_count + 1,
+                            agent_id=agent.id,
+                            agent_name=agent.name,
+                        )
+
                     # Stream response
-                    console.print(f"[dim]{agent.name}:[/dim]")
                     await _stream_response(runtime, agent, user_input, session)
                     console.print()
 
@@ -1215,10 +1326,14 @@ async def _ask_repl(
             # Log session end and flush
             if event_logger:
                 event_logger.session_complete(session_id=session.id, turn_count=session.turn_count)
-                console.print(f"[dim]Events logged to: {log_path}[/dim]")
-            # Show session summary
-            console.print()
-            console.print(f"[dim]Session ended: {session.turn_count} turns[/dim]")
+                if _verbosity >= 1:
+                    log_console.print(f"[dim]Events logged to: {log_path}[/dim]")
+            # Report session end with summary
+            if _status_reporter:
+                _status_reporter.session_end(turn_count=session.turn_count)
+            else:
+                console.print()
+                console.print(f"[dim]Session ended: {session.turn_count} turns[/dim]")
             await provider.close()
             project.close()
 

--- a/src/questfoundry/cli_output.py
+++ b/src/questfoundry/cli_output.py
@@ -1,0 +1,467 @@
+"""
+CLI output management for QuestFoundry.
+
+Provides structured status output on stdout while routing logs to stderr.
+Implements:
+- Turn/role status indicators
+- Artifact creation tracking
+- Summary table generation
+- Stream separation (output: stdout, logs: stderr)
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.session import TokenUsage
+
+
+@dataclass
+class ArtifactEvent:
+    """Record of an artifact creation during a session."""
+
+    artifact_id: str
+    artifact_type: str
+    store: str
+    created_by: str
+    turn_number: int
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class ToolCallEvent:
+    """Record of a tool call during a session."""
+
+    tool_id: str
+    success: bool
+    turn_number: int
+    agent_id: str
+    execution_time_ms: float | None = None
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class DelegationEvent:
+    """Record of a delegation during a session."""
+
+    from_agent: str
+    to_agent: str
+    task_preview: str
+    success: bool
+    turn_number: int
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class TurnSummary:
+    """Summary of a single turn."""
+
+    turn_number: int
+    agent_id: str
+    agent_name: str
+    tool_calls: int = 0
+    artifacts_created: int = 0
+    delegations: int = 0
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    duration_ms: float | None = None
+
+
+class StatusReporter:
+    """
+    Manages structured CLI output with stream separation.
+
+    - Status updates go to stdout (main console)
+    - Logs go to stderr (log console)
+    - Tracks events for summary table
+    """
+
+    def __init__(
+        self,
+        verbosity: int = 0,
+        show_summary: bool = True,
+        quiet: bool = False,
+    ):
+        """
+        Initialize the status reporter.
+
+        Args:
+            verbosity: Verbosity level (0=WARN, 1=INFO, 2=DEBUG)
+            show_summary: Whether to show summary table at end
+            quiet: If True, suppress all status output
+        """
+        # Main output console (stdout)
+        self.console = Console(file=sys.stdout)
+
+        # Log console (stderr) - for logs and debug info
+        self.log_console = Console(file=sys.stderr, stderr=True)
+
+        self.verbosity = verbosity
+        self.show_summary = show_summary
+        self.quiet = quiet
+
+        # Tracking state
+        self._artifacts: list[ArtifactEvent] = []
+        self._tool_calls: list[ToolCallEvent] = []
+        self._delegations: list[DelegationEvent] = []
+        self._turns: list[TurnSummary] = []
+        self._current_turn: TurnSummary | None = None
+
+        # Session metadata
+        self._session_id: str | None = None
+        self._project_id: str | None = None
+        self._agent_id: str | None = None
+        self._playbook_id: str | None = None
+        self._start_time: datetime | None = None
+
+    # -------------------------------------------------------------------------
+    # Session Lifecycle
+    # -------------------------------------------------------------------------
+
+    def session_start(
+        self,
+        session_id: str,
+        project_id: str,
+        agent_name: str,
+        agent_id: str,
+        playbook_id: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        """Report session start."""
+        self._session_id = session_id
+        self._project_id = project_id
+        self._playbook_id = playbook_id
+        self._agent_id = agent_id
+        self._start_time = datetime.now()
+
+        if self.quiet:
+            return
+
+        # Minimal header on stdout
+        self.console.print()
+        self.console.print(f"[bold]Session[/bold] {project_id}")
+        info_parts = [f"[cyan]{agent_name}[/cyan] ({agent_id})"]
+        if playbook_id:
+            info_parts.append(f"playbook: [green]{playbook_id}[/green]")
+        if model and self.verbosity >= 1:
+            info_parts.append(f"model: [dim]{model}[/dim]")
+        self.console.print(" | ".join(info_parts))
+        self.console.print()
+
+    def session_end(self, turn_count: int) -> None:
+        """Report session end and show summary if enabled."""
+        if self.quiet:
+            return
+
+        # Show summary table
+        if self.show_summary and self._turns:
+            self._print_summary_table()
+
+        # Final status
+        duration = ""
+        if self._start_time:
+            elapsed = (datetime.now() - self._start_time).total_seconds()
+            if elapsed < 60:
+                duration = f" in {elapsed:.1f}s"
+            else:
+                mins = int(elapsed // 60)
+                secs = int(elapsed % 60)
+                duration = f" in {mins}m {secs}s"
+
+        self.console.print()
+        self.console.print(f"[dim]Session complete: {turn_count} turns{duration}[/dim]")
+
+    # -------------------------------------------------------------------------
+    # Turn Lifecycle
+    # -------------------------------------------------------------------------
+
+    def turn_start(
+        self,
+        turn_number: int,
+        agent_id: str,
+        agent_name: str,
+        playbook_id: str | None = None,
+    ) -> None:
+        """Report turn start."""
+        self._current_turn = TurnSummary(
+            turn_number=turn_number,
+            agent_id=agent_id,
+            agent_name=agent_name,
+        )
+
+        if self.quiet:
+            return
+
+        # Status line format: [Turn N] Agent Name (playbook)
+        parts = [f"[bold cyan]Turn {turn_number}[/bold cyan]"]
+        parts.append(f"[green]{agent_name}[/green]")
+        if playbook_id:
+            parts.append(f"[dim]({playbook_id})[/dim]")
+
+        self.console.print(" ".join(parts))
+
+    def turn_complete(
+        self,
+        usage: TokenUsage | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Report turn completion."""
+        if self._current_turn:
+            if usage:
+                self._current_turn.prompt_tokens = usage.prompt_tokens
+                self._current_turn.completion_tokens = usage.completion_tokens
+            self._current_turn.duration_ms = duration_ms
+            self._turns.append(self._current_turn)
+            self._current_turn = None
+
+    # -------------------------------------------------------------------------
+    # Tool Events
+    # -------------------------------------------------------------------------
+
+    def tool_call(
+        self,
+        tool_id: str,
+        success: bool,
+        agent_id: str,
+        turn_number: int,
+        execution_time_ms: float | None = None,
+        result_preview: str | None = None,
+    ) -> None:
+        """Report a tool call."""
+        event = ToolCallEvent(
+            tool_id=tool_id,
+            success=success,
+            turn_number=turn_number,
+            agent_id=agent_id,
+            execution_time_ms=execution_time_ms,
+        )
+        self._tool_calls.append(event)
+
+        if self._current_turn:
+            self._current_turn.tool_calls += 1
+
+        if self.quiet:
+            return
+
+        # Only show tool calls at verbosity >= 1, or always show failures
+        if self.verbosity >= 1 or not success:
+            status = "[green]OK[/green]" if success else "[red]FAIL[/red]"
+            time_str = f" ({execution_time_ms:.0f}ms)" if execution_time_ms else ""
+            self.console.print(f"  [dim]tool:[/dim] {tool_id} {status}{time_str}")
+            # Show result preview at higher verbosity
+            if result_preview and self.verbosity >= 2:
+                preview = (
+                    result_preview[:80] + "..." if len(result_preview) > 80 else result_preview
+                )
+                self.console.print(f"    [dim]{preview}[/dim]")
+
+    # -------------------------------------------------------------------------
+    # Artifact Events
+    # -------------------------------------------------------------------------
+
+    def artifact_created(
+        self,
+        artifact_id: str,
+        artifact_type: str,
+        store: str,
+        created_by: str,
+        turn_number: int,
+    ) -> None:
+        """Report artifact creation."""
+        event = ArtifactEvent(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            store=store,
+            created_by=created_by,
+            turn_number=turn_number,
+        )
+        self._artifacts.append(event)
+
+        if self._current_turn:
+            self._current_turn.artifacts_created += 1
+
+        if self.quiet:
+            return
+
+        # Always show artifact creation (this is what user wants to see)
+        self.console.print(
+            f"  [bold green]+[/bold green] {artifact_type}: "
+            f"[cyan]{artifact_id}[/cyan] [dim]-> {store}[/dim]"
+        )
+
+    # -------------------------------------------------------------------------
+    # Delegation Events
+    # -------------------------------------------------------------------------
+
+    def delegation_start(
+        self,
+        from_agent: str,
+        to_agent: str,
+        task: str,
+        turn_number: int,
+    ) -> None:
+        """Report delegation start."""
+        if self.quiet:
+            return
+
+        task_preview = task[:50] + "..." if len(task) > 50 else task
+        turn_info = f" (turn {turn_number})" if self.verbosity >= 2 else ""
+        self.console.print(
+            f"  [dim]delegate:[/dim] {from_agent} [yellow]->[/yellow] {to_agent}{turn_info}"
+        )
+        if self.verbosity >= 1:
+            self.console.print(f"    [dim]{task_preview}[/dim]")
+
+    def delegation_complete(
+        self,
+        from_agent: str,
+        to_agent: str,
+        task: str,
+        success: bool,
+        turn_number: int,
+        error: str | None = None,
+    ) -> None:
+        """Report delegation completion."""
+        task_preview = task[:50] + "..." if len(task) > 50 else task
+
+        event = DelegationEvent(
+            from_agent=from_agent,
+            to_agent=to_agent,
+            task_preview=task_preview,
+            success=success,
+            turn_number=turn_number,
+        )
+        self._delegations.append(event)
+
+        if self._current_turn:
+            self._current_turn.delegations += 1
+
+        if self.quiet:
+            return
+
+        status = "[green]OK[/green]" if success else "[red]FAIL[/red]"
+        self.console.print(f"  [dim]result:[/dim] {to_agent} {status}")
+        if not success and error:
+            self.console.print(f"    [red]{error}[/red]")
+
+    # -------------------------------------------------------------------------
+    # Summary Table
+    # -------------------------------------------------------------------------
+
+    def _print_summary_table(self) -> None:
+        """Print the session summary table."""
+        table = Table(title="Session Summary", show_header=True, header_style="bold")
+        table.add_column("Turn", style="cyan", justify="right")
+        table.add_column("Agent", style="green")
+        table.add_column("Tools", justify="right")
+        table.add_column("Artifacts", justify="right")
+        table.add_column("Tokens", justify="right", style="dim")
+
+        total_tokens = 0
+        total_artifacts = 0
+        total_tools = 0
+
+        for turn in self._turns:
+            tokens_str = ""
+            if turn.prompt_tokens and turn.completion_tokens:
+                tokens = (turn.prompt_tokens or 0) + (turn.completion_tokens or 0)
+                total_tokens += tokens
+                tokens_str = f"{tokens:,}"
+
+            artifacts_str = str(turn.artifacts_created) if turn.artifacts_created else "-"
+            tools_str = str(turn.tool_calls) if turn.tool_calls else "-"
+
+            total_artifacts += turn.artifacts_created
+            total_tools += turn.tool_calls
+
+            table.add_row(
+                str(turn.turn_number),
+                turn.agent_name,
+                tools_str,
+                artifacts_str,
+                tokens_str,
+            )
+
+        # Add totals row
+        table.add_section()
+        table.add_row(
+            "[bold]Total[/bold]",
+            f"[bold]{len(self._turns)} turns[/bold]",
+            f"[bold]{total_tools}[/bold]",
+            f"[bold]{total_artifacts}[/bold]",
+            f"[bold]{total_tokens:,}[/bold]" if total_tokens else "-",
+        )
+
+        self.console.print()
+        self.console.print(table)
+
+        # Artifacts summary if any were created
+        if self._artifacts:
+            self.console.print()
+            self.console.print("[bold]Artifacts Created:[/bold]")
+            for art in self._artifacts:
+                self.console.print(
+                    f"  [cyan]{art.artifact_id}[/cyan] ({art.artifact_type}) "
+                    f"[dim]-> {art.store}[/dim]"
+                )
+
+    # -------------------------------------------------------------------------
+    # Generic Output
+    # -------------------------------------------------------------------------
+
+    def print(self, message: str, style: str | None = None) -> None:
+        """Print a message to stdout."""
+        if self.quiet:
+            return
+        self.console.print(message, style=style)
+
+    def log(self, message: str, level: str = "info") -> None:
+        """Print a log message to stderr."""
+        styles = {
+            "debug": "dim",
+            "info": "blue",
+            "warning": "yellow",
+            "error": "red",
+        }
+        style = styles.get(level, "")
+        self.log_console.print(f"[{style}]{message}[/{style}]")
+
+    def agent_response(self, agent_name: str) -> None:
+        """Print agent response header."""
+        if self.quiet:
+            return
+        self.console.print(f"[dim]{agent_name}:[/dim]")
+
+    def print_response(self, content: str) -> None:
+        """Print agent response content."""
+        if self.quiet:
+            return
+        self.console.print(content)
+
+
+def create_log_handler(log_console: Console, verbosity: int) -> Any:
+    """
+    Create a RichHandler that outputs to stderr.
+
+    Args:
+        log_console: Console instance configured for stderr
+        verbosity: Verbosity level
+
+    Returns:
+        RichHandler configured for the log console
+    """
+    from rich.logging import RichHandler
+
+    return RichHandler(
+        console=log_console,
+        rich_tracebacks=True,
+        show_path=verbosity >= 2,
+        show_time=verbosity >= 1,
+    )

--- a/src/questfoundry/cli_output.py
+++ b/src/questfoundry/cli_output.py
@@ -370,8 +370,11 @@ class StatusReporter:
 
         for turn in self._turns:
             tokens_str = ""
-            if turn.prompt_tokens and turn.completion_tokens:
-                tokens = (turn.prompt_tokens or 0) + (turn.completion_tokens or 0)
+            # Handle None/0 values correctly - 0 is valid, None means unknown
+            prompt = turn.prompt_tokens if turn.prompt_tokens is not None else 0
+            completion = turn.completion_tokens if turn.completion_tokens is not None else 0
+            if turn.prompt_tokens is not None or turn.completion_tokens is not None:
+                tokens = prompt + completion
                 total_tokens += tokens
                 tokens_str = f"{tokens:,}"
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -35,6 +35,7 @@ from questfoundry.runtime.agent.turn_validator import (
     TurnValidationConfig,
     TurnValidator,
 )
+from questfoundry.runtime.context import Secretary, SummarizationPolicy
 from questfoundry.runtime.observability import EventType
 from questfoundry.runtime.providers import (
     ContextOverflowError,
@@ -163,6 +164,10 @@ class AgentRuntime:
         self._prompt_builder = PromptBuilder()
         self._tool_registry: ToolRegistry | None = None
 
+        # Secretary for context management via tool summarization
+        self._secretary = Secretary()
+        self._secretary_initialized = False
+
         # Turn validator for orchestrator enforcement
         self._turn_validator = TurnValidator(studio, turn_validation_config)
 
@@ -188,7 +193,26 @@ class AgentRuntime:
                 logger.warning("Tools module not available, tool execution disabled", exc_info=True)
                 return None
 
+        # Initialize secretary with tool definitions (once)
+        if not self._secretary_initialized and self._tool_registry:
+            self._initialize_secretary()
+
         return self._tool_registry
+
+    def _initialize_secretary(self) -> None:
+        """Initialize the Secretary with tool definitions for summarization."""
+        for tool in self._studio.tools:
+            self._secretary.register_tool(tool)
+        self._secretary_initialized = True
+        logger.debug(
+            "Secretary initialized with %d tools",
+            len(self._studio.tools),
+        )
+
+    @property
+    def secretary(self) -> Secretary:
+        """Get the Secretary for context management."""
+        return self._secretary
 
     def get_agent_tools(self, agent: Agent, session_id: str | None = None) -> list[BaseTool]:
         """
@@ -416,24 +440,56 @@ class AgentRuntime:
         self,
         tool_calls: list[ToolCallRequest],
         tool_results: list[ToolCall],
+        *,
+        apply_summarization: bool = True,
     ) -> list[LLMMessage]:
         """
         Convert tool call results to LLM messages.
 
+        Applies Secretary pattern summarization based on each tool's
+        summarization_policy (drop, ultra_concise, concise, preserve).
+
         Args:
             tool_calls: Original tool call requests (with IDs)
             tool_results: Executed tool results
+            apply_summarization: Whether to apply summarization policies.
+                Set False to always preserve full results.
 
         Returns:
             List of tool result messages for the LLM
         """
         messages = []
         for tc, result in zip(tool_calls, tool_results, strict=True):
-            # Format the result as JSON
-            if result.success:
-                content = json.dumps(result.result) if result.result else "{}"
-            else:
+            # Handle errors (always preserve error messages)
+            if not result.success:
                 content = json.dumps({"error": result.error or "Tool execution failed"})
+                messages.append(
+                    LLMMessage(
+                        role="tool",
+                        content=content,
+                        tool_call_id=tc.id,
+                        name=tc.name,
+                    )
+                )
+                continue
+
+            # Apply Secretary summarization for successful results
+            if apply_summarization and result.result:
+                summary = self._secretary.summarize_tool_result(
+                    tool_id=tc.name,
+                    result=result.result,
+                )
+
+                # Handle DROP policy - still need to include a message for tool call flow
+                if summary.policy_applied == SummarizationPolicy.DROP:
+                    content = json.dumps({"_summarized": "dropped", "_tool": tc.name})
+                elif summary.content is not None:
+                    content = summary.content
+                else:
+                    content = "{}"
+            else:
+                # No summarization - use raw JSON
+                content = json.dumps(result.result) if result.result else "{}"
 
             messages.append(
                 LLMMessage(

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -478,13 +478,18 @@ class AgentRuntime:
                 summary = self._secretary.summarize_tool_result(
                     tool_id=tc.name,
                     result=result.result,
+                    arguments=tc.arguments,
                 )
 
-                # Handle DROP policy - still need to include a message for tool call flow
+                # Wrap summarized content in consistent JSON format
                 if summary.policy_applied == SummarizationPolicy.DROP:
                     content = json.dumps({"_summarized": "dropped", "_tool": tc.name})
+                elif summary.policy_applied == SummarizationPolicy.PRESERVE:
+                    # PRESERVE keeps original JSON as-is
+                    content = summary.content or "{}"
                 elif summary.content is not None:
-                    content = summary.content
+                    # ULTRA_CONCISE and CONCISE wrap text in JSON for consistency
+                    content = json.dumps({"_summarized": summary.content, "_tool": tc.name})
                 else:
                     content = "{}"
             else:

--- a/src/questfoundry/runtime/context/__init__.py
+++ b/src/questfoundry/runtime/context/__init__.py
@@ -1,0 +1,18 @@
+"""
+Context management for QuestFoundry runtime.
+
+The Secretary pattern manages context growth during agent execution by
+summarizing tool results based on their declared summarization_policy.
+"""
+
+from questfoundry.runtime.context.secretary import (
+    Secretary,
+    SummarizationPolicy,
+    ToolResultSummary,
+)
+
+__all__ = [
+    "Secretary",
+    "SummarizationPolicy",
+    "ToolResultSummary",
+]

--- a/src/questfoundry/runtime/context/secretary.py
+++ b/src/questfoundry/runtime/context/secretary.py
@@ -92,6 +92,7 @@ class Secretary:
         tool_id: str,
         result: dict[str, Any],
         *,
+        arguments: dict[str, Any] | None = None,
         force_policy: SummarizationPolicy | None = None,
     ) -> ToolResultSummary:
         """
@@ -100,6 +101,7 @@ class Secretary:
         Args:
             tool_id: The ID of the tool that produced the result
             result: The tool's result data
+            arguments: The tool's input arguments (for template substitution)
             force_policy: Override the tool's declared policy
 
         Returns:
@@ -110,6 +112,10 @@ class Secretary:
 
         policy = force_policy or self.get_policy(tool_id)
         tool = self._tool_cache.get(tool_id)
+
+        # Merge arguments with result for template substitution
+        # Arguments take precedence for keys that exist in both
+        template_context = {**result, **(arguments or {})}
 
         if policy == SummarizationPolicy.DROP:
             self.tools_dropped += 1
@@ -124,9 +130,9 @@ class Secretary:
             )
 
         if policy == SummarizationPolicy.ULTRA_CONCISE:
-            summary = self._apply_ultra_concise(tool, result)
+            summary = self._apply_ultra_concise(tool, template_context)
             self.tools_summarized += 1
-            self.total_tokens_saved += (original_size - len(summary)) // 4
+            self.total_tokens_saved += max(0, (original_size - len(summary)) // 4)
             return ToolResultSummary(
                 tool_id=tool_id,
                 original_size=original_size,
@@ -137,9 +143,9 @@ class Secretary:
             )
 
         if policy == SummarizationPolicy.CONCISE:
-            summary = self._apply_concise(tool, result)
+            summary = self._apply_concise(tool, template_context)
             self.tools_summarized += 1
-            self.total_tokens_saved += (original_size - len(summary)) // 4
+            self.total_tokens_saved += max(0, (original_size - len(summary)) // 4)
             return ToolResultSummary(
                 tool_id=tool_id,
                 original_size=original_size,

--- a/src/questfoundry/runtime/context/secretary.py
+++ b/src/questfoundry/runtime/context/secretary.py
@@ -1,0 +1,241 @@
+"""
+Secretary pattern for context management.
+
+The Secretary manages context growth by summarizing tool results based on
+their declared summarization_policy. This prevents context overflow during
+multi-turn conversations with many tool calls.
+
+Summarization Policies:
+- drop: Remove from context entirely (tool can be re-called if needed)
+- ultra_concise: Single-line summary using summary_template
+- concise: Brief multi-line summary preserving key facts
+- preserve: Keep full result (default)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models.base import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class SummarizationPolicy(str, Enum):
+    """Tool result summarization policies."""
+
+    DROP = "drop"
+    ULTRA_CONCISE = "ultra_concise"
+    CONCISE = "concise"
+    PRESERVE = "preserve"
+
+
+@dataclass
+class ToolResultSummary:
+    """Result of summarizing a tool result."""
+
+    tool_id: str
+    original_size: int
+    summarized_size: int
+    policy_applied: SummarizationPolicy
+    content: str | None  # None if dropped
+    was_summarized: bool = False
+
+
+@dataclass
+class Secretary:
+    """
+    Context management secretary that summarizes tool results.
+
+    The Secretary pattern prevents context overflow by intelligently
+    summarizing tool results based on their declared summarization_policy.
+    """
+
+    # Track summarization statistics
+    total_tokens_saved: int = 0
+    tools_dropped: int = 0
+    tools_summarized: int = 0
+    tools_preserved: int = 0
+
+    # Cache for tool definitions (tool_id -> Tool)
+    _tool_cache: dict[str, Tool] = field(default_factory=dict)
+
+    def register_tool(self, tool: Tool) -> None:
+        """Register a tool definition for summarization lookups."""
+        self._tool_cache[tool.id] = tool
+
+    def get_policy(self, tool_id: str) -> SummarizationPolicy:
+        """Get the summarization policy for a tool."""
+        tool = self._tool_cache.get(tool_id)
+        if tool is None:
+            logger.debug(f"Tool {tool_id} not in cache, defaulting to PRESERVE")
+            return SummarizationPolicy.PRESERVE
+
+        policy_str = tool.summarization_policy
+        try:
+            return SummarizationPolicy(policy_str)
+        except ValueError:
+            logger.warning(
+                f"Unknown summarization_policy '{policy_str}' for tool {tool_id}, "
+                "defaulting to PRESERVE"
+            )
+            return SummarizationPolicy.PRESERVE
+
+    def summarize_tool_result(
+        self,
+        tool_id: str,
+        result: dict[str, Any],
+        *,
+        force_policy: SummarizationPolicy | None = None,
+    ) -> ToolResultSummary:
+        """
+        Summarize a tool result based on its policy.
+
+        Args:
+            tool_id: The ID of the tool that produced the result
+            result: The tool's result data
+            force_policy: Override the tool's declared policy
+
+        Returns:
+            ToolResultSummary with the summarized (or original) content
+        """
+        original_json = json.dumps(result, ensure_ascii=False)
+        original_size = len(original_json)
+
+        policy = force_policy or self.get_policy(tool_id)
+        tool = self._tool_cache.get(tool_id)
+
+        if policy == SummarizationPolicy.DROP:
+            self.tools_dropped += 1
+            self.total_tokens_saved += original_size // 4  # Rough token estimate
+            return ToolResultSummary(
+                tool_id=tool_id,
+                original_size=original_size,
+                summarized_size=0,
+                policy_applied=policy,
+                content=None,
+                was_summarized=True,
+            )
+
+        if policy == SummarizationPolicy.ULTRA_CONCISE:
+            summary = self._apply_ultra_concise(tool, result)
+            self.tools_summarized += 1
+            self.total_tokens_saved += (original_size - len(summary)) // 4
+            return ToolResultSummary(
+                tool_id=tool_id,
+                original_size=original_size,
+                summarized_size=len(summary),
+                policy_applied=policy,
+                content=summary,
+                was_summarized=True,
+            )
+
+        if policy == SummarizationPolicy.CONCISE:
+            summary = self._apply_concise(tool, result)
+            self.tools_summarized += 1
+            self.total_tokens_saved += (original_size - len(summary)) // 4
+            return ToolResultSummary(
+                tool_id=tool_id,
+                original_size=original_size,
+                summarized_size=len(summary),
+                policy_applied=policy,
+                content=summary,
+                was_summarized=True,
+            )
+
+        # PRESERVE - keep original
+        self.tools_preserved += 1
+        return ToolResultSummary(
+            tool_id=tool_id,
+            original_size=original_size,
+            summarized_size=original_size,
+            policy_applied=policy,
+            content=original_json,
+            was_summarized=False,
+        )
+
+    def _apply_ultra_concise(self, tool: Tool | None, result: dict[str, Any]) -> str:
+        """Apply ultra_concise summarization using summary_template."""
+        if tool and tool.summary_template:
+            return self._substitute_template(tool.summary_template, result)
+
+        # Fallback: create a minimal summary
+        if "success" in result:
+            status = "succeeded" if result.get("success") else "failed"
+            return f"Tool call {status}"
+
+        # Very minimal fallback
+        keys = list(result.keys())[:3]
+        return f"Result with keys: {', '.join(keys)}"
+
+    def _apply_concise(self, tool: Tool | None, result: dict[str, Any]) -> str:
+        """Apply concise summarization preserving key facts."""
+        lines = []
+
+        # Start with template if available
+        if tool and tool.summary_template:
+            lines.append(self._substitute_template(tool.summary_template, result))
+
+        # Add key scalar values
+        for key, value in result.items():
+            if key.startswith("_"):
+                continue  # Skip internal fields
+
+            if isinstance(value, (str, int, float, bool)) and value is not None:
+                # Truncate long strings
+                if isinstance(value, str) and len(value) > 100:
+                    value = value[:97] + "..."
+                lines.append(f"  {key}: {value}")
+            elif isinstance(value, list):
+                lines.append(f"  {key}: [{len(value)} items]")
+            elif isinstance(value, dict):
+                lines.append(f"  {key}: {{...}}")
+
+        # Limit to reasonable size
+        if len(lines) > 10:
+            lines = lines[:9] + ["  ..."]
+
+        return "\n".join(lines)
+
+    def _substitute_template(self, template: str, result: dict[str, Any]) -> str:
+        """
+        Substitute {variables} in a template with values from result.
+
+        Handles nested access like {artifact.id} and missing values gracefully.
+        """
+
+        def replacer(match: re.Match[str]) -> str:
+            key = match.group(1)
+            # Handle nested keys like "artifact.id"
+            parts = key.split(".")
+            value = result
+            for part in parts:
+                if isinstance(value, dict) and part in value:
+                    value = value[part]
+                else:
+                    return f"{{{key}}}"  # Keep original if not found
+            return str(value)
+
+        return re.sub(r"\{(\w+(?:\.\w+)*)\}", replacer, template)
+
+    def reset_stats(self) -> None:
+        """Reset summarization statistics."""
+        self.total_tokens_saved = 0
+        self.tools_dropped = 0
+        self.tools_summarized = 0
+        self.tools_preserved = 0
+
+    def get_stats(self) -> dict[str, int]:
+        """Get summarization statistics."""
+        return {
+            "total_tokens_saved": self.total_tokens_saved,
+            "tools_dropped": self.tools_dropped,
+            "tools_summarized": self.tools_summarized,
+            "tools_preserved": self.tools_preserved,
+        }

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -238,6 +238,14 @@ class Tool(BaseModel):
     examples: list[ToolExample] = Field(default_factory=list)
     terminates_turn: bool = False
 
+    # Summarization policy for Secretary pattern context management
+    # - drop: Remove from summarized context (tool can be re-called)
+    # - ultra_concise: Single-line summary using summary_template
+    # - concise: Brief multi-line summary preserving key facts
+    # - preserve: Keep full result in context (default)
+    summarization_policy: Literal["drop", "ultra_concise", "concise", "preserve"] = "preserve"
+    summary_template: str | None = None
+
 
 class ArtifactType(BaseModel):
     """Artifact type definition from artifact-type.schema.json."""

--- a/tests/cli/test_ask.py
+++ b/tests/cli/test_ask.py
@@ -336,7 +336,10 @@ class TestAskREPL:
             )
 
             # REPL should have shown the header and ended cleanly
-            assert "Interactive Session" in result.stdout or "Session ended" in result.stdout
+            # New format: "Session {project}" header and "Session complete" ending
+            assert "Session" in result.stdout and (
+                "Session complete" in result.stdout or "Session ended" in result.stdout
+            )
 
     def test_ask_repl_quit(self, test_project: Project, mock_studio: Studio) -> None:
         """ask REPL mode can be exited with 'quit'."""
@@ -364,4 +367,5 @@ class TestAskREPL:
                 input="quit\n",
             )
 
-            assert "Session ended" in result.stdout
+            # New format: "Session complete" instead of "Session ended"
+            assert "Session complete" in result.stdout or "Session ended" in result.stdout

--- a/tests/runtime/context/__init__.py
+++ b/tests/runtime/context/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for context management."""

--- a/tests/runtime/context/test_secretary.py
+++ b/tests/runtime/context/test_secretary.py
@@ -1,0 +1,319 @@
+"""Tests for Secretary pattern context management."""
+
+import pytest
+
+from questfoundry.runtime.context import Secretary, SummarizationPolicy, ToolResultSummary
+from questfoundry.runtime.models.base import Tool
+
+
+class TestSummarizationPolicy:
+    """Tests for SummarizationPolicy enum."""
+
+    def test_enum_values(self):
+        """Test that all expected policy values exist."""
+        assert SummarizationPolicy.DROP.value == "drop"
+        assert SummarizationPolicy.ULTRA_CONCISE.value == "ultra_concise"
+        assert SummarizationPolicy.CONCISE.value == "concise"
+        assert SummarizationPolicy.PRESERVE.value == "preserve"
+
+
+class TestSecretary:
+    """Tests for Secretary context management."""
+
+    @pytest.fixture
+    def secretary(self) -> Secretary:
+        """Create a Secretary instance."""
+        return Secretary()
+
+    @pytest.fixture
+    def tool_drop(self) -> Tool:
+        """Tool with DROP summarization policy."""
+        return Tool(
+            id="list_agents",
+            name="List Agents",
+            description="List available agents",
+            summarization_policy="drop",
+            summary_template="Listed {count} agents",
+        )
+
+    @pytest.fixture
+    def tool_ultra_concise(self) -> Tool:
+        """Tool with ULTRA_CONCISE summarization policy."""
+        return Tool(
+            id="delegate",
+            name="Delegate Work",
+            description="Delegate work to another agent",
+            summarization_policy="ultra_concise",
+            summary_template="Delegated to {assigned_to}: {task}",
+        )
+
+    @pytest.fixture
+    def tool_concise(self) -> Tool:
+        """Tool with CONCISE summarization policy."""
+        return Tool(
+            id="search_workspace",
+            name="Search Workspace",
+            description="Search for artifacts",
+            summarization_policy="concise",
+            summary_template="Found {total_count} artifacts",
+        )
+
+    @pytest.fixture
+    def tool_preserve(self) -> Tool:
+        """Tool with PRESERVE summarization policy (default)."""
+        return Tool(
+            id="validate_artifact",
+            name="Validate Artifact",
+            description="Validate an artifact",
+            summarization_policy="preserve",
+        )
+
+    def test_register_tool(self, secretary: Secretary, tool_drop: Tool):
+        """Test registering a tool with the Secretary."""
+        secretary.register_tool(tool_drop)
+        assert tool_drop.id in secretary._tool_cache
+        assert secretary._tool_cache[tool_drop.id] == tool_drop
+
+    def test_get_policy_registered(self, secretary: Secretary, tool_drop: Tool):
+        """Test getting policy for a registered tool."""
+        secretary.register_tool(tool_drop)
+        policy = secretary.get_policy(tool_drop.id)
+        assert policy == SummarizationPolicy.DROP
+
+    def test_get_policy_unregistered(self, secretary: Secretary):
+        """Test getting policy for an unregistered tool defaults to PRESERVE."""
+        policy = secretary.get_policy("unknown_tool")
+        assert policy == SummarizationPolicy.PRESERVE
+
+    def test_summarize_drop_policy(self, secretary: Secretary, tool_drop: Tool):
+        """Test DROP policy removes result from context."""
+        secretary.register_tool(tool_drop)
+        result = {"agents": [{"id": "agent1"}, {"id": "agent2"}], "count": 2}
+
+        summary = secretary.summarize_tool_result(tool_drop.id, result)
+
+        assert summary.tool_id == tool_drop.id
+        assert summary.policy_applied == SummarizationPolicy.DROP
+        assert summary.content is None  # Dropped
+        assert summary.was_summarized is True
+        assert summary.summarized_size == 0
+
+    def test_summarize_ultra_concise_policy(self, secretary: Secretary, tool_ultra_concise: Tool):
+        """Test ULTRA_CONCISE policy uses summary template."""
+        secretary.register_tool(tool_ultra_concise)
+        result = {
+            "delegation_id": "del-123",
+            "assigned_to": "scene_smith",
+            "task": "Write section prose",
+            "status": "sent",
+        }
+
+        summary = secretary.summarize_tool_result(tool_ultra_concise.id, result)
+
+        assert summary.tool_id == tool_ultra_concise.id
+        assert summary.policy_applied == SummarizationPolicy.ULTRA_CONCISE
+        assert summary.content == "Delegated to scene_smith: Write section prose"
+        assert summary.was_summarized is True
+        assert summary.summarized_size < summary.original_size
+
+    def test_summarize_concise_policy(self, secretary: Secretary, tool_concise: Tool):
+        """Test CONCISE policy preserves key facts."""
+        secretary.register_tool(tool_concise)
+        result = {
+            "results": [
+                {"artifact_id": "art-1", "type": "section"},
+                {"artifact_id": "art-2", "type": "section"},
+            ],
+            "total_count": 2,
+            "query": "lighthouse",
+        }
+
+        summary = secretary.summarize_tool_result(tool_concise.id, result)
+
+        assert summary.tool_id == tool_concise.id
+        assert summary.policy_applied == SummarizationPolicy.CONCISE
+        assert summary.content is not None
+        assert "Found 2 artifacts" in summary.content  # Template applied
+        assert "total_count: 2" in summary.content  # Key facts preserved
+        assert summary.was_summarized is True
+
+    def test_summarize_preserve_policy(self, secretary: Secretary, tool_preserve: Tool):
+        """Test PRESERVE policy keeps full result."""
+        secretary.register_tool(tool_preserve)
+        result = {
+            "valid": True,
+            "schema_errors": [],
+            "bar_results": [{"bar": "integrity", "status": "green"}],
+        }
+
+        summary = secretary.summarize_tool_result(tool_preserve.id, result)
+
+        assert summary.tool_id == tool_preserve.id
+        assert summary.policy_applied == SummarizationPolicy.PRESERVE
+        assert summary.content is not None
+        assert summary.was_summarized is False
+        assert summary.summarized_size == summary.original_size
+
+    def test_force_policy_override(self, secretary: Secretary, tool_preserve: Tool):
+        """Test forcing a different policy than the tool's default."""
+        secretary.register_tool(tool_preserve)
+        result = {"valid": True, "schema_errors": []}
+
+        summary = secretary.summarize_tool_result(
+            tool_preserve.id,
+            result,
+            force_policy=SummarizationPolicy.DROP,
+        )
+
+        assert summary.policy_applied == SummarizationPolicy.DROP
+        assert summary.content is None
+
+    def test_template_substitution_simple(self, secretary: Secretary):
+        """Test simple template variable substitution."""
+        result = secretary._substitute_template("Count: {count}", {"count": 42})
+        assert result == "Count: 42"
+
+    def test_template_substitution_nested(self, secretary: Secretary):
+        """Test nested key template substitution."""
+        result = secretary._substitute_template(
+            "Artifact: {artifact.id}",
+            {"artifact": {"id": "art-123", "type": "section"}},
+        )
+        assert result == "Artifact: art-123"
+
+    def test_template_substitution_missing_key(self, secretary: Secretary):
+        """Test template with missing key preserves placeholder."""
+        result = secretary._substitute_template("Value: {missing}", {"other": "data"})
+        assert result == "Value: {missing}"
+
+    def test_template_substitution_multiple(self, secretary: Secretary):
+        """Test multiple variable substitution."""
+        result = secretary._substitute_template(
+            "{action} to {target}: {task}",
+            {"action": "Delegated", "target": "agent", "task": "work"},
+        )
+        assert result == "Delegated to agent: work"
+
+    def test_statistics_tracking(self, secretary: Secretary):
+        """Test that Secretary tracks summarization statistics."""
+        tool_drop = Tool(
+            id="tool_drop",
+            name="Drop Tool",
+            description="Test",
+            summarization_policy="drop",
+        )
+        tool_preserve = Tool(
+            id="tool_preserve",
+            name="Preserve Tool",
+            description="Test",
+            summarization_policy="preserve",
+        )
+        tool_concise = Tool(
+            id="tool_concise",
+            name="Concise Tool",
+            description="Test",
+            summarization_policy="concise",
+            summary_template="Result",
+        )
+
+        secretary.register_tool(tool_drop)
+        secretary.register_tool(tool_preserve)
+        secretary.register_tool(tool_concise)
+
+        # Make some tool calls
+        secretary.summarize_tool_result("tool_drop", {"data": "x" * 100})
+        secretary.summarize_tool_result("tool_drop", {"data": "y" * 100})
+        secretary.summarize_tool_result("tool_preserve", {"data": "z" * 100})
+        secretary.summarize_tool_result("tool_concise", {"key": "value"})
+
+        stats = secretary.get_stats()
+
+        assert stats["tools_dropped"] == 2
+        assert stats["tools_preserved"] == 1
+        assert stats["tools_summarized"] == 1
+        assert stats["total_tokens_saved"] > 0
+
+    def test_reset_stats(self, secretary: Secretary, tool_drop: Tool):
+        """Test resetting statistics."""
+        secretary.register_tool(tool_drop)
+        secretary.summarize_tool_result(tool_drop.id, {"data": "test"})
+
+        assert secretary.tools_dropped == 1
+
+        secretary.reset_stats()
+
+        assert secretary.tools_dropped == 0
+        assert secretary.tools_preserved == 0
+        assert secretary.tools_summarized == 0
+        assert secretary.total_tokens_saved == 0
+
+    def test_ultra_concise_fallback_no_template(self, secretary: Secretary):
+        """Test ULTRA_CONCISE fallback when no template is provided."""
+        tool = Tool(
+            id="no_template",
+            name="No Template",
+            description="Test",
+            summarization_policy="ultra_concise",
+            # No summary_template
+        )
+        secretary.register_tool(tool)
+
+        result = {"success": True, "data": {"key": "value"}}
+        summary = secretary.summarize_tool_result("no_template", result)
+
+        assert summary.policy_applied == SummarizationPolicy.ULTRA_CONCISE
+        assert summary.content is not None
+        assert "succeeded" in summary.content  # Fallback message
+
+    def test_concise_truncates_long_strings(self, secretary: Secretary):
+        """Test CONCISE policy truncates long string values."""
+        tool = Tool(
+            id="long_string",
+            name="Long String",
+            description="Test",
+            summarization_policy="concise",
+        )
+        secretary.register_tool(tool)
+
+        result = {"message": "x" * 200}  # Longer than 100 chars
+        summary = secretary.summarize_tool_result("long_string", result)
+
+        assert summary.content is not None
+        assert "..." in summary.content  # Truncation marker
+        assert len(summary.content) < 200  # Significantly shorter
+
+
+class TestToolResultSummary:
+    """Tests for ToolResultSummary dataclass."""
+
+    def test_creation(self):
+        """Test creating a ToolResultSummary."""
+        summary = ToolResultSummary(
+            tool_id="test_tool",
+            original_size=100,
+            summarized_size=50,
+            policy_applied=SummarizationPolicy.CONCISE,
+            content="Summarized content",
+            was_summarized=True,
+        )
+
+        assert summary.tool_id == "test_tool"
+        assert summary.original_size == 100
+        assert summary.summarized_size == 50
+        assert summary.policy_applied == SummarizationPolicy.CONCISE
+        assert summary.content == "Summarized content"
+        assert summary.was_summarized is True
+
+    def test_dropped_result(self):
+        """Test ToolResultSummary for dropped result."""
+        summary = ToolResultSummary(
+            tool_id="dropped_tool",
+            original_size=500,
+            summarized_size=0,
+            policy_applied=SummarizationPolicy.DROP,
+            content=None,
+            was_summarized=True,
+        )
+
+        assert summary.content is None
+        assert summary.summarized_size == 0

--- a/tests/runtime/context/test_secretary.py
+++ b/tests/runtime/context/test_secretary.py
@@ -116,6 +116,49 @@ class TestSecretary:
         assert summary.was_summarized is True
         assert summary.summarized_size < summary.original_size
 
+    def test_summarize_with_arguments(self, secretary: Secretary):
+        """Test that arguments are merged with result for template substitution."""
+        # Create a tool that uses template variables from arguments
+        tool = Tool(
+            id="search_tool",
+            name="Search Tool",
+            description="Search for things",
+            summarization_policy="ultra_concise",
+            summary_template="Searched for '{query}': found {count} results",
+        )
+        secretary.register_tool(tool)
+
+        # Result only has count, query comes from arguments
+        result = {"count": 5, "items": ["a", "b", "c", "d", "e"]}
+        arguments = {"query": "test search", "limit": 10}
+
+        summary = secretary.summarize_tool_result(tool.id, result, arguments=arguments)
+
+        assert summary.policy_applied == SummarizationPolicy.ULTRA_CONCISE
+        # Template should use query from arguments and count from result
+        assert summary.content == "Searched for 'test search': found 5 results"
+        assert summary.was_summarized is True
+
+    def test_arguments_override_result_keys(self, secretary: Secretary):
+        """Test that arguments take precedence when keys exist in both."""
+        tool = Tool(
+            id="echo_tool",
+            name="Echo Tool",
+            description="Echo input",
+            summarization_policy="ultra_concise",
+            summary_template="Input: {value}",
+        )
+        secretary.register_tool(tool)
+
+        # Both have 'value' - arguments should win
+        result = {"value": "result_value", "extra": "data"}
+        arguments = {"value": "arg_value"}
+
+        summary = secretary.summarize_tool_result(tool.id, result, arguments=arguments)
+
+        # Arguments take precedence
+        assert summary.content == "Input: arg_value"
+
     def test_summarize_concise_policy(self, secretary: Secretary, tool_concise: Tool):
         """Test CONCISE policy preserves key facts."""
         secretary.register_tool(tool_concise)


### PR DESCRIPTION
## Summary

This PR implements Phase 6 (Issue #150) flow control and polish:

- **Secretary Pattern (#178)**: Context management via tool summarization policies
- **CLI Output Improvements (#177)**: Structured status output with stream separation

## Changes

### Secretary Pattern
- Added `summarization_policy` and `summary_template` to `meta/schemas/core/tool-definition.schema.json`
- Created `src/questfoundry/runtime/context/` module with `Secretary` class
- Integrated Secretary with runtime's `_tool_results_to_messages()`
- Added fields to `Tool` Pydantic model

**Summarization policies:**
| Policy | Tools | Behavior |
|--------|-------|----------|
| `drop` | consult_*, list_* | Remove from context (re-callable) |
| `ultra_concise` | delegate, generate_* | Single-line summary via template |
| `concise` | search_workspace, web_* | Key facts preserved |
| `preserve` | validate_*, communicate, assemble_export | Full result retained |

### CLI Output Improvements
- Created `StatusReporter` class for structured output
- Separated logs (stderr) from status output (stdout)
- Added turn/role indicators during execution
- Added artifact and delegation tracking
- Added summary table at session end

## Test plan
- [x] All 655 tests passing (19 new Secretary tests)
- [x] Pre-commit hooks passing
- [ ] Manual verification of CLI output with `qf ask`

Closes #177, #178
Addresses #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)