### PR TITLE
fix(delegation): enforce hub-and-spoke architecture

### DIFF
--- a/domain-v4/agents/art_director.json
+++ b/domain-v4/agents/art_director.json
@@ -23,6 +23,13 @@
       "tool_ref": "search_workspace"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Read workspace for briefs and style guide, canon for world details, exports for placement context",

--- a/domain-v4/agents/audio_director.json
+++ b/domain-v4/agents/audio_director.json
@@ -30,6 +30,13 @@
       "tool_ref": "generate_audio"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Read workspace, canon, and codex for context",

--- a/domain-v4/agents/book_binder.json
+++ b/domain-v4/agents/book_binder.json
@@ -31,6 +31,13 @@
       "tool_ref": "validate_artifact"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_canon",
       "name": "Read Canon",
       "description": "Read from Canon store to assemble exports",

--- a/domain-v4/agents/codex_curator.json
+++ b/domain-v4/agents/codex_curator.json
@@ -30,6 +30,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Read canon for source truth, workspace for context and style guidance",

--- a/domain-v4/agents/gatekeeper.json
+++ b/domain-v4/agents/gatekeeper.json
@@ -36,6 +36,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_all_stores",
       "name": "Read All Stores",
       "description": "Can read from any store to validate content",

--- a/domain-v4/agents/lore_weaver.json
+++ b/domain-v4/agents/lore_weaver.json
@@ -30,6 +30,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Read workspace for briefs and context, audit for consistency checks",

--- a/domain-v4/agents/player_narrator.json
+++ b/domain-v4/agents/player_narrator.json
@@ -18,6 +18,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_canon",
       "name": "Read Canon",
       "description": "Read canon for world truth—used to ensure improvisation never contradicts established facts",

--- a/domain-v4/agents/plotwright.json
+++ b/domain-v4/agents/plotwright.json
@@ -23,11 +23,11 @@
       "tool_ref": "consult_schema"
     },
     {
-      "id": "use_delegate_tool",
-      "name": "Use Delegate Tool",
-      "description": "Can delegate to Scene Smith when briefs are ready",
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
       "category": "tool",
-      "tool_ref": "delegate"
+      "tool_ref": "return_to_orchestrator"
     },
     {
       "id": "use_consult_corpus",
@@ -98,7 +98,7 @@
     {
       "id": "no_direct_prose",
       "name": "No Direct Prose Writing",
-      "rule": "Write briefs and topology notes, not section prose. Delegate prose to Scene Smith.",
+      "rule": "Write briefs and topology notes, not section prose. Scene Smith handles prose—Showrunner will coordinate that handoff.",
       "category": "content",
       "enforcement": "llm",
       "severity": "warning"

--- a/domain-v4/agents/researcher.json
+++ b/domain-v4/agents/researcher.json
@@ -31,6 +31,13 @@
       "tool_ref": "consult_schema"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Can read workspace and canon for context on what needs verification",

--- a/domain-v4/agents/scene_smith.json
+++ b/domain-v4/agents/scene_smith.json
@@ -37,6 +37,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Can read workspace and canon for context",

--- a/domain-v4/agents/style_lead.json
+++ b/domain-v4/agents/style_lead.json
@@ -30,6 +30,13 @@
       "tool_ref": "consult_corpus"
     },
     {
+      "id": "use_return_to_orchestrator",
+      "name": "Return to Orchestrator",
+      "description": "Signal task completion and return control to Showrunner",
+      "category": "tool",
+      "tool_ref": "return_to_orchestrator"
+    },
+    {
       "id": "read_stores",
       "name": "Read Stores",
       "description": "Read workspace, canon, and exports to detect drift and review surfaces",

--- a/domain-v4/tools/return_to_orchestrator.json
+++ b/domain-v4/tools/return_to_orchestrator.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "return_to_orchestrator",
+  "name": "Return to Orchestrator",
+  "description": "Signal task completion and return control to the orchestrator (Showrunner). Use this when your delegated work is complete, blocked, or needs orchestrator decision.\n\nThis is the standard way for specialist agents to end their turn after completing delegated work. The orchestrator will receive your summary and decide next steps.\n\nNOTE: This tool is for NON-ORCHESTRATOR agents only. Orchestrators use 'delegate' or 'communicate' to end their turns.",
+
+  "terminates_turn": true,
+  "summarization_policy": "ultra_concise",
+  "summary_template": "Returned to orchestrator: {status} - {summary}",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "enum": ["complete", "partial", "blocked", "needs_decision"],
+        "description": "Outcome of your work: complete (all done), partial (some done), blocked (cannot proceed), needs_decision (requires orchestrator input)"
+      },
+      "summary": {
+        "type": "string",
+        "description": "Brief summary of what was accomplished or what's blocking progress"
+      },
+      "artifacts_produced": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "IDs of artifacts created or updated during this work"
+      },
+      "artifacts_ready_for_review": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "IDs of artifacts that are ready for quality gating"
+      },
+      "blockers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["missing_input", "quality_issue", "canon_conflict", "needs_clarification", "other"]
+            },
+            "description": { "type": "string" }
+          }
+        },
+        "description": "If blocked, what's preventing progress"
+      },
+      "recommendations": {
+        "type": "string",
+        "description": "Optional suggestions for what should happen next"
+      }
+    },
+    "required": ["status", "summary"]
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "acknowledged": {
+        "type": "boolean",
+        "description": "Whether the return was successfully processed"
+      },
+      "message_id": {
+        "type": "string",
+        "description": "ID of the delegation_response message sent to orchestrator"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Scene Smith completes section drafting",
+      "input": {
+        "status": "complete",
+        "summary": "Drafted section prose for SB-005 with 3 choices as specified in the brief",
+        "artifacts_produced": ["section-lighthouse-lock-v1"],
+        "artifacts_ready_for_review": ["section-lighthouse-lock-v1"],
+        "recommendations": "Ready for Gatekeeper review"
+      }
+    },
+    {
+      "description": "Plotwright blocked by missing canon",
+      "input": {
+        "status": "blocked",
+        "summary": "Cannot complete topology for Act 2 - lighthouse backstory not established",
+        "blockers": [
+          {
+            "type": "missing_input",
+            "description": "Need lighthouse history and keeper's motivation from canon"
+          }
+        ],
+        "recommendations": "Suggest delegating to Lore Weaver to establish lighthouse canon first"
+      }
+    },
+    {
+      "description": "Gatekeeper returns with quality findings",
+      "input": {
+        "status": "partial",
+        "summary": "Gatecheck complete - 6/8 bars pass, 2 need rework",
+        "artifacts_produced": ["gatecheck-section-005"],
+        "blockers": [
+          {
+            "type": "quality_issue",
+            "description": "Choice Integrity: options 2 and 3 are near-synonyms. Nonlinearity: missing return path from dead end."
+          }
+        ],
+        "recommendations": "Route back to Scene Smith with specific fixes"
+      }
+    }
+  ]
+}

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -30,6 +30,7 @@ from questfoundry.runtime.tools import (
     list_artifact_types,  # noqa: F401
     list_stores,  # noqa: F401
     request_clarification,  # noqa: F401  # Legacy: to be removed after migration
+    return_to_orchestrator,  # noqa: F401  # Hub-and-spoke: specialists return to orchestrator
     save_artifact,  # noqa: F401  # Phase 4: artifact persistence
     search_workspace,  # noqa: F401
     stubs,  # noqa: F401

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -99,6 +99,10 @@ class ToolContext:
     # Interactive mode flag - tools requiring human input should check this
     interactive: bool = True
 
+    # Delegation context (for return_to_orchestrator tool)
+    delegation_id: str | None = None  # Current delegation being executed
+    delegator_agent_id: str | None = None  # Agent who delegated to us
+
 
 class BaseTool(ABC):
     """

--- a/src/questfoundry/runtime/tools/return_to_orchestrator.py
+++ b/src/questfoundry/runtime/tools/return_to_orchestrator.py
@@ -73,11 +73,10 @@ class ReturnToOrchestratorTool(BaseTool):
         # Determine success based on status
         success = status in ("complete", "partial")
 
-        # Build result data
+        # Build result data (artifacts_produced passed separately to create_delegation_response)
         result_data = {
             "status": status,
             "summary": summary,
-            "artifacts_produced": artifacts_produced,
             "artifacts_ready_for_review": artifacts_ready_for_review,
         }
         if blockers:
@@ -88,7 +87,10 @@ class ReturnToOrchestratorTool(BaseTool):
         # Build error string for blocked/needs_decision
         error_msg = None
         if status == "blocked" and blockers:
-            error_msg = "; ".join(b.get("description", str(b)) for b in blockers)
+            error_msg = "; ".join(
+                (b.get("description") or str(b)) if isinstance(b, dict) else str(b)
+                for b in blockers
+            )
         elif status == "needs_decision":
             error_msg = f"Needs orchestrator decision: {summary}"
 

--- a/src/questfoundry/runtime/tools/return_to_orchestrator.py
+++ b/src/questfoundry/runtime/tools/return_to_orchestrator.py
@@ -1,0 +1,142 @@
+"""
+Return to Orchestrator tool implementation.
+
+Allows specialist agents to signal completion and return control
+to the orchestrator (Showrunner) after completing delegated work.
+
+This enforces the hub-and-spoke delegation pattern where:
+- Orchestrator delegates to specialists
+- Specialists complete work and return to orchestrator
+- Orchestrator decides next steps
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from questfoundry.runtime.messaging import create_delegation_response
+from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
+from questfoundry.runtime.tools.registry import register_tool
+
+logger = logging.getLogger(__name__)
+
+
+@register_tool("return_to_orchestrator")
+class ReturnToOrchestratorTool(BaseTool):
+    """
+    Signal task completion and return control to the orchestrator.
+
+    This is the standard way for specialist agents to end their turn
+    after completing delegated work. The orchestrator will receive
+    the summary and decide next steps.
+
+    NOTE: This tool is for NON-ORCHESTRATOR agents only.
+    Orchestrators use 'delegate' or 'communicate' to end their turns.
+    """
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """
+        Create and route a delegation response to the orchestrator.
+
+        Args:
+            args: Tool arguments including:
+                - status: complete, partial, blocked, needs_decision
+                - summary: Brief summary of what was accomplished
+                - artifacts_produced: IDs of artifacts created/updated
+                - artifacts_ready_for_review: IDs ready for quality gating
+                - blockers: What's preventing progress (if blocked)
+                - recommendations: Suggestions for next steps
+        """
+        status = args.get("status")
+        summary = args.get("summary")
+        artifacts_produced = args.get("artifacts_produced", [])
+        artifacts_ready_for_review = args.get("artifacts_ready_for_review", [])
+        blockers = args.get("blockers", [])
+        recommendations = args.get("recommendations")
+
+        # Validate required fields
+        if not status:
+            raise ToolValidationError("Status is required")
+        if not summary:
+            raise ToolValidationError("Summary is required")
+
+        # Find the orchestrator agent
+        orchestrator_id = self._find_orchestrator()
+        if not orchestrator_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="No orchestrator agent found in studio",
+            )
+
+        # Determine success based on status
+        success = status in ("complete", "partial")
+
+        # Build result data
+        result_data = {
+            "status": status,
+            "summary": summary,
+            "artifacts_produced": artifacts_produced,
+            "artifacts_ready_for_review": artifacts_ready_for_review,
+        }
+        if blockers:
+            result_data["blockers"] = blockers
+        if recommendations:
+            result_data["recommendations"] = recommendations
+
+        # Build error string for blocked/needs_decision
+        error_msg = None
+        if status == "blocked" and blockers:
+            error_msg = "; ".join(b.get("description", str(b)) for b in blockers)
+        elif status == "needs_decision":
+            error_msg = f"Needs orchestrator decision: {summary}"
+
+        # Get delegation context from tool context (if available)
+        delegation_id = self._context.delegation_id or "implicit"
+        delegator_id = self._context.delegator_agent_id or orchestrator_id
+
+        # Create delegation response message
+        message = create_delegation_response(
+            from_agent=self._context.agent_id or "unknown",
+            to_agent=delegator_id,
+            delegation_id=delegation_id,
+            success=success,
+            result=result_data,
+            error=error_msg,
+            artifacts_produced=artifacts_produced,
+        )
+
+        # Route via broker if available
+        if self._context.broker:
+            await self._context.broker.send(message)
+            logger.info(
+                "Return to orchestrator: %s -> %s (status: %s, delegation: %s)",
+                self._context.agent_id,
+                delegator_id,
+                status,
+                delegation_id,
+            )
+        else:
+            logger.warning("No broker available - return message created but not routed")
+
+        return ToolResult(
+            success=True,
+            data={
+                "acknowledged": True,
+                "message_id": message.id,
+                "returned_to": delegator_id,
+                "status": status,
+            },
+        )
+
+    def _find_orchestrator(self) -> str | None:
+        """
+        Find the orchestrator agent in the studio.
+
+        Returns the ID of the first agent with the 'orchestrator' archetype.
+        """
+        for agent in self._context.studio.agents:
+            if "orchestrator" in agent.archetypes:
+                return agent.id
+        return None


### PR DESCRIPTION
## Summary

- Fixes #193 - Delegation flow bypassed Showrunner, breaking hub-and-spoke architecture
- Root cause: Plotwright (non-orchestrator) had delegate capability, allowing direct delegation to Scene Smith
- `return_to_orchestrator` tool was referenced but never implemented

## Changes

### Domain (domain-v4/)
- **Removed** `delegate` capability from Plotwright (only orchestrators should delegate)
- **Added** `return_to_orchestrator` capability to all 11 non-orchestrator agents
- **Created** `return_to_orchestrator.json` tool definition

### Runtime (src/questfoundry/)
- **Created** `return_to_orchestrator.py` tool implementation
- **Extended** `ToolContext` with delegation context fields (`delegation_id`, `delegator_agent_id`)

## Architecture Alignment

This enforces the hub-and-spoke pattern from `meta/docs/tool-patterns.md`:

**Before (broken):**
```
Showrunner → Plotwright → Scene Smith → (ends, no return)
```

**After (correct):**
```
Showrunner → Plotwright → return_to_orchestrator → Showrunner → Scene Smith → return_to_orchestrator → Showrunner → Gatekeeper → ...
```

## Test plan
- [ ] Run E2E test with verbose logging: `uv run qf ask -vvv -p openai --no-interactive --log testX "create a whodunnit story"`
- [ ] Verify Plotwright returns to Showrunner after creating briefs
- [ ] Verify Scene Smith returns to Showrunner after writing prose
- [ ] Verify Gatekeeper is invoked for quality gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)