### PR TITLE
fix(runtime): orchestrator follow-up turns after delegation

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -818,7 +818,7 @@ async def _stream_response(
         log_console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
         logger.debug(f"Response generated in {duration_ms:.0f}ms")
 
-    # Process any pending delegations
+    # Process any pending delegations and handle orchestrator follow-up
     if process_delegations:
         delegation_results = await runtime.process_pending_delegations(session)
         if delegation_results:
@@ -837,6 +837,33 @@ async def _stream_response(
                         turn_number=turn_number,
                         error=dr.get("error") if not success else None,
                     )
+
+        # Hub-and-spoke: Give orchestrator follow-up turns after delegations complete
+        # Check if this agent is an orchestrator and has delegation responses
+        if runtime._is_orchestrator(agent):
+            responses = await runtime.get_delegation_responses(agent.id)
+            if responses:
+                # Build follow-up prompt with delegation results
+                follow_up_prompt = runtime.build_delegation_response_prompt(responses)
+                logger.debug(
+                    "Orchestrator %s has %d delegation responses, giving follow-up turn",
+                    agent.id,
+                    len(responses),
+                )
+
+                # Report follow-up turn
+                if _status_reporter:
+                    _status_reporter.turn_start(
+                        turn_number=session.turn_count + 1,
+                        agent_id=agent.id,
+                        agent_name=agent.name,
+                    )
+
+                # Recursively stream the follow-up response
+                follow_up_content = await _stream_response(
+                    runtime, agent, follow_up_prompt, session, process_delegations=True
+                )
+                full_content += "\n\n" + follow_up_content
 
     return full_content
 
@@ -923,7 +950,7 @@ async def _invoke_response(
         log_console.print(f"[dim]time: {duration_ms:.0f}ms | model: {runtime._model}[/dim]")
         logger.debug(f"Response generated in {duration_ms:.0f}ms")
 
-    # Process any pending delegations
+    # Process any pending delegations and handle orchestrator follow-up
     if process_delegations:
         delegation_results = await runtime.process_pending_delegations(session)
         if delegation_results:
@@ -942,6 +969,33 @@ async def _invoke_response(
                         turn_number=result.turn.turn_number,
                         error=dr.get("error") if not success else None,
                     )
+
+        # Hub-and-spoke: Give orchestrator follow-up turns after delegations complete
+        # Check if this agent is an orchestrator and has delegation responses
+        if runtime._is_orchestrator(agent):
+            responses = await runtime.get_delegation_responses(agent.id)
+            if responses:
+                # Build follow-up prompt with delegation results
+                follow_up_prompt = runtime.build_delegation_response_prompt(responses)
+                logger.debug(
+                    "Orchestrator %s has %d delegation responses, giving follow-up turn",
+                    agent.id,
+                    len(responses),
+                )
+
+                # Report follow-up turn
+                if _status_reporter:
+                    _status_reporter.turn_start(
+                        turn_number=session.turn_count + 1,
+                        agent_id=agent.id,
+                        agent_name=agent.name,
+                    )
+
+                # Recursively invoke the follow-up response
+                follow_up_content = await _invoke_response(
+                    runtime, agent, follow_up_prompt, session, process_delegations=True
+                )
+                full_content += "\n\n" + follow_up_content
 
     return full_content
 

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from collections.abc import Awaitable, Callable
 from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
@@ -36,6 +37,9 @@ from questfoundry.cli_output import StatusReporter, create_log_handler
 
 # Global verbosity level (set by callback)
 _verbosity: int = 0
+
+# Maximum recursion depth for orchestrator follow-up turns
+MAX_ORCHESTRATOR_FOLLOW_UP_DEPTH = 10
 
 # Main output console (stdout)
 console = Console()
@@ -735,12 +739,81 @@ async def _setup_runtime(
     )
 
 
+async def _handle_orchestrator_follow_up(
+    runtime: AgentRuntime,
+    agent: Agent,
+    session: Session,
+    respond_fn: Callable[..., Awaitable[str]],
+    current_depth: int,
+) -> str:
+    """
+    Handle orchestrator follow-up turns after delegations complete.
+
+    This is the hub-and-spoke pattern: after specialists return, the
+    orchestrator gets follow-up turns to decide next steps.
+
+    Args:
+        runtime: Agent runtime
+        agent: The orchestrator agent
+        session: Current session
+        respond_fn: Response function (_stream_response or _invoke_response)
+        current_depth: Current recursion depth
+
+    Returns:
+        Additional content from follow-up turns (empty string if none)
+    """
+    logger = logging.getLogger("questfoundry.cli")
+
+    if current_depth >= MAX_ORCHESTRATOR_FOLLOW_UP_DEPTH:
+        logger.warning(
+            "Max orchestrator follow-up depth (%d) reached, stopping recursion",
+            MAX_ORCHESTRATOR_FOLLOW_UP_DEPTH,
+        )
+        return ""
+
+    if not runtime._is_orchestrator(agent):
+        return ""
+
+    responses = await runtime.get_delegation_responses(agent.id)
+    if not responses:
+        return ""
+
+    # Build follow-up prompt with delegation results
+    follow_up_prompt = runtime.build_delegation_response_prompt(responses)
+    logger.debug(
+        "Orchestrator %s has %d delegation responses, giving follow-up turn (depth %d)",
+        agent.id,
+        len(responses),
+        current_depth + 1,
+    )
+
+    # Report follow-up turn start (turn number will be updated after activation)
+    if _status_reporter:
+        _status_reporter.turn_start(
+            turn_number=session.turn_count + 1,
+            agent_id=agent.id,
+            agent_name=agent.name,
+        )
+
+    # Recursively invoke the follow-up response with incremented depth
+    follow_up_content = await respond_fn(
+        runtime,
+        agent,
+        follow_up_prompt,
+        session,
+        process_delegations=True,
+        _follow_up_depth=current_depth + 1,
+    )
+    return "\n\n" + follow_up_content
+
+
 async def _stream_response(
     runtime: AgentRuntime,
     agent: Agent,
     user_input: str,
     session: Session,
     process_delegations: bool = True,
+    _follow_up_depth: int = 0,
 ) -> str:
     """Stream a response from the agent and return full content."""
     import time
@@ -839,31 +912,10 @@ async def _stream_response(
                     )
 
         # Hub-and-spoke: Give orchestrator follow-up turns after delegations complete
-        # Check if this agent is an orchestrator and has delegation responses
-        if runtime._is_orchestrator(agent):
-            responses = await runtime.get_delegation_responses(agent.id)
-            if responses:
-                # Build follow-up prompt with delegation results
-                follow_up_prompt = runtime.build_delegation_response_prompt(responses)
-                logger.debug(
-                    "Orchestrator %s has %d delegation responses, giving follow-up turn",
-                    agent.id,
-                    len(responses),
-                )
-
-                # Report follow-up turn
-                if _status_reporter:
-                    _status_reporter.turn_start(
-                        turn_number=session.turn_count + 1,
-                        agent_id=agent.id,
-                        agent_name=agent.name,
-                    )
-
-                # Recursively stream the follow-up response
-                follow_up_content = await _stream_response(
-                    runtime, agent, follow_up_prompt, session, process_delegations=True
-                )
-                full_content += "\n\n" + follow_up_content
+        follow_up_content = await _handle_orchestrator_follow_up(
+            runtime, agent, session, _stream_response, _follow_up_depth
+        )
+        full_content += follow_up_content
 
     return full_content
 
@@ -874,6 +926,7 @@ async def _invoke_response(
     user_input: str,
     session: Session,
     process_delegations: bool = True,
+    _follow_up_depth: int = 0,
 ) -> str:
     """Invoke agent without streaming (single response)."""
     import time
@@ -971,31 +1024,10 @@ async def _invoke_response(
                     )
 
         # Hub-and-spoke: Give orchestrator follow-up turns after delegations complete
-        # Check if this agent is an orchestrator and has delegation responses
-        if runtime._is_orchestrator(agent):
-            responses = await runtime.get_delegation_responses(agent.id)
-            if responses:
-                # Build follow-up prompt with delegation results
-                follow_up_prompt = runtime.build_delegation_response_prompt(responses)
-                logger.debug(
-                    "Orchestrator %s has %d delegation responses, giving follow-up turn",
-                    agent.id,
-                    len(responses),
-                )
-
-                # Report follow-up turn
-                if _status_reporter:
-                    _status_reporter.turn_start(
-                        turn_number=session.turn_count + 1,
-                        agent_id=agent.id,
-                        agent_name=agent.name,
-                    )
-
-                # Recursively invoke the follow-up response
-                follow_up_content = await _invoke_response(
-                    runtime, agent, follow_up_prompt, session, process_delegations=True
-                )
-                full_content += "\n\n" + follow_up_content
+        follow_up_content = await _handle_orchestrator_follow_up(
+            runtime, agent, session, _invoke_response, _follow_up_depth
+        )
+        full_content += follow_up_content
 
     return full_content
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -53,6 +53,7 @@ from questfoundry.runtime.storage import StoreManager
 if TYPE_CHECKING:
     from questfoundry.runtime.checkpoint import CheckpointManager, ContextUsage
     from questfoundry.runtime.delegation.tracker import PlaybookTracker
+    from questfoundry.runtime.messaging import Message
     from questfoundry.runtime.models import Agent, Studio
     from questfoundry.runtime.observability import EventLogger, TracingManager
     from questfoundry.runtime.storage import Project
@@ -1506,9 +1507,11 @@ class AgentRuntime:
 
         return results
 
-    async def get_delegation_responses(self, agent_id: str) -> list[Any]:
+    async def get_delegation_responses(self, agent_id: str) -> list[Message]:
         """
         Get pending delegation_response messages for an agent.
+
+        This properly drains the mailbox to avoid duplicates.
 
         Args:
             agent_id: Agent to check mailbox for
@@ -1522,18 +1525,31 @@ class AgentRuntime:
         from questfoundry.runtime.messaging.types import MessageType
 
         mailbox = await self._broker.get_mailbox(agent_id)
-        all_messages = await mailbox.get_all_pending()
 
-        responses = [msg for msg in all_messages if msg.type == MessageType.DELEGATION_RESPONSE]
+        # Drain the mailbox properly (same pattern as process_pending_delegations)
+        all_messages: list[Message] = []
+        while True:
+            msg = await mailbox.get_nowait()
+            if msg is None:
+                break
+            all_messages.append(msg)
+
+        # Separate responses from other messages
+        responses: list[Message] = []
+        other_messages: list[Message] = []
+        for msg in all_messages:
+            if msg.type == MessageType.DELEGATION_RESPONSE:
+                responses.append(msg)
+            else:
+                other_messages.append(msg)
 
         # Put back non-response messages
-        for msg in all_messages:
-            if msg.type != MessageType.DELEGATION_RESPONSE:
-                await mailbox.put(msg)
+        for msg in other_messages:
+            await mailbox.put(msg)
 
         return responses
 
-    def build_delegation_response_prompt(self, responses: list[Any]) -> str:
+    def build_delegation_response_prompt(self, responses: list[Message]) -> str:
         """
         Build a prompt summarizing delegation responses for the orchestrator.
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -1506,6 +1506,89 @@ class AgentRuntime:
 
         return results
 
+    async def get_delegation_responses(self, agent_id: str) -> list[Any]:
+        """
+        Get pending delegation_response messages for an agent.
+
+        Args:
+            agent_id: Agent to check mailbox for
+
+        Returns:
+            List of delegation_response messages
+        """
+        if not self._broker:
+            return []
+
+        from questfoundry.runtime.messaging.types import MessageType
+
+        mailbox = await self._broker.get_mailbox(agent_id)
+        all_messages = await mailbox.get_all_pending()
+
+        responses = [msg for msg in all_messages if msg.type == MessageType.DELEGATION_RESPONSE]
+
+        # Put back non-response messages
+        for msg in all_messages:
+            if msg.type != MessageType.DELEGATION_RESPONSE:
+                await mailbox.put(msg)
+
+        return responses
+
+    def build_delegation_response_prompt(self, responses: list[Any]) -> str:
+        """
+        Build a prompt summarizing delegation responses for the orchestrator.
+
+        Args:
+            responses: List of delegation_response messages
+
+        Returns:
+            Prompt text describing the delegation results
+        """
+        if not responses:
+            return ""
+
+        lines = ["Your delegated work has completed. Here are the results:\n"]
+
+        for i, msg in enumerate(responses, 1):
+            from_agent = msg.from_agent
+            payload = msg.payload or {}
+            success = payload.get("success", False)
+            result = payload.get("result", {})
+
+            status = result.get("status", "complete" if success else "failed")
+            summary = result.get("summary", "No summary provided")
+            artifacts = result.get("artifacts_produced", [])
+            ready_for_review = result.get("artifacts_ready_for_review", [])
+            blockers = result.get("blockers", [])
+            recommendations = result.get("recommendations", "")
+
+            lines.append(f"## Delegation {i}: {from_agent}")
+            lines.append(f"- **Status**: {status}")
+            lines.append(f"- **Summary**: {summary}")
+
+            if artifacts:
+                lines.append(f"- **Artifacts produced**: {', '.join(artifacts)}")
+            if ready_for_review:
+                lines.append(f"- **Ready for review**: {', '.join(ready_for_review)}")
+            if blockers:
+                blocker_strs = [
+                    b.get("description", str(b)) if isinstance(b, dict) else str(b)
+                    for b in blockers
+                ]
+                lines.append(f"- **Blockers**: {'; '.join(blocker_strs)}")
+            if recommendations:
+                lines.append(f"- **Recommendations**: {recommendations}")
+
+            lines.append("")
+
+        lines.append(
+            "Based on these results, decide what to do next:\n"
+            "- Delegate to another agent if more work is needed\n"
+            "- Call communicate to ask the human a question\n"
+            "- Or return your final response if the task is complete"
+        )
+
+        return "\n".join(lines)
+
 
 async def activate_agent(
     agent_id: str,


### PR DESCRIPTION
## Summary

Fixes #196 - Orchestrator didn't get follow-up turns after delegations completed.

### Problem

After `process_pending_delegations` completed, the session ended without giving the orchestrator (Showrunner) a chance to process the delegation responses and decide next steps.

**Before:**
```
1. Showrunner Turn 1: delegates to Plotwright
2. Plotwright Turn 2: does work, returns artifacts
3. Session ends ← Showrunner never gets Turn 3
```

### Solution

Added orchestrator follow-up turn logic to the CLI:

**After:**
```
1. Showrunner Turn 1: delegates to Plotwright
2. Plotwright Turn 2: does work, calls return_to_orchestrator
3. Showrunner Turn 3: receives response, decides next steps
4. ...continues until workflow complete
```

### Changes

1. **Runtime** (`src/questfoundry/runtime/agent/runtime.py`):
   - `get_delegation_responses()`: Get pending DELEGATION_RESPONSE messages from agent's mailbox
   - `build_delegation_response_prompt()`: Format responses into a follow-up prompt for the orchestrator

2. **CLI** (`src/questfoundry/cli.py`):
   - Updated `_stream_response()` and `_invoke_response()` to recursively give orchestrator follow-up turns when delegation responses exist

### How it works

After delegations complete:
1. Check if the agent is an orchestrator
2. Check orchestrator's mailbox for `delegation_response` messages
3. If found, build a follow-up prompt summarizing the results
4. Give orchestrator another turn with that prompt
5. Recurse until orchestrator stops delegating or calls communicate

## Test plan

- [x] All 782 existing tests pass
- [ ] E2E test: Run `uv run qf ask -vvv` with a story creation prompt
- [ ] Verify orchestrator gets Turn 3+ after specialists return
- [ ] Verify full workflow flows through multiple agents

## Related

- #193 - Hub-and-spoke fix (domain changes) - closed
- #194 - PR implementing domain changes - merged
- #195 - Meta-level core tool definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)