### PR TITLE
feat(delegation): add PlaybookLoader for rework loop support

### DIFF
--- a/src/questfoundry/runtime/delegation/__init__.py
+++ b/src/questfoundry/runtime/delegation/__init__.py
@@ -26,6 +26,7 @@ from questfoundry.runtime.delegation.nudger import (
     NudgeContext,
     PlaybookNudger,
 )
+from questfoundry.runtime.delegation.playbook_loader import PlaybookLoader
 from questfoundry.runtime.delegation.tracker import (
     BudgetCheckResult,
     PlaybookInstance,
@@ -50,4 +51,6 @@ __all__ = [
     # Nudger
     "PlaybookNudger",
     "NudgeContext",
+    # Playbook Loader
+    "PlaybookLoader",
 ]

--- a/src/questfoundry/runtime/delegation/playbook_loader.py
+++ b/src/questfoundry/runtime/delegation/playbook_loader.py
@@ -1,0 +1,201 @@
+"""
+Playbook loader for delegation system.
+
+Provides convenient access to playbook metadata required for delegation,
+particularly rework budgets and phase properties.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.models.base import Playbook
+
+
+class PlaybookLoader:
+    """
+    Loads and provides access to playbook metadata for delegation.
+
+    This class bridges the domain model (Playbook objects) with the delegation
+    system's needs for rework budget information and phase properties.
+
+    The delegation system needs:
+    - max_rework_cycles: Per-playbook ceiling on how many times phases can be reworked
+    - is_rework_target: Per-phase marker indicating if re-entry counts against budget
+
+    Usage:
+        # Create from loaded Studio
+        loader = PlaybookLoader.from_playbooks(studio.playbooks)
+
+        # Get rework budget for a playbook
+        budget = loader.get_max_rework_cycles("story_spark")  # Returns 3
+
+        # Check if a phase is a rework target
+        is_rework = loader.is_rework_target("story_spark", "brief_creation")  # True
+    """
+
+    def __init__(self, playbooks: dict[str, dict[str, Any]]) -> None:
+        """
+        Initialize the loader with playbook data.
+
+        Args:
+            playbooks: Dictionary of playbook_id -> playbook definition dict
+        """
+        self._playbooks = playbooks
+
+    @classmethod
+    def from_playbooks(cls, playbooks: list[Playbook]) -> PlaybookLoader:
+        """
+        Create a PlaybookLoader from a list of Playbook model objects.
+
+        This is the preferred way to create a loader from domain data loaded
+        via load_studio().
+
+        Args:
+            playbooks: List of Playbook model objects from Studio.playbooks
+
+        Returns:
+            PlaybookLoader instance
+        """
+        playbook_dict: dict[str, dict[str, Any]] = {}
+        for pb in playbooks:
+            playbook_dict[pb.id] = {
+                "id": pb.id,
+                "name": pb.name,
+                "phases": pb.phases,
+                "max_rework_cycles": pb.max_rework_cycles,
+                "entry_phase": pb.entry_phase,
+            }
+        return cls(playbook_dict)
+
+    def get_playbook(self, playbook_id: str) -> dict[str, Any] | None:
+        """
+        Get the raw playbook definition.
+
+        Args:
+            playbook_id: ID of the playbook
+
+        Returns:
+            Playbook definition dict, or None if not found
+        """
+        return self._playbooks.get(playbook_id)
+
+    def get_max_rework_cycles(self, playbook_id: str) -> int:
+        """
+        Get the maximum rework cycles for a playbook.
+
+        This is the per-playbook ceiling on how many times phases marked
+        as rework targets can be re-entered before escalation.
+
+        Args:
+            playbook_id: ID of the playbook
+
+        Returns:
+            Maximum rework cycles, defaults to 3 if playbook not found
+        """
+        playbook = self._playbooks.get(playbook_id)
+        if not playbook:
+            return 3  # Default from schema
+        result: int = playbook.get("max_rework_cycles", 3)
+        return result
+
+    def is_rework_target(self, playbook_id: str, phase_id: str) -> bool:
+        """
+        Check if a phase is marked as a rework target.
+
+        Phases with is_rework_target=true have their re-entries counted
+        against the playbook's rework budget. When the budget is exhausted,
+        re-entering these phases triggers escalation.
+
+        Args:
+            playbook_id: ID of the playbook
+            phase_id: ID of the phase
+
+        Returns:
+            True if the phase is a rework target, False otherwise
+        """
+        playbook = self._playbooks.get(playbook_id)
+        if not playbook:
+            return False
+
+        phases = playbook.get("phases", {})
+        phase = phases.get(phase_id)
+        if not phase:
+            return False
+
+        result: bool = phase.get("is_rework_target", False)
+        return result
+
+    def get_phase(self, playbook_id: str, phase_id: str) -> dict[str, Any] | None:
+        """
+        Get a specific phase definition.
+
+        Args:
+            playbook_id: ID of the playbook
+            phase_id: ID of the phase
+
+        Returns:
+            Phase definition dict, or None if not found
+        """
+        playbook = self._playbooks.get(playbook_id)
+        if not playbook:
+            return None
+
+        phases: dict[str, dict[str, Any]] = playbook.get("phases", {})
+        return phases.get(phase_id)
+
+    def get_entry_phase(self, playbook_id: str) -> str | None:
+        """
+        Get the entry phase for a playbook.
+
+        Args:
+            playbook_id: ID of the playbook
+
+        Returns:
+            Entry phase ID, or None if not found/not specified
+        """
+        playbook = self._playbooks.get(playbook_id)
+        if not playbook:
+            return None
+        return playbook.get("entry_phase")
+
+    def get_rework_target_phases(self, playbook_id: str) -> list[str]:
+        """
+        Get all phases marked as rework targets in a playbook.
+
+        Args:
+            playbook_id: ID of the playbook
+
+        Returns:
+            List of phase IDs that are rework targets
+        """
+        playbook = self._playbooks.get(playbook_id)
+        if not playbook:
+            return []
+
+        phases = playbook.get("phases", {})
+        return [
+            phase_id for phase_id, phase in phases.items() if phase.get("is_rework_target", False)
+        ]
+
+    def list_playbooks(self) -> list[str]:
+        """
+        List all loaded playbook IDs.
+
+        Returns:
+            List of playbook IDs
+        """
+        return list(self._playbooks.keys())
+
+    def get_playbook_dict(self) -> dict[str, dict[str, Any]]:
+        """
+        Get the raw playbook dictionary.
+
+        This can be passed directly to PlaybookNudger which expects
+        the same dict[str, dict[str, Any]] format.
+
+        Returns:
+            Dictionary of playbook_id -> playbook definition
+        """
+        return self._playbooks

--- a/src/questfoundry/runtime/delegation/playbook_loader.py
+++ b/src/questfoundry/runtime/delegation/playbook_loader.py
@@ -58,15 +58,16 @@ class PlaybookLoader:
         Returns:
             PlaybookLoader instance
         """
-        playbook_dict: dict[str, dict[str, Any]] = {}
-        for pb in playbooks:
-            playbook_dict[pb.id] = {
+        playbook_dict = {
+            pb.id: {
                 "id": pb.id,
                 "name": pb.name,
                 "phases": pb.phases,
                 "max_rework_cycles": pb.max_rework_cycles,
                 "entry_phase": pb.entry_phase,
             }
+            for pb in playbooks
+        }
         return cls(playbook_dict)
 
     def get_playbook(self, playbook_id: str) -> dict[str, Any] | None:
@@ -94,10 +95,7 @@ class PlaybookLoader:
         Returns:
             Maximum rework cycles, defaults to 3 if playbook not found
         """
-        playbook = self._playbooks.get(playbook_id)
-        if not playbook:
-            return 3  # Default from schema
-        result: int = playbook.get("max_rework_cycles", 3)
+        result: int = self._playbooks.get(playbook_id, {}).get("max_rework_cycles", 3)
         return result
 
     def is_rework_target(self, playbook_id: str, phase_id: str) -> bool:
@@ -115,15 +113,9 @@ class PlaybookLoader:
         Returns:
             True if the phase is a rework target, False otherwise
         """
-        playbook = self._playbooks.get(playbook_id)
-        if not playbook:
-            return False
-
+        playbook = self._playbooks.get(playbook_id, {})
         phases = playbook.get("phases", {})
-        phase = phases.get(phase_id)
-        if not phase:
-            return False
-
+        phase = phases.get(phase_id, {})
         result: bool = phase.get("is_rework_target", False)
         return result
 
@@ -138,12 +130,10 @@ class PlaybookLoader:
         Returns:
             Phase definition dict, or None if not found
         """
-        playbook = self._playbooks.get(playbook_id)
-        if not playbook:
-            return None
-
-        phases: dict[str, dict[str, Any]] = playbook.get("phases", {})
-        return phases.get(phase_id)
+        result: dict[str, Any] | None = (
+            self._playbooks.get(playbook_id, {}).get("phases", {}).get(phase_id)
+        )
+        return result
 
     def get_entry_phase(self, playbook_id: str) -> str | None:
         """
@@ -170,11 +160,7 @@ class PlaybookLoader:
         Returns:
             List of phase IDs that are rework targets
         """
-        playbook = self._playbooks.get(playbook_id)
-        if not playbook:
-            return []
-
-        phases = playbook.get("phases", {})
+        phases = self._playbooks.get(playbook_id, {}).get("phases", {})
         return [
             phase_id for phase_id, phase in phases.items() if phase.get("is_rework_target", False)
         ]

--- a/src/questfoundry/runtime/messaging/message.py
+++ b/src/questfoundry/runtime/messaging/message.py
@@ -211,6 +211,7 @@ def create_delegation_request(
     playbook_instance_id: str | None = None,
     phase_id: str | None = None,
     turn_created: int | None = None,
+    is_rework_target: bool = False,
 ) -> Message:
     """
     Create a delegation request message.
@@ -224,6 +225,7 @@ def create_delegation_request(
         playbook_instance_id: Specific playbook execution
         phase_id: Current phase
         turn_created: Current turn number
+        is_rework_target: Whether the phase is a rework target (counts against budget)
 
     Returns:
         Delegation request message
@@ -234,6 +236,7 @@ def create_delegation_request(
     payload = {
         "task": task,
         "context": context or {},
+        "is_rework_target": is_rework_target,
     }
 
     return create_message(

--- a/src/questfoundry/runtime/tools/delegate.py
+++ b/src/questfoundry/runtime/tools/delegate.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from questfoundry.runtime.delegation import PlaybookLoader
 from questfoundry.runtime.messaging import create_delegation_request
 from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
 from questfoundry.runtime.tools.registry import register_tool
@@ -50,7 +51,12 @@ class DelegateTool(BaseTool):
         playbook_ref = args.get("playbook_ref")
         playbook_instance_id = args.get("playbook_instance_id")
         phase_ref = args.get("phase_ref")
-        is_rework_target = args.get("is_rework_target", False)
+
+        # Auto-resolve is_rework_target from playbook definition if not explicitly set
+        is_rework_target = args.get("is_rework_target")
+        if is_rework_target is None and playbook_ref and phase_ref:
+            is_rework_target = self._lookup_is_rework_target(playbook_ref, phase_ref)
+        is_rework_target = is_rework_target or False
 
         # Validate: must have task
         if not task:
@@ -78,21 +84,16 @@ class DelegateTool(BaseTool):
                 error="Cannot delegate to self",
             )
 
-        # Build delegation context including additional metadata
-        delegation_context = {
-            **context,
-            "is_rework_target": is_rework_target,
-        }
-
         # Create delegation request message
         message = create_delegation_request(
             from_agent=self._context.agent_id or "unknown",
             to_agent=target_agent,
             task=task,
-            context=delegation_context,
+            context=context,
             playbook_id=playbook_ref,
             playbook_instance_id=playbook_instance_id,
             phase_id=phase_ref,
+            is_rework_target=is_rework_target,
         )
 
         # Route via broker if available
@@ -144,3 +145,21 @@ class DelegateTool(BaseTool):
             return None
 
         return None
+
+    def _lookup_is_rework_target(self, playbook_id: str, phase_id: str) -> bool:
+        """
+        Look up whether a phase is a rework target from playbook definitions.
+
+        Phases marked as rework targets have their re-entries counted against
+        the playbook's rework budget. When the budget is exhausted, re-entering
+        these phases triggers escalation.
+
+        Args:
+            playbook_id: ID of the playbook
+            phase_id: ID of the phase
+
+        Returns:
+            True if the phase is a rework target, False otherwise
+        """
+        loader = PlaybookLoader.from_playbooks(self._context.studio.playbooks)
+        return loader.is_rework_target(playbook_id, phase_id)

--- a/src/questfoundry/runtime/tools/delegate.py
+++ b/src/questfoundry/runtime/tools/delegate.py
@@ -54,9 +54,11 @@ class DelegateTool(BaseTool):
 
         # Auto-resolve is_rework_target from playbook definition if not explicitly set
         is_rework_target = args.get("is_rework_target")
-        if is_rework_target is None and playbook_ref and phase_ref:
-            is_rework_target = self._lookup_is_rework_target(playbook_ref, phase_ref)
-        is_rework_target = is_rework_target or False
+        if is_rework_target is None:
+            if playbook_ref and phase_ref:
+                is_rework_target = self._lookup_is_rework_target(playbook_ref, phase_ref)
+            else:
+                is_rework_target = False
 
         # Validate: must have task
         if not task:
@@ -161,5 +163,7 @@ class DelegateTool(BaseTool):
         Returns:
             True if the phase is a rework target, False otherwise
         """
-        loader = PlaybookLoader.from_playbooks(self._context.studio.playbooks)
-        return loader.is_rework_target(playbook_id, phase_id)
+        # Lazy initialization of cached PlaybookLoader
+        if not hasattr(self, "_playbook_loader"):
+            self._playbook_loader = PlaybookLoader.from_playbooks(self._context.studio.playbooks)
+        return self._playbook_loader.is_rework_target(playbook_id, phase_id)

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for runtime tests."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def make_mock_playbook(
+    playbook_id: str,
+    phases: dict[str, dict[str, Any]],
+    max_rework_cycles: int = 3,
+) -> MagicMock:
+    """
+    Create a mock playbook for testing.
+
+    Args:
+        playbook_id: Playbook ID
+        phases: Dictionary of phase_id -> phase definition
+        max_rework_cycles: Maximum rework cycles for this playbook
+
+    Returns:
+        Mock playbook object
+    """
+    playbook = MagicMock()
+    playbook.id = playbook_id
+    playbook.name = playbook_id.replace("_", " ").title()
+    playbook.phases = phases
+    playbook.max_rework_cycles = max_rework_cycles
+    playbook.entry_phase = next(iter(phases.keys())) if phases else None
+    return playbook
+
+
+@pytest.fixture
+def mock_playbook_factory():
+    """Factory fixture for creating mock playbooks."""
+    return make_mock_playbook

--- a/tests/runtime/delegation/test_integration.py
+++ b/tests/runtime/delegation/test_integration.py
@@ -26,21 +26,7 @@ from questfoundry.runtime.messaging import (
 )
 from questfoundry.runtime.tools.base import ToolContext
 from questfoundry.runtime.tools.delegate import DelegateTool
-
-
-def make_mock_playbook(
-    playbook_id: str,
-    phases: dict,
-    max_rework_cycles: int = 3,
-):
-    """Create mock playbook."""
-    playbook = MagicMock()
-    playbook.id = playbook_id
-    playbook.name = playbook_id.replace("_", " ").title()
-    playbook.phases = phases
-    playbook.max_rework_cycles = max_rework_cycles
-    playbook.entry_phase = next(iter(phases.keys())) if phases else None
-    return playbook
+from tests.runtime.conftest import make_mock_playbook
 
 
 def make_mock_studio():

--- a/tests/runtime/delegation/test_integration.py
+++ b/tests/runtime/delegation/test_integration.py
@@ -28,6 +28,21 @@ from questfoundry.runtime.tools.base import ToolContext
 from questfoundry.runtime.tools.delegate import DelegateTool
 
 
+def make_mock_playbook(
+    playbook_id: str,
+    phases: dict,
+    max_rework_cycles: int = 3,
+):
+    """Create mock playbook."""
+    playbook = MagicMock()
+    playbook.id = playbook_id
+    playbook.name = playbook_id.replace("_", " ").title()
+    playbook.phases = phases
+    playbook.max_rework_cycles = max_rework_cycles
+    playbook.entry_phase = next(iter(phases.keys())) if phases else None
+    return playbook
+
+
 def make_mock_studio():
     """Create a mock studio with agents."""
     studio = MagicMock()
@@ -45,6 +60,28 @@ def make_mock_studio():
         agents.append(agent)
 
     studio.agents = agents
+
+    # Add playbooks with rework target markers
+    studio.playbooks = [
+        make_mock_playbook(
+            "scene_weave",
+            {
+                "drafting": {"name": "Drafting", "is_rework_target": True},
+                "polish": {"name": "Polish", "is_rework_target": True},
+                "quality_check": {"name": "Quality Check", "is_rework_target": False},
+            },
+            max_rework_cycles=2,
+        ),
+        make_mock_playbook(
+            "story_spark",
+            {
+                "topology": {"name": "Topology", "is_rework_target": False},
+                "brief_creation": {"name": "Brief Creation", "is_rework_target": True},
+            },
+            max_rework_cycles=3,
+        ),
+    ]
+
     return studio
 
 
@@ -458,3 +495,263 @@ class TestEscalationFlow:
         # Verify playbook was marked escalated
         updated_instance = await tracker.get_instance(instance.instance_id)
         assert updated_instance.status == PlaybookStatus.ESCALATED
+
+
+class TestPlaybookLoaderIntegration:
+    """Tests for PlaybookLoader integration with delegation flow."""
+
+    @pytest.fixture
+    def broker(self):
+        return AsyncMessageBroker()
+
+    @pytest.fixture
+    def tracker(self):
+        return PlaybookTracker()
+
+    @pytest.fixture
+    def bouncer(self):
+        return DelegationBouncer()
+
+    @pytest.mark.asyncio
+    async def test_delegate_tool_auto_resolves_rework_target(self, broker):
+        """Test full flow where delegate tool auto-resolves is_rework_target."""
+        studio = make_mock_studio()
+        definition = make_mock_tool_definition()
+
+        context = ToolContext(
+            studio=studio,
+            agent_id="showrunner",
+            broker=broker,
+        )
+        tool = DelegateTool(definition, context)
+
+        # Delegate to a rework target phase
+        result = await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Write the draft",
+                "playbook_ref": "scene_weave",
+                "phase_ref": "drafting",  # is_rework_target: True
+            }
+        )
+
+        assert result.success is True
+
+        # Verify message has is_rework_target=True from auto-lookup
+        inbox = await broker.get_inbox("scene_smith")
+        assert len(inbox) == 1
+        assert inbox[0].payload["is_rework_target"] is True
+
+    @pytest.mark.asyncio
+    async def test_delegate_tool_non_rework_target_phase(self, broker):
+        """Test delegate tool with non-rework target phase."""
+        studio = make_mock_studio()
+        definition = make_mock_tool_definition()
+
+        context = ToolContext(
+            studio=studio,
+            agent_id="showrunner",
+            broker=broker,
+        )
+        tool = DelegateTool(definition, context)
+
+        # Delegate to a non-rework target phase
+        result = await tool.execute(
+            {
+                "to_agent": "gatekeeper",
+                "task": "Check quality",
+                "playbook_ref": "scene_weave",
+                "phase_ref": "quality_check",  # is_rework_target: False
+            }
+        )
+
+        assert result.success is True
+
+        inbox = await broker.get_inbox("gatekeeper")
+        assert len(inbox) == 1
+        assert inbox[0].payload["is_rework_target"] is False
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_rework_loop_with_auto_lookup(self, broker, bouncer, tracker):
+        """Test complete rework loop using PlaybookLoader auto-lookup."""
+        from questfoundry.runtime.delegation import PlaybookLoader
+
+        studio = make_mock_studio()
+        definition = make_mock_tool_definition()
+
+        # Create loader from studio playbooks
+        loader = PlaybookLoader.from_playbooks(studio.playbooks)
+
+        # Start playbook with max_rework_cycles from loader
+        max_rework = loader.get_max_rework_cycles("scene_weave")
+        instance = await tracker.start_playbook(
+            playbook_id="scene_weave",
+            max_rework_cycles=max_rework,  # Should be 2
+            initiating_agent="showrunner",
+        )
+        assert max_rework == 2
+
+        # Setup delegate tool
+        context = ToolContext(
+            studio=studio,
+            agent_id="showrunner",
+            broker=broker,
+        )
+        tool = DelegateTool(definition, context)
+
+        # Setup executor
+        activator = AsyncMock()
+        activator.activate.return_value = {"success": True, "result": {}}
+        executor = AsyncDelegationExecutor(broker, bouncer, tracker, activator)
+
+        # First delegation to drafting phase (rework target)
+        await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Write first draft",
+                "playbook_ref": "scene_weave",
+                "playbook_instance_id": instance.instance_id,
+                "phase_ref": "drafting",
+            }
+        )
+
+        # Process the delegation
+        inbox = await broker.get_inbox("scene_smith")
+        assert len(inbox) == 1
+        msg = inbox[0]
+
+        # Verify is_rework_target was auto-resolved
+        assert msg.payload["is_rework_target"] is True
+
+        result = await executor.execute(msg)
+        assert result.success is True
+
+        # Check rework tracking
+        updated_instance = await tracker.get_instance(instance.instance_id)
+        assert updated_instance.rework_target_visits["drafting"] == 1
+        assert updated_instance.rework_count == 0  # First visit doesn't count
+
+        # Clear inbox and do rework #1
+        broker._mailboxes["scene_smith"]._queue.clear()
+        await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Revise draft",
+                "playbook_ref": "scene_weave",
+                "playbook_instance_id": instance.instance_id,
+                "phase_ref": "drafting",
+            }
+        )
+
+        inbox = await broker.get_inbox("scene_smith")
+        msg = inbox[0]
+        result = await executor.execute(msg)
+        assert result.success is True
+
+        updated_instance = await tracker.get_instance(instance.instance_id)
+        assert updated_instance.rework_target_visits["drafting"] == 2
+        assert updated_instance.rework_count == 1  # First rework
+
+        # Clear inbox and do rework #2
+        broker._mailboxes["scene_smith"]._queue.clear()
+        await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Revise again",
+                "playbook_ref": "scene_weave",
+                "playbook_instance_id": instance.instance_id,
+                "phase_ref": "drafting",
+            }
+        )
+
+        inbox = await broker.get_inbox("scene_smith")
+        msg = inbox[0]
+        result = await executor.execute(msg)
+        assert result.success is True
+
+        updated_instance = await tracker.get_instance(instance.instance_id)
+        assert updated_instance.rework_count == 2  # Second rework (at limit)
+
+        # Now rework #3 should trigger escalation
+        broker._mailboxes["scene_smith"]._queue.clear()
+        broker._mailboxes["showrunner"]._queue.clear()
+
+        await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "One more revision",
+                "playbook_ref": "scene_weave",
+                "playbook_instance_id": instance.instance_id,
+                "phase_ref": "drafting",
+            }
+        )
+
+        inbox = await broker.get_inbox("scene_smith")
+        msg = inbox[0]
+        result = await executor.execute(msg)
+
+        # Should fail and escalate
+        assert result.success is False
+        assert "Escalated" in result.error
+
+        # Check for escalation message
+        sr_inbox = await broker.get_inbox("showrunner")
+        escalations = [m for m in sr_inbox if m.type == MessageType.ESCALATION]
+        assert len(escalations) == 1
+
+    @pytest.mark.asyncio
+    async def test_rework_budget_not_consumed_for_non_target_phases(self, bouncer, tracker):
+        """Test that non-rework target phases don't consume budget."""
+        # Create fresh broker for this test
+        broker = AsyncMessageBroker()
+        studio = make_mock_studio()
+        definition = make_mock_tool_definition()
+
+        instance = await tracker.start_playbook(
+            playbook_id="scene_weave",
+            max_rework_cycles=1,
+            initiating_agent="showrunner",
+        )
+
+        context = ToolContext(
+            studio=studio,
+            agent_id="showrunner",
+            broker=broker,
+        )
+        tool = DelegateTool(definition, context)
+
+        activator = AsyncMock()
+        activator.activate.return_value = {"success": True, "result": {}}
+        executor = AsyncDelegationExecutor(broker, bouncer, tracker, activator)
+
+        # Multiple visits to quality_check (is_rework_target: False)
+        # Process messages one at a time using get_next
+        for i in range(5):
+            await tool.execute(
+                {
+                    "to_agent": "gatekeeper",
+                    "task": f"Quality check iteration {i}",
+                    "playbook_ref": "scene_weave",
+                    "playbook_instance_id": instance.instance_id,
+                    "phase_ref": "quality_check",  # is_rework_target: False
+                }
+            )
+
+            # Get the mailbox and pop the message
+            mailbox = await broker.get_mailbox("gatekeeper")
+            msg = await mailbox.get(timeout=1.0)
+
+            assert msg is not None
+            # Verify auto-lookup set is_rework_target to False
+            assert msg.payload["is_rework_target"] is False
+
+            result = await executor.execute(msg)
+            assert result.success is True  # Should never escalate
+
+        # Verify budget wasn't consumed
+        # Non-rework target phases don't count against budget or track visits
+        updated_instance = await tracker.get_instance(instance.instance_id)
+        assert updated_instance.rework_count == 0
+        assert updated_instance.current_phase == "quality_check"
+        # Non-rework targets aren't tracked in rework_target_visits
+        # (only is_rework_target=True phases are tracked there)

--- a/tests/runtime/delegation/test_playbook_loader.py
+++ b/tests/runtime/delegation/test_playbook_loader.py
@@ -1,0 +1,246 @@
+"""Tests for PlaybookLoader."""
+
+import pytest
+
+from questfoundry.runtime.delegation import PlaybookLoader
+from questfoundry.runtime.models.base import Playbook
+
+
+class TestPlaybookLoader:
+    """Tests for PlaybookLoader class."""
+
+    @pytest.fixture
+    def sample_playbooks_dict(self) -> dict:
+        """Sample playbook definitions as dicts."""
+        return {
+            "story_spark": {
+                "id": "story_spark",
+                "name": "Story Spark",
+                "max_rework_cycles": 3,
+                "entry_phase": "topology_design",
+                "phases": {
+                    "topology_design": {
+                        "name": "Topology Design",
+                        "is_rework_target": False,
+                    },
+                    "brief_creation": {
+                        "name": "Brief Creation",
+                        "is_rework_target": True,
+                    },
+                    "preview_gate": {
+                        "name": "Preview Gate",
+                        "is_rework_target": False,
+                    },
+                },
+            },
+            "scene_weave": {
+                "id": "scene_weave",
+                "name": "Scene Weave",
+                "max_rework_cycles": 2,
+                "entry_phase": "drafting",
+                "phases": {
+                    "drafting": {
+                        "name": "Drafting",
+                        "is_rework_target": True,
+                    },
+                    "polish": {
+                        "name": "Polish",
+                        "is_rework_target": True,
+                    },
+                },
+            },
+        }
+
+    @pytest.fixture
+    def sample_playbook_models(self) -> list[Playbook]:
+        """Sample Playbook model objects."""
+        return [
+            Playbook(
+                id="story_spark",
+                name="Story Spark",
+                purpose="Design story structure",
+                max_rework_cycles=3,
+                entry_phase="topology_design",
+                phases={
+                    "topology_design": {
+                        "name": "Topology Design",
+                        "is_rework_target": False,
+                    },
+                    "brief_creation": {
+                        "name": "Brief Creation",
+                        "is_rework_target": True,
+                    },
+                },
+            ),
+            Playbook(
+                id="scene_weave",
+                name="Scene Weave",
+                purpose="Draft prose",
+                max_rework_cycles=2,
+                entry_phase="drafting",
+                phases={
+                    "drafting": {
+                        "name": "Drafting",
+                        "is_rework_target": True,
+                    },
+                },
+            ),
+        ]
+
+    def test_init_from_dict(self, sample_playbooks_dict: dict):
+        """Test initialization from playbook dict."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.list_playbooks() == ["story_spark", "scene_weave"]
+
+    def test_from_playbooks_factory(self, sample_playbook_models: list[Playbook]):
+        """Test factory method from Playbook models."""
+        loader = PlaybookLoader.from_playbooks(sample_playbook_models)
+
+        assert set(loader.list_playbooks()) == {"story_spark", "scene_weave"}
+
+    def test_get_max_rework_cycles(self, sample_playbooks_dict: dict):
+        """Test getting max rework cycles."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_max_rework_cycles("story_spark") == 3
+        assert loader.get_max_rework_cycles("scene_weave") == 2
+
+    def test_get_max_rework_cycles_default(self, sample_playbooks_dict: dict):
+        """Test default max rework cycles for missing playbook."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        # Missing playbook returns default
+        assert loader.get_max_rework_cycles("nonexistent") == 3
+
+    def test_is_rework_target_true(self, sample_playbooks_dict: dict):
+        """Test identifying rework target phases."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.is_rework_target("story_spark", "brief_creation") is True
+        assert loader.is_rework_target("scene_weave", "drafting") is True
+        assert loader.is_rework_target("scene_weave", "polish") is True
+
+    def test_is_rework_target_false(self, sample_playbooks_dict: dict):
+        """Test non-rework target phases."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.is_rework_target("story_spark", "topology_design") is False
+        assert loader.is_rework_target("story_spark", "preview_gate") is False
+
+    def test_is_rework_target_missing_playbook(self, sample_playbooks_dict: dict):
+        """Test rework target check for missing playbook."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.is_rework_target("nonexistent", "some_phase") is False
+
+    def test_is_rework_target_missing_phase(self, sample_playbooks_dict: dict):
+        """Test rework target check for missing phase."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.is_rework_target("story_spark", "nonexistent_phase") is False
+
+    def test_get_phase(self, sample_playbooks_dict: dict):
+        """Test getting phase definition."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        phase = loader.get_phase("story_spark", "brief_creation")
+        assert phase is not None
+        assert phase["name"] == "Brief Creation"
+        assert phase["is_rework_target"] is True
+
+    def test_get_phase_missing(self, sample_playbooks_dict: dict):
+        """Test getting missing phase."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_phase("story_spark", "nonexistent") is None
+        assert loader.get_phase("nonexistent", "brief_creation") is None
+
+    def test_get_entry_phase(self, sample_playbooks_dict: dict):
+        """Test getting entry phase."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_entry_phase("story_spark") == "topology_design"
+        assert loader.get_entry_phase("scene_weave") == "drafting"
+
+    def test_get_entry_phase_missing(self, sample_playbooks_dict: dict):
+        """Test getting entry phase for missing playbook."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_entry_phase("nonexistent") is None
+
+    def test_get_rework_target_phases(self, sample_playbooks_dict: dict):
+        """Test getting all rework target phases."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        targets = loader.get_rework_target_phases("story_spark")
+        assert targets == ["brief_creation"]
+
+        targets = loader.get_rework_target_phases("scene_weave")
+        assert set(targets) == {"drafting", "polish"}
+
+    def test_get_rework_target_phases_none(self):
+        """Test playbook with no rework targets."""
+        loader = PlaybookLoader(
+            {
+                "no_rework": {
+                    "id": "no_rework",
+                    "name": "No Rework",
+                    "phases": {
+                        "phase1": {"name": "Phase 1"},
+                        "phase2": {"name": "Phase 2"},
+                    },
+                }
+            }
+        )
+
+        assert loader.get_rework_target_phases("no_rework") == []
+
+    def test_get_rework_target_phases_missing(self, sample_playbooks_dict: dict):
+        """Test rework targets for missing playbook."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_rework_target_phases("nonexistent") == []
+
+    def test_get_playbook(self, sample_playbooks_dict: dict):
+        """Test getting full playbook definition."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        playbook = loader.get_playbook("story_spark")
+        assert playbook is not None
+        assert playbook["id"] == "story_spark"
+        assert playbook["max_rework_cycles"] == 3
+
+    def test_get_playbook_missing(self, sample_playbooks_dict: dict):
+        """Test getting missing playbook."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        assert loader.get_playbook("nonexistent") is None
+
+    def test_get_playbook_dict(self, sample_playbooks_dict: dict):
+        """Test getting raw playbook dictionary."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        playbook_dict = loader.get_playbook_dict()
+        assert playbook_dict is sample_playbooks_dict
+
+    def test_from_playbooks_preserves_phases(self, sample_playbook_models: list[Playbook]):
+        """Test that from_playbooks preserves phase structure."""
+        loader = PlaybookLoader.from_playbooks(sample_playbook_models)
+
+        # Verify phases are properly transferred
+        phase = loader.get_phase("story_spark", "brief_creation")
+        assert phase is not None
+        assert phase["is_rework_target"] is True
+
+    def test_playbook_dict_compatible_with_nudger(self, sample_playbooks_dict: dict):
+        """Test that playbook dict can be used with PlaybookNudger."""
+        loader = PlaybookLoader(sample_playbooks_dict)
+
+        # PlaybookNudger expects dict[str, dict[str, Any]]
+        playbook_dict = loader.get_playbook_dict()
+        assert isinstance(playbook_dict, dict)
+        for pb_id, pb_def in playbook_dict.items():
+            assert isinstance(pb_id, str)
+            assert isinstance(pb_def, dict)
+            assert "phases" in pb_def

--- a/tests/runtime/tools/test_delegate.py
+++ b/tests/runtime/tools/test_delegate.py
@@ -9,21 +9,7 @@ import pytest
 from questfoundry.runtime.messaging import AsyncMessageBroker
 from questfoundry.runtime.tools.base import ToolContext, ToolValidationError
 from questfoundry.runtime.tools.delegate import DelegateTool
-
-
-def make_mock_playbook(
-    playbook_id: str,
-    phases: dict,
-    max_rework_cycles: int = 3,
-):
-    """Create mock playbook."""
-    playbook = MagicMock()
-    playbook.id = playbook_id
-    playbook.name = playbook_id.replace("_", " ").title()
-    playbook.phases = phases
-    playbook.max_rework_cycles = max_rework_cycles
-    playbook.entry_phase = next(iter(phases.keys())) if phases else None
-    return playbook
+from tests.runtime.conftest import make_mock_playbook
 
 
 def make_mock_studio_with_agents():

--- a/tests/runtime/tools/test_delegate.py
+++ b/tests/runtime/tools/test_delegate.py
@@ -11,6 +11,21 @@ from questfoundry.runtime.tools.base import ToolContext, ToolValidationError
 from questfoundry.runtime.tools.delegate import DelegateTool
 
 
+def make_mock_playbook(
+    playbook_id: str,
+    phases: dict,
+    max_rework_cycles: int = 3,
+):
+    """Create mock playbook."""
+    playbook = MagicMock()
+    playbook.id = playbook_id
+    playbook.name = playbook_id.replace("_", " ").title()
+    playbook.phases = phases
+    playbook.max_rework_cycles = max_rework_cycles
+    playbook.entry_phase = next(iter(phases.keys())) if phases else None
+    return playbook
+
+
 def make_mock_studio_with_agents():
     """Create mock studio with agents."""
     studio = MagicMock()
@@ -31,6 +46,27 @@ def make_mock_studio_with_agents():
     agent3.archetypes = ["validator"]
 
     studio.agents = [agent1, agent2, agent3]
+
+    # Add playbooks for testing rework target lookup
+    studio.playbooks = [
+        make_mock_playbook(
+            "story_spark",
+            {
+                "topology_design": {"name": "Topology Design", "is_rework_target": False},
+                "brief_creation": {"name": "Brief Creation", "is_rework_target": True},
+                "preview_gate": {"name": "Preview Gate", "is_rework_target": False},
+            },
+            max_rework_cycles=3,
+        ),
+        make_mock_playbook(
+            "scene_weave",
+            {
+                "drafting": {"name": "Drafting", "is_rework_target": True},
+                "polish": {"name": "Polish", "is_rework_target": True},
+            },
+            max_rework_cycles=2,
+        ),
+    ]
 
     return studio
 
@@ -232,3 +268,129 @@ class TestDelegateTool:
 
         assert result.success is True
         assert result.data["assigned_to"] == "scene_smith"
+
+    @pytest.mark.asyncio
+    async def test_is_rework_target_auto_lookup_true(self):
+        """Test automatic lookup of is_rework_target from playbook definition."""
+        studio = make_mock_studio_with_agents()
+        definition = make_mock_definition()
+        broker = AsyncMock(spec=AsyncMessageBroker)
+        context = ToolContext(studio=studio, agent_id="showrunner", broker=broker)
+        tool = DelegateTool(definition, context)
+
+        # Delegate to a phase that is marked as rework target
+        result = await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Create briefs",
+                "playbook_ref": "story_spark",
+                "phase_ref": "brief_creation",  # This phase has is_rework_target: True
+            }
+        )
+
+        assert result.success is True
+
+        # Verify the message payload includes is_rework_target from lookup
+        broker.send.assert_called_once()
+        message = broker.send.call_args[0][0]
+        assert message.payload["is_rework_target"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_rework_target_auto_lookup_false(self):
+        """Test auto-lookup returns false for non-rework target phases."""
+        studio = make_mock_studio_with_agents()
+        definition = make_mock_definition()
+        broker = AsyncMock(spec=AsyncMessageBroker)
+        context = ToolContext(studio=studio, agent_id="showrunner", broker=broker)
+        tool = DelegateTool(definition, context)
+
+        # Delegate to a phase that is NOT marked as rework target
+        result = await tool.execute(
+            {
+                "to_agent": "gatekeeper",
+                "task": "Run preview gate",
+                "playbook_ref": "story_spark",
+                "phase_ref": "preview_gate",  # This phase has is_rework_target: False
+            }
+        )
+
+        assert result.success is True
+
+        # Verify is_rework_target is false
+        message = broker.send.call_args[0][0]
+        assert message.payload["is_rework_target"] is False
+
+    @pytest.mark.asyncio
+    async def test_is_rework_target_explicit_override(self):
+        """Test that explicit is_rework_target overrides auto-lookup."""
+        studio = make_mock_studio_with_agents()
+        definition = make_mock_definition()
+        broker = AsyncMock(spec=AsyncMessageBroker)
+        context = ToolContext(studio=studio, agent_id="showrunner", broker=broker)
+        tool = DelegateTool(definition, context)
+
+        # Explicitly set is_rework_target=False even though phase has it True
+        result = await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Create briefs",
+                "playbook_ref": "story_spark",
+                "phase_ref": "brief_creation",  # Has is_rework_target: True
+                "is_rework_target": False,  # Explicit override
+            }
+        )
+
+        assert result.success is True
+
+        # Verify explicit override took precedence
+        message = broker.send.call_args[0][0]
+        assert message.payload["is_rework_target"] is False
+
+    @pytest.mark.asyncio
+    async def test_is_rework_target_without_playbook_context(self):
+        """Test is_rework_target defaults to False without playbook context."""
+        studio = make_mock_studio_with_agents()
+        definition = make_mock_definition()
+        broker = AsyncMock(spec=AsyncMessageBroker)
+        context = ToolContext(studio=studio, agent_id="showrunner", broker=broker)
+        tool = DelegateTool(definition, context)
+
+        # Delegate without playbook context
+        result = await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Write something",
+                # No playbook_ref or phase_ref
+            }
+        )
+
+        assert result.success is True
+
+        # Verify is_rework_target defaults to False
+        message = broker.send.call_args[0][0]
+        assert message.payload["is_rework_target"] is False
+
+    @pytest.mark.asyncio
+    async def test_is_rework_target_unknown_playbook(self):
+        """Test is_rework_target defaults to False for unknown playbook."""
+        studio = make_mock_studio_with_agents()
+        definition = make_mock_definition()
+        broker = AsyncMock(spec=AsyncMessageBroker)
+        context = ToolContext(studio=studio, agent_id="showrunner", broker=broker)
+        tool = DelegateTool(definition, context)
+
+        # Delegate with unknown playbook
+        result = await tool.execute(
+            {
+                "to_agent": "scene_smith",
+                "task": "Do something",
+                "playbook_ref": "nonexistent_playbook",
+                "phase_ref": "some_phase",
+            }
+        )
+
+        assert result.success is True
+
+        # Verify is_rework_target defaults to False for unknown playbook
+        message = broker.send.call_args[0][0]
+        assert message.payload["is_rework_target"] is False


### PR DESCRIPTION
## Summary

- **PlaybookLoader class** extracts rework metadata from playbook definitions
  - `get_max_rework_cycles()` for per-playbook budget ceilings
  - `is_rework_target()` for per-phase rework tracking markers
  - `from_playbooks()` factory for Studio.playbooks integration

- **Delegate tool auto-resolves** `is_rework_target` from playbook definitions when `playbook_ref` and `phase_ref` are provided

- **create_delegation_request()** now includes `is_rework_target` in payload at the top level where the executor expects it

## Test Plan

- [x] 20 unit tests for PlaybookLoader
- [x] 5 new tests for auto-lookup in delegate tool
- [x] 4 new integration tests for rework loop flow
- [x] All 765 runtime tests pass

## Related

Part of Phase 6 remaining items for issue #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)