### PR TITLE
runtime: wire LifecycleManager to ToolRegistry for lifecycle transitions

### DIFF
--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -48,7 +48,7 @@ from questfoundry.runtime.providers import (
     ToolCallRequest,
 )
 from questfoundry.runtime.session import Session, TokenUsage, Turn
-from questfoundry.runtime.storage import StoreManager
+from questfoundry.runtime.storage import LifecycleManager, StoreManager
 
 if TYPE_CHECKING:
     from questfoundry.runtime.checkpoint import CheckpointManager, ContextUsage
@@ -167,10 +167,17 @@ class AgentRuntime:
         self._prompt_builder = PromptBuilder()
         self._tool_registry: ToolRegistry | None = None
         self._store_manager: StoreManager | None = None
+        self._lifecycle_manager: LifecycleManager | None = None
         try:
             self._store_manager = StoreManager.from_studio(studio)
         except (KeyError, ValueError) as exc:  # pragma: no cover - defensive logging
             logger.warning("Failed to load store manager from studio definition: %s", exc)
+
+        # Initialize lifecycle manager from artifact types
+        try:
+            self._lifecycle_manager = LifecycleManager.from_artifact_types(studio.artifact_types)
+        except (KeyError, ValueError, AttributeError) as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to load lifecycle manager from studio definition: %s", exc)
 
         # Secretary for tiered context management
         # context_limit from model determines when to start summarizing
@@ -201,6 +208,7 @@ class AgentRuntime:
                     broker=self._broker,
                     interactive=self._interactive,
                     store_manager=self._store_manager,
+                    lifecycle_manager=self._lifecycle_manager,
                 )
             except ImportError:
                 logger.warning("Tools module not available, tool execution disabled", exc_info=True)

--- a/src/questfoundry/runtime/tools/registry.py
+++ b/src/questfoundry/runtime/tools/registry.py
@@ -25,7 +25,7 @@ from questfoundry.runtime.tools.base import (
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Agent, Studio, Tool
-    from questfoundry.runtime.storage import Project, StoreManager
+    from questfoundry.runtime.storage import LifecycleManager, Project, StoreManager
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +100,7 @@ class ToolRegistry:
         broker: AsyncMessageBroker | None = None,
         interactive: bool = True,
         store_manager: StoreManager | None = None,
+        lifecycle_manager: LifecycleManager | None = None,
     ):
         """
         Initialize tool registry.
@@ -110,6 +111,8 @@ class ToolRegistry:
             domain_path: Path to domain directory
             broker: Message broker for delegation routing
             interactive: Whether running in interactive mode (disables human-input tools if False)
+            store_manager: Store manager for artifact storage
+            lifecycle_manager: Lifecycle manager for artifact state transitions
         """
         self._studio = studio
         self._project = project
@@ -117,7 +120,7 @@ class ToolRegistry:
         self._broker = broker
         self._interactive = interactive
         self._store_manager = store_manager
-        self._lifecycle_manager = None
+        self._lifecycle_manager = lifecycle_manager
         self._tool_cache: dict[str, BaseTool] = {}
 
     def get_tool_definition(self, tool_id: str) -> Tool | None:


### PR DESCRIPTION
## Summary
- AgentRuntime now initializes LifecycleManager from `studio.artifact_types`
- ToolRegistry receives `lifecycle_manager` parameter for tools that need it
- Enables tools like `request_lifecycle_transition` to validate state changes

## Context
This completes the **runtime support** for issue #203. The domain changes (manuscript store, gatekeeper permissions) were already merged in PR #204.

With this PR:
1. `LifecycleManager` is created from artifact type definitions when runtime starts
2. The lifecycle manager is passed through `ToolRegistry` to tools
3. Tools that need to validate state transitions (e.g., `request_lifecycle_transition`) can now access the lifecycle manager

## Test plan
- [x] All 109 runtime tests pass
- [x] All pre-commit hooks pass
- [ ] Integration test: section lifecycle draft→cold via gatekeeper

Closes part of #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)