### PR TITLE
feat(domain): add manuscript store for narrative sections

### DIFF
--- a/domain-v4/agents/gatekeeper.json
+++ b/domain-v4/agents/gatekeeper.json
@@ -47,7 +47,7 @@
       "name": "Read All Stores",
       "description": "Can read from any store to validate content",
       "category": "store_access",
-      "stores": ["workspace", "canon", "audit"],
+      "stores": ["workspace", "canon", "manuscript", "audit"],
       "access_level": "read"
     },
     {
@@ -56,6 +56,14 @@
       "description": "Can write gatecheck reports and pre-gate notes",
       "category": "store_access",
       "stores": ["workspace"],
+      "access_level": "write"
+    },
+    {
+      "id": "write_manuscript",
+      "name": "Write to Manuscript",
+      "description": "Can promote validated sections to narrative canon after gatecheck passes",
+      "category": "store_access",
+      "stores": ["manuscript"],
       "access_level": "write"
     },
     {

--- a/domain-v4/artifact-types/section.json
+++ b/domain-v4/artifact-types/section.json
@@ -3,7 +3,7 @@
   "id": "section",
   "name": "Section",
   "summary": "Interactive story section with choices",
-  "description": "A complete unit of narrative prose ending in one or more player-facing choices. Sections are the atomic reading units of the manuscript, written by Scene Smith from Section Briefs. In Cold state, sections are player-safe and ready for export.",
+  "description": "A complete unit of narrative prose ending in one or more player-facing choices. Sections are the atomic reading units of the manuscript, written by Scene Smith from Section Briefs. Sections are drafted in workspace (draft/review/approved states), then Gatekeeper promotes approved sections to manuscript store (cold state). In Cold state, sections are player-safe and ready for export.",
   "category": "document",
 
   "fields": [

--- a/domain-v4/stores/canon.json
+++ b/domain-v4/stores/canon.json
@@ -7,8 +7,7 @@
   "semantics": "cold",
 
   "artifact_types": [
-    "canon_pack",
-    "section"
+    "canon_pack"
   ],
 
   "workflow_intent": {

--- a/domain-v4/stores/manuscript.json
+++ b/domain-v4/stores/manuscript.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../meta/schemas/core/store.schema.json",
+  "id": "manuscript",
+  "name": "Manuscript (Narrative Canon)",
+  "description": "Validated narrative sections ready for export and downstream consumption. Append-only; represents narrative canon (story prose), distinct from world-lore canon. Gatekeeper promotes approved sections here after validation passes.",
+
+  "semantics": "cold",
+
+  "artifact_types": [
+    "section"
+  ],
+
+  "workflow_intent": {
+    "consumption_guidance": "all",
+    "production_guidance": "exclusive",
+    "designated_producers": ["gatekeeper"]
+  },
+
+  "retention": {
+    "type": "forever"
+  }
+}

--- a/meta/docs/store-semantics.md
+++ b/meta/docs/store-semantics.md
@@ -55,10 +55,10 @@ Stores are classified by **semantics** that define their mutability and purpose:
 
 **Use cases**:
 
-- Validated story sections
-- Canonical lore and world facts
+- Canonical lore and world facts (canon store)
+- Validated story sections (manuscript store)
+- Player-safe glossary entries (codex store)
 - Approved character definitions
-- Final scene prose
 
 **Key rule**: Promote to cold only after validation passes. Never bypass quality gates.
 
@@ -116,7 +116,7 @@ draft → review → approved → cold
 | `approved` | Passed validation, ready for promotion |
 | `cold` | Committed to canon (final) |
 
-**Key insight**: "Cold" is a lifecycle state, not just a store semantics. An artifact transitions to `cold` when committed to canon.
+**Key insight**: "Cold" is a lifecycle state, not just a store semantics. An artifact transitions to `cold` when committed to a cold store (canon for lore, manuscript for narrative sections, codex for glossary entries).
 
 ---
 
@@ -126,7 +126,8 @@ Cold stores have **exclusive writers** to maintain consistency:
 
 | Store | Exclusive Writer | Rationale |
 |-------|------------------|-----------|
-| canon | `lore_weaver` | Single source of world truth |
+| canon | `lore_weaver` | Single source of world truth (lore) |
+| manuscript | `gatekeeper` | Validated narrative prose (sections) |
 | codex | `codex_curator` | Player-safe glossary control |
 | exports | `book_binder` | Controlled publishing |
 
@@ -210,11 +211,11 @@ draft → cold (skipping review/approved)
 
 ### Cross-write to Cold
 
-**Wrong**: Scene Smith writing directly to canon
+**Wrong**: Scene Smith writing directly to manuscript (bypassing Gatekeeper)
 
 **Why it's wrong**: Violates exclusive writer principle. Creates conflicts.
 
-**Correct**: Request promotion via lifecycle transition tool.
+**Correct**: Request promotion via lifecycle transition tool. Gatekeeper validates and promotes to manuscript.
 
 ---
 


### PR DESCRIPTION
## Summary

Introduces a new storage model that separates world-lore (canon) from narrative prose (manuscript):

- **Create manuscript store** - New cold store for validated sections, with gatekeeper as exclusive writer
- **Fix canon store** - Remove `section` from artifact_types; lore_weaver owns `canon_pack` only
- **Update gatekeeper** - Grant read and write access to manuscript store
- **Clarify section flow** - Update description to document workspace→manuscript lifecycle
- **Update documentation** - Add manuscript to store-semantics.md exclusive writers table

### New Storage Model

| Store | Semantics | Artifacts | Exclusive Writer |
|-------|-----------|-----------|------------------|
| workspace | mutable | section_brief, section (draft/review), hook_card | all |
| canon | cold | canon_pack | lore_weaver |
| **manuscript** | **cold** | **section (approved→cold)** | **gatekeeper** |
| codex | cold | codex_entry | codex_curator |
| exports | versioned | bundles | book_binder |

### Design Rationale

1. **Canon = lore only** - Lore Weaver owns world truth (canon_pack), not narrative prose
2. **Manuscript = narrative canon** - Validated sections ready for export
3. **Gatekeeper as exclusive writer** - They're the final quality gate; "signing off" by committing to manuscript
4. **Sections flow workspace→manuscript** - Scene Smith drafts in workspace, Gatekeeper promotes approved sections

### Files Changed

- `domain-v4/stores/manuscript.json` - NEW cold store definition
- `domain-v4/stores/canon.json` - Remove `section` from artifact_types
- `domain-v4/agents/gatekeeper.json` - Add manuscript read/write capabilities
- `domain-v4/artifact-types/section.json` - Clarify store flow in description
- `meta/docs/store-semantics.md` - Document new model

## Test plan

- [x] All JSON validates (pre-commit hooks pass)
- [ ] Manual review of store relationships
- [ ] Runtime integration (future - not in this PR)

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)