### PR TITLE
feat(meta): add followups schema to playbook phase transitions

### DIFF
--- a/domain-v4/playbooks/hook_harvest.json
+++ b/domain-v4/playbooks/hook_harvest.json
@@ -271,7 +271,29 @@
 
       "on_success": {
         "message": "Harvest complete. Accepted hooks routed to next loops. Showrunner has activation list.",
-        "end_playbook": true
+        "end_playbook": true,
+        "followups": {
+          "conditional": [
+            {
+              "playbook": "story_spark",
+              "condition": "Accepted hooks classified as structure-impact or topology changes",
+              "description": "Process hooks requiring structural changes to narrative topology",
+              "priority": 1
+            },
+            {
+              "playbook": "scene_weave",
+              "condition": "Accepted hooks classified as scene-level or prose needs",
+              "description": "Process hooks requiring prose additions or revisions",
+              "priority": 2
+            },
+            {
+              "playbook": "lore_deepening",
+              "condition": "Accepted hooks classified as factual or requiring canon research",
+              "description": "Build canon required by accepted hooks",
+              "priority": 2
+            }
+          ]
+        }
       }
     }
   },

--- a/domain-v4/playbooks/hook_harvest.json
+++ b/domain-v4/playbooks/hook_harvest.json
@@ -290,7 +290,7 @@
               "playbook": "lore_deepening",
               "condition": "Accepted hooks classified as factual or requiring canon research",
               "description": "Build canon required by accepted hooks",
-              "priority": 2
+              "priority": 3
             }
           ]
         }

--- a/domain-v4/playbooks/lore_deepening.json
+++ b/domain-v4/playbooks/lore_deepening.json
@@ -279,7 +279,40 @@
 
       "on_success": {
         "message": "Canon packs and codex entries ready. Canon available to creative agents, codex ready for export.",
-        "end_playbook": true
+        "end_playbook": true,
+        "followups": {
+          "runtime_actions": [
+            {
+              "action": "commit_to_cold",
+              "condition": "Gatekeeper approved canon packs and codex entries",
+              "description": "Commit canon packs and codex entries to cold store"
+            }
+          ],
+          "parallel": [
+            {
+              "playbook": "hook_harvest",
+              "artifact_condition": {
+                "artifact_type": "hook_card",
+                "state": "proposed"
+              },
+              "description": "Triage hooks generated during lore work"
+            }
+          ],
+          "conditional": [
+            {
+              "playbook": "story_spark",
+              "condition": "Canon gaps were blocking topology design",
+              "description": "Resume structure work now that canon is available",
+              "priority": 1
+            },
+            {
+              "playbook": "scene_weave",
+              "condition": "Canon gaps were blocking prose writing",
+              "description": "Resume prose work now that canon is available",
+              "priority": 2
+            }
+          ]
+        }
       },
 
       "on_failure": {

--- a/domain-v4/playbooks/scene_weave.json
+++ b/domain-v4/playbooks/scene_weave.json
@@ -272,7 +272,34 @@
 
       "on_success": {
         "message": "Sections approved. Ready for Cold merge after full pipeline (Lore, Codex, etc.).",
-        "end_playbook": true
+        "end_playbook": true,
+        "followups": {
+          "runtime_actions": [
+            {
+              "action": "commit_to_cold",
+              "condition": "Gatekeeper approved all sections",
+              "description": "Commit approved sections to canon store"
+            }
+          ],
+          "parallel": [
+            {
+              "playbook": "hook_harvest",
+              "artifact_condition": {
+                "artifact_type": "hook_card",
+                "state": "proposed"
+              },
+              "description": "Triage scene hooks generated during prose drafting"
+            }
+          ],
+          "conditional": [
+            {
+              "playbook": "binding_run",
+              "condition": "All sections for current milestone are in cold store",
+              "description": "Export completed story segment for distribution",
+              "priority": 3
+            }
+          ]
+        }
       },
 
       "on_failure": {

--- a/domain-v4/playbooks/story_spark.json
+++ b/domain-v4/playbooks/story_spark.json
@@ -203,7 +203,35 @@
 
       "on_success": {
         "message": "Section Briefs ready for Scene Weave. Hooks ready for Hook Harvest.",
-        "end_playbook": true
+        "end_playbook": true,
+        "followups": {
+          "primary": {
+            "playbook": "scene_weave",
+            "artifact_condition": {
+              "artifact_type": "section_brief",
+              "state": "ready"
+            },
+            "description": "Write prose from the completed section briefs"
+          },
+          "parallel": [
+            {
+              "playbook": "hook_harvest",
+              "artifact_condition": {
+                "artifact_type": "hook_card",
+                "state": "proposed"
+              },
+              "description": "Triage hooks generated during topology design"
+            }
+          ],
+          "conditional": [
+            {
+              "playbook": "lore_deepening",
+              "condition": "Canon gaps identified in feasibility check",
+              "description": "Build missing canon before prose writing",
+              "priority": 1
+            }
+          ]
+        }
       },
 
       "on_failure": {

--- a/meta/schemas/core/playbook.schema.json
+++ b/meta/schemas/core/playbook.schema.json
@@ -520,6 +520,113 @@
           "type": "boolean",
           "default": false,
           "description": "If true, this transition ends the playbook"
+        },
+        "followups": {
+          "$ref": "#/$defs/followups",
+          "description": "Guidance for orchestrator on what comes after this playbook ends"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "followups": {
+      "type": "object",
+      "description": "Guidance for orchestrator on workflow continuation after playbook completes",
+      "properties": {
+        "primary": {
+          "$ref": "#/$defs/followup_spec",
+          "description": "The main next playbook (sequential)"
+        },
+        "parallel": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/followup_spec"
+          },
+          "description": "Playbooks that can run alongside primary"
+        },
+        "conditional": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/followup_spec"
+          },
+          "description": "Playbooks triggered by specific conditions"
+        },
+        "runtime_actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/runtime_action_spec"
+          },
+          "description": "Non-playbook actions (e.g., cold commit, checkpoint)"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "followup_spec": {
+      "type": "object",
+      "description": "Specification for a playbook that should follow",
+      "required": ["playbook"],
+      "properties": {
+        "playbook": {
+          "$ref": "_definitions.schema.json#/$defs/playbook_ref",
+          "description": "ID of the playbook to run"
+        },
+        "condition": {
+          "type": "string",
+          "description": "Natural language condition for when this applies (LLM interprets)"
+        },
+        "artifact_condition": {
+          "type": "object",
+          "description": "Machine-checkable condition: artifact type + state exists",
+          "properties": {
+            "artifact_type": {
+              "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
+              "description": "Type of artifact to check for"
+            },
+            "state": {
+              "type": "string",
+              "description": "Required lifecycle state"
+            },
+            "exists": {
+              "type": "boolean",
+              "default": true,
+              "description": "True = must exist, False = must not exist"
+            }
+          },
+          "additionalProperties": false
+        },
+        "description": {
+          "type": "string",
+          "description": "Why this followup makes sense"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "default": 5,
+          "description": "Priority when multiple conditions match (1=highest)"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "runtime_action_spec": {
+      "type": "object",
+      "description": "Non-playbook action to perform (e.g., cold commit)",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["commit_to_cold", "notify_user", "create_checkpoint"],
+          "description": "The runtime action to perform"
+        },
+        "condition": {
+          "type": "string",
+          "description": "Natural language condition for when to perform this action"
+        },
+        "description": {
+          "type": "string",
+          "description": "Why this action is needed"
         }
       },
       "additionalProperties": false

--- a/meta/schemas/core/playbook.schema.json
+++ b/meta/schemas/core/playbook.schema.json
@@ -542,7 +542,7 @@
           "items": {
             "$ref": "#/$defs/followup_spec"
           },
-          "description": "Playbooks that can run alongside primary"
+          "description": "Playbooks that may run alongside a primary followup or independently"
         },
         "conditional": {
           "type": "array",
@@ -578,6 +578,7 @@
         "artifact_condition": {
           "type": "object",
           "description": "Machine-checkable condition: artifact type + state exists",
+          "required": ["artifact_type"],
           "properties": {
             "artifact_type": {
               "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
@@ -607,7 +608,11 @@
           "description": "Priority when multiple conditions match (1=highest)"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "not": {
+        "description": "condition and artifact_condition are mutually exclusive",
+        "required": ["condition", "artifact_condition"]
+      }
     },
 
     "runtime_action_spec": {

--- a/src/questfoundry/runtime/delegation/nudger.py
+++ b/src/questfoundry/runtime/delegation/nudger.py
@@ -277,6 +277,22 @@ class PlaybookNudger:
 
         return None
 
+    def _format_artifact_condition(self, artifact_condition: dict[str, Any]) -> str:
+        """Format an artifact_condition into a human-readable string."""
+        artifact_type = artifact_condition.get("artifact_type", "artifact")
+        state = artifact_condition.get("state")
+        exists = artifact_condition.get("exists", True)
+
+        parts = [artifact_type]
+        if state:
+            parts.append(f"in state '{state}'")
+        if exists:
+            parts.append("exists")
+        else:
+            parts.append("does not exist")
+
+        return " ".join(parts)
+
     def check_playbook_followups(
         self,
         ctx: NudgeContext,
@@ -303,15 +319,22 @@ class PlaybookNudger:
         # Primary followup
         primary = followups.get("primary")
         if primary:
-            playbook_id = primary.get("playbook", "unknown")
+            playbook_id = primary.get("playbook", "?")
             desc = primary.get("description", "")
             parts.append(f"Primary: {playbook_id}" + (f" ({desc})" if desc else ""))
 
-        # Parallel options
+        # Parallel options (include descriptions for consistency)
         parallel = followups.get("parallel", [])
         if parallel:
-            parallel_ids = [f.get("playbook", "?") for f in parallel]
-            parts.append(f"Parallel options: {', '.join(parallel_ids)}")
+            parallel_items: list[str] = []
+            for f in parallel:
+                playbook_id = f.get("playbook", "?")
+                desc = f.get("description", "")
+                if desc:
+                    parallel_items.append(f"{playbook_id} ({desc})")
+                else:
+                    parallel_items.append(playbook_id)
+            parts.append(f"Parallel options: {', '.join(parallel_items)}")
 
         # Conditional followups (sorted by priority)
         conditional = followups.get("conditional", [])
@@ -320,15 +343,30 @@ class PlaybookNudger:
             cond_parts = []
             for cond in sorted_cond:
                 playbook_id = cond.get("playbook", "?")
-                condition = cond.get("condition", "")
-                cond_parts.append(f"{playbook_id} (if {condition})" if condition else playbook_id)
+                # Use natural language condition, or format artifact_condition
+                condition = cond.get("condition")
+                if not condition:
+                    artifact_cond = cond.get("artifact_condition")
+                    if artifact_cond:
+                        condition = self._format_artifact_condition(artifact_cond)
+                if condition:
+                    cond_parts.append(f"{playbook_id} (if {condition})")
+                else:
+                    cond_parts.append(playbook_id)
             parts.append(f"Conditional: {', '.join(cond_parts)}")
 
         # Runtime actions
         runtime_actions = followups.get("runtime_actions", [])
         if runtime_actions:
-            action_names = [a.get("action", "?") for a in runtime_actions]
-            parts.append(f"Runtime actions: {', '.join(action_names)}")
+            action_items: list[str] = []
+            for a in runtime_actions:
+                action = a.get("action", "?")
+                desc = a.get("description", "")
+                if desc:
+                    action_items.append(f"{action} ({desc})")
+                else:
+                    action_items.append(action)
+            parts.append(f"Runtime actions: {', '.join(action_items)}")
 
         if not parts:
             return None
@@ -336,8 +374,7 @@ class PlaybookNudger:
         message = (
             f"Playbook '{ctx.playbook_id}' is complete. "
             f"Typical followups: {'; '.join(parts)}. "
-            "In interactive mode, propose these options to the user. "
-            "In non-interactive mode, the session may end here."
+            "Consider these as potential next steps."
         )
 
         return create_nudge(

--- a/src/questfoundry/runtime/delegation/nudger.py
+++ b/src/questfoundry/runtime/delegation/nudger.py
@@ -38,6 +38,7 @@ class PlaybookNudger:
     - unexpected_state: Phase/step state doesn't match expectations
     - quality_gate_reminder: Upcoming quality checkpoint
     - budget_warning: Rework budget running low or exhausted
+    - playbook_followups: Guidance on what typically comes next after playbook ends
     """
 
     def __init__(self, playbooks: dict[str, dict[str, Any]]) -> None:
@@ -276,6 +277,80 @@ class PlaybookNudger:
 
         return None
 
+    def check_playbook_followups(
+        self,
+        ctx: NudgeContext,
+        followups: dict[str, Any] | None,
+    ) -> Message | None:
+        """
+        Generate guidance about typical followups when a playbook ends.
+
+        This provides domain knowledge to the orchestrator about what
+        typically comes next, enabling informed proposals to the user.
+
+        Args:
+            ctx: Nudge context
+            followups: The followups object from phase transition
+
+        Returns:
+            Nudge with followup guidance, or None if no followups defined
+        """
+        if not followups:
+            return None
+
+        parts: list[str] = []
+
+        # Primary followup
+        primary = followups.get("primary")
+        if primary:
+            playbook_id = primary.get("playbook", "unknown")
+            desc = primary.get("description", "")
+            parts.append(f"Primary: {playbook_id}" + (f" ({desc})" if desc else ""))
+
+        # Parallel options
+        parallel = followups.get("parallel", [])
+        if parallel:
+            parallel_ids = [f.get("playbook", "?") for f in parallel]
+            parts.append(f"Parallel options: {', '.join(parallel_ids)}")
+
+        # Conditional followups (sorted by priority)
+        conditional = followups.get("conditional", [])
+        if conditional:
+            sorted_cond = sorted(conditional, key=lambda c: c.get("priority", 5))
+            cond_parts = []
+            for cond in sorted_cond:
+                playbook_id = cond.get("playbook", "?")
+                condition = cond.get("condition", "")
+                cond_parts.append(f"{playbook_id} (if {condition})" if condition else playbook_id)
+            parts.append(f"Conditional: {', '.join(cond_parts)}")
+
+        # Runtime actions
+        runtime_actions = followups.get("runtime_actions", [])
+        if runtime_actions:
+            action_names = [a.get("action", "?") for a in runtime_actions]
+            parts.append(f"Runtime actions: {', '.join(action_names)}")
+
+        if not parts:
+            return None
+
+        message = (
+            f"Playbook '{ctx.playbook_id}' is complete. "
+            f"Typical followups: {'; '.join(parts)}. "
+            "In interactive mode, propose these options to the user. "
+            "In non-interactive mode, the session may end here."
+        )
+
+        return create_nudge(
+            from_agent="runtime",
+            to_agent=ctx.agent_id,
+            nudge_type="playbook_followups",
+            message=message,
+            playbook_id=ctx.playbook_id,
+            playbook_instance_id=ctx.instance_id,
+            phase_id=ctx.phase_id,
+            turn_created=ctx.turn,
+        )
+
     def generate_phase_entry_nudges(
         self,
         ctx: NudgeContext,
@@ -309,5 +384,36 @@ class PlaybookNudger:
         consistency_nudge = self.check_phase_consistency(ctx, previous_phase)
         if consistency_nudge:
             nudges.append(consistency_nudge)
+
+        return nudges
+
+    def generate_playbook_end_nudges(
+        self,
+        ctx: NudgeContext,
+        transition: dict[str, Any] | None,
+    ) -> list[Message]:
+        """
+        Generate nudges when a playbook ends.
+
+        Args:
+            ctx: Nudge context
+            transition: The phase transition object (contains followups)
+
+        Returns:
+            List of nudge messages
+        """
+        nudges: list[Message] = []
+
+        if not transition:
+            return nudges
+
+        # Only generate followup nudges if playbook is ending
+        if not transition.get("end_playbook"):
+            return nudges
+
+        followups = transition.get("followups")
+        followup_nudge = self.check_playbook_followups(ctx, followups)
+        if followup_nudge:
+            nudges.append(followup_nudge)
 
         return nudges

--- a/tests/runtime/delegation/test_nudger.py
+++ b/tests/runtime/delegation/test_nudger.py
@@ -212,6 +212,160 @@ class TestPlaybookNudger:
         assert quality is None
 
 
+class TestPlaybookFollowupsNudge:
+    """Tests for playbook followups nudging."""
+
+    @pytest.fixture
+    def nudger(self):
+        """Create a nudger with sample playbook."""
+        return PlaybookNudger({"test_playbook": SAMPLE_PLAYBOOK})
+
+    @pytest.fixture
+    def ctx(self):
+        """Create a sample nudge context."""
+        return NudgeContext(
+            playbook_id="test_playbook",
+            instance_id="inst-001",
+            phase_id="drafting",
+            turn=5,
+            agent_id="showrunner",
+        )
+
+    def test_format_artifact_condition_basic(self, nudger):
+        """Test formatting artifact condition with all fields."""
+        cond = {
+            "artifact_type": "section_brief",
+            "state": "ready",
+            "exists": True,
+        }
+        result = nudger._format_artifact_condition(cond)
+        assert result == "section_brief in state 'ready' exists"
+
+    def test_format_artifact_condition_not_exists(self, nudger):
+        """Test formatting artifact condition with exists=False."""
+        cond = {
+            "artifact_type": "hook_card",
+            "exists": False,
+        }
+        result = nudger._format_artifact_condition(cond)
+        assert result == "hook_card does not exist"
+
+    def test_format_artifact_condition_minimal(self, nudger):
+        """Test formatting artifact condition with only type."""
+        cond = {"artifact_type": "section"}
+        result = nudger._format_artifact_condition(cond)
+        assert result == "section exists"
+
+    def test_check_playbook_followups_none(self, nudger, ctx):
+        """Test no nudge when followups is None."""
+        nudge = nudger.check_playbook_followups(ctx, None)
+        assert nudge is None
+
+    def test_check_playbook_followups_empty(self, nudger, ctx):
+        """Test no nudge when followups is empty."""
+        nudge = nudger.check_playbook_followups(ctx, {})
+        assert nudge is None
+
+    def test_check_playbook_followups_primary_only(self, nudger, ctx):
+        """Test nudge with only primary followup."""
+        followups = {
+            "primary": {
+                "playbook": "scene_weave",
+                "description": "Write prose from briefs",
+            }
+        }
+        nudge = nudger.check_playbook_followups(ctx, followups)
+
+        assert nudge is not None
+        assert nudge.type == MessageType.NUDGE
+        assert nudge.payload["nudge_type"] == "playbook_followups"
+        assert "Primary: scene_weave (Write prose from briefs)" in nudge.payload["message"]
+
+    def test_check_playbook_followups_all_types(self, nudger, ctx):
+        """Test nudge with all followup types."""
+        followups = {
+            "primary": {"playbook": "scene_weave"},
+            "parallel": [{"playbook": "hook_harvest", "description": "Triage hooks"}],
+            "conditional": [
+                {"playbook": "lore_deepening", "condition": "canon gaps identified", "priority": 1},
+                {"playbook": "story_spark", "condition": "structure changes needed", "priority": 2},
+            ],
+            "runtime_actions": [
+                {"action": "commit_to_cold", "description": "Save approved sections"}
+            ],
+        }
+        nudge = nudger.check_playbook_followups(ctx, followups)
+
+        assert nudge is not None
+        msg = nudge.payload["message"]
+        assert "Primary: scene_weave" in msg
+        assert "hook_harvest (Triage hooks)" in msg
+        assert "lore_deepening (if canon gaps identified)" in msg
+        assert "commit_to_cold (Save approved sections)" in msg
+
+    def test_check_playbook_followups_conditional_sorted(self, nudger, ctx):
+        """Test that conditional followups are sorted by priority."""
+        followups = {
+            "conditional": [
+                {"playbook": "low_priority", "condition": "c1", "priority": 5},
+                {"playbook": "high_priority", "condition": "c2", "priority": 1},
+                {"playbook": "med_priority", "condition": "c3", "priority": 3},
+            ],
+        }
+        nudge = nudger.check_playbook_followups(ctx, followups)
+
+        msg = nudge.payload["message"]
+        # high_priority should appear before med_priority before low_priority
+        assert msg.index("high_priority") < msg.index("med_priority")
+        assert msg.index("med_priority") < msg.index("low_priority")
+
+    def test_check_playbook_followups_artifact_condition(self, nudger, ctx):
+        """Test that artifact_condition is formatted when condition is absent."""
+        followups = {
+            "conditional": [
+                {
+                    "playbook": "scene_weave",
+                    "artifact_condition": {
+                        "artifact_type": "section_brief",
+                        "state": "ready",
+                    },
+                },
+            ],
+        }
+        nudge = nudger.check_playbook_followups(ctx, followups)
+
+        msg = nudge.payload["message"]
+        assert "section_brief in state 'ready' exists" in msg
+
+    def test_generate_playbook_end_nudges_no_transition(self, nudger, ctx):
+        """Test no nudges when transition is None."""
+        nudges = nudger.generate_playbook_end_nudges(ctx, None)
+        assert nudges == []
+
+    def test_generate_playbook_end_nudges_not_ending(self, nudger, ctx):
+        """Test no nudges when end_playbook is false."""
+        transition = {"end_playbook": False, "followups": {"primary": {"playbook": "x"}}}
+        nudges = nudger.generate_playbook_end_nudges(ctx, transition)
+        assert nudges == []
+
+    def test_generate_playbook_end_nudges_ending_with_followups(self, nudger, ctx):
+        """Test nudge generated when playbook ends with followups."""
+        transition = {
+            "end_playbook": True,
+            "followups": {"primary": {"playbook": "next_playbook"}},
+        }
+        nudges = nudger.generate_playbook_end_nudges(ctx, transition)
+
+        assert len(nudges) == 1
+        assert nudges[0].payload["nudge_type"] == "playbook_followups"
+
+    def test_generate_playbook_end_nudges_ending_no_followups(self, nudger, ctx):
+        """Test no nudge when playbook ends without followups."""
+        transition = {"end_playbook": True}
+        nudges = nudger.generate_playbook_end_nudges(ctx, transition)
+        assert nudges == []
+
+
 class TestNudgeContext:
     """Tests for NudgeContext dataclass."""
 


### PR DESCRIPTION
## Summary
- Adds rich `followups` schema to `phase_transition` in `playbook.schema.json` to provide domain knowledge for orchestrator workflow guidance
- Updated 4 playbooks with concrete followup definitions
- **NEW**: Added runtime support via `PlaybookNudger.check_playbook_followups()`

## Context Shift

Originally this was proposed as *automatic* playbook chaining. After discussion, we reframed it as **domain knowledge** that:
- Gives Showrunner informed guidance about what typically follows
- Enables proposing options to users in interactive mode
- Does NOT automatically execute followups

## Schema Changes (`meta/schemas/core/playbook.schema.json`)
- Added `followups` property to `phase_transition`
- Added `followup_spec` definition for playbook references with conditions
- Added `runtime_action_spec` for non-playbook actions (commit_to_cold, notify_user, create_checkpoint)
- Added `artifact_condition` for machine-checkable conditions
- **Review fixes**: Unique priorities, mutual exclusivity constraint, required artifact_type

## Runtime Changes (`src/questfoundry/runtime/delegation/nudger.py`)
- Added `check_playbook_followups()` - generates nudge from followups definition
- Added `generate_playbook_end_nudges()` - convenience method for playbook completion

## Playbooks Updated
| Playbook | Followups |
|----------|-----------|
| `story_spark` | primary→scene_weave, parallel→hook_harvest, conditional→lore_deepening |
| `scene_weave` | runtime_actions→commit_to_cold, parallel→hook_harvest, conditional→binding_run |
| `hook_harvest` | conditional routing to story_spark/scene_weave/lore_deepening based on hook classification |
| `lore_deepening` | runtime_actions→commit_to_cold, parallel→hook_harvest, conditional resume to blocked playbooks |

## How It Works

1. `consult_playbook` tool already exposes `on_success.followups` to agents
2. When playbook ends, `PlaybookNudger.generate_playbook_end_nudges()` creates guidance nudge
3. Showrunner receives: "Playbook 'story_spark' is complete. Typical followups: Primary: scene_weave; Parallel: hook_harvest..."
4. In interactive mode, Showrunner proposes these to user
5. In non-interactive mode, session may end here

## Test plan
- [x] All JSON files validate
- [x] Schema $refs resolve correctly
- [x] All 99 delegation tests pass
- [x] Mypy passes
- [ ] E2E test to verify workflow progression

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)