### PR TITLE
fix(runtime): resolve search tool misuse and cancel bugs

### DIFF
--- a/domain-v4/tools/get_artifact.json
+++ b/domain-v4/tools/get_artifact.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "get_artifact",
+  "name": "Get Artifact",
+  "description": "Retrieve artifacts by ID. Use this to fetch specific artifacts when you know their IDs. Accepts a single ID or list of IDs.\n\nUse search_workspace instead if you need to find artifacts by criteria (type, lifecycle state, text search).",
+
+  "summarization_policy": "concise",
+  "summary_template": "Retrieved {count} artifact(s)",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "artifact_ids": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ],
+        "description": "Artifact ID(s) to fetch - single string or array of strings"
+      }
+    },
+    "required": ["artifact_ids"]
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "artifacts": {
+        "type": "array",
+        "description": "List of artifacts found (full content)"
+      },
+      "count": {
+        "type": "integer",
+        "description": "Number of artifacts retrieved"
+      },
+      "not_found": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "IDs that were not found (only present if some IDs not found)"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Fetch a single artifact by ID",
+      "input": {
+        "artifact_ids": "section_brief_abc123"
+      }
+    },
+    {
+      "description": "Fetch multiple artifacts at once",
+      "input": {
+        "artifact_ids": ["section_brief_abc123", "section_brief_def456", "section_brief_ghi789"]
+      }
+    }
+  ]
+}

--- a/domain-v4/tools/search_workspace.json
+++ b/domain-v4/tools/search_workspace.json
@@ -11,8 +11,11 @@
     "type": "object",
     "properties": {
       "query": {
-        "type": "string",
-        "description": "Text search query (searches across text fields)"
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "string" } }
+        ],
+        "description": "Text search query - single string or array of strings (OR search)"
       },
       "artifact_types": {
         "type": "array",
@@ -95,6 +98,12 @@
       "input": {
         "created_by": "plotwright",
         "lifecycle_states": ["draft"]
+      }
+    },
+    {
+      "description": "Search for multiple section briefs by ID (OR search)",
+      "input": {
+        "query": ["section_brief_abc123", "section_brief_def456", "section_brief_ghi789"]
       }
     }
   ]

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1399,6 +1399,7 @@ async def _ask_repl(
 ) -> None:
     """Run interactive REPL mode."""
     from questfoundry.runtime.providers import ContextOverflowError, ProviderError
+    from questfoundry.runtime.session.turn import TurnStatus
 
     # Select response function based on streaming preference
     respond = _stream_response if stream else _invoke_response
@@ -1512,7 +1513,11 @@ async def _ask_repl(
                     console.print()
 
         except (KeyboardInterrupt, EOFError):
-            console.print()
+            # Cancel any in-progress turn
+            current = session.current_turn
+            if current and current.status == TurnStatus.STREAMING:
+                session.cancel_turn(current, "Interrupted by user")
+            console.print("\n[dim]Cancelled[/dim]")
 
         finally:
             # End session tracing

--- a/src/questfoundry/runtime/session/session.py
+++ b/src/questfoundry/runtime/session/session.py
@@ -276,6 +276,34 @@ class Session:
             )
             conn.commit()
 
+    def cancel_turn(self, turn: Turn, reason: str | None = None) -> None:
+        """
+        Cancel a turn that was interrupted.
+
+        Args:
+            turn: The turn to cancel
+            reason: Optional cancellation reason
+        """
+        turn.cancel(reason)
+
+        # Persist to database
+        if self._project and turn.db_id:
+            conn = self._project._get_connection()
+            conn.execute(
+                """
+                UPDATE turns
+                SET output = ?, ended_at = ?, status = ?
+                WHERE id = ?
+                """,
+                (
+                    turn.output,
+                    turn.ended_at.isoformat() if turn.ended_at else None,
+                    turn.status.value,
+                    turn.db_id,
+                ),
+            )
+            conn.commit()
+
     def complete(self) -> None:
         """Mark session as completed."""
         self.status = SessionStatus.COMPLETED

--- a/src/questfoundry/runtime/session/turn.py
+++ b/src/questfoundry/runtime/session/turn.py
@@ -19,6 +19,7 @@ class TurnStatus(str, Enum):
     STREAMING = "streaming"
     COMPLETED = "completed"
     ERROR = "error"
+    CANCELLED = "cancelled"
 
 
 @dataclass
@@ -87,6 +88,12 @@ class Turn:
         self.output = error_message
         self.ended_at = datetime.now()
         self.status = TurnStatus.ERROR
+
+    def cancel(self, reason: str | None = None) -> None:
+        """Mark turn as cancelled."""
+        self.output = reason or "Cancelled by user"
+        self.ended_at = datetime.now()
+        self.status = TurnStatus.CANCELLED
 
     @property
     def duration_ms(self) -> float | None:

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -502,18 +502,21 @@ class UpdateArtifactTool(BaseTool):
 @register_tool("get_artifact")
 class GetArtifactTool(BaseTool):
     """
-    Retrieve an artifact by ID.
+    Retrieve artifacts by ID.
+
+    Accepts a single ID or list of IDs. Always returns an array of artifacts
+    for consistent response shape.
     """
 
     async def execute(self, args: dict[str, Any]) -> ToolResult:
         """Execute artifact retrieval."""
-        artifact_id = args.get("artifact_id")
+        artifact_ids = args.get("artifact_ids")
 
-        if not artifact_id:
+        if not artifact_ids:
             return ToolResult(
                 success=False,
                 data={},
-                error="artifact_id is required",
+                error="artifact_ids is required",
             )
 
         if not self._context.project:
@@ -523,18 +526,38 @@ class GetArtifactTool(BaseTool):
                 error="No project available - cannot retrieve artifact",
             )
 
-        artifact = self._context.project.get_artifact(artifact_id)
+        # Normalize to list
+        if isinstance(artifact_ids, str):
+            artifact_ids = [artifact_ids]
 
-        if artifact:
+        # Fetch all requested artifacts
+        artifacts = []
+        not_found = []
+        for aid in artifact_ids:
+            artifact = self._context.project.get_artifact(aid)
+            if artifact:
+                artifacts.append(artifact)
+            else:
+                not_found.append(aid)
+
+        # Build response
+        data: dict[str, Any] = {
+            "artifacts": artifacts,
+            "count": len(artifacts),
+        }
+        if not_found:
+            data["not_found"] = not_found
+
+        if artifacts:
             return ToolResult(
                 success=True,
-                data={"artifact": artifact},
+                data=data,
             )
         else:
             return ToolResult(
                 success=False,
-                data={},
-                error=f"Artifact not found: {artifact_id}",
+                data=data,
+                error=f"No artifacts found for IDs: {', '.join(not_found)}",
             )
 
 

--- a/src/questfoundry/runtime/tools/search_workspace.py
+++ b/src/questfoundry/runtime/tools/search_workspace.py
@@ -39,7 +39,7 @@ class SearchWorkspaceTool(BaseTool):
                 error="No project storage available",
             )
 
-        query = args.get("query")
+        query_input = args.get("query")
         artifact_types = args.get("artifact_types", [])
         lifecycle_states = args.get("lifecycle_states", [])
         created_by = args.get("created_by")
@@ -47,9 +47,17 @@ class SearchWorkspaceTool(BaseTool):
         related_to = args.get("related_to")
         limit = args.get("limit", 20)
 
+        # Normalize query to list (supports single string or array input)
+        if query_input is None:
+            queries = None
+        elif isinstance(query_input, list):
+            queries = [q.strip() for q in query_input if q and q.strip()]
+        else:
+            queries = [query_input.strip()] if query_input.strip() else None
+
         try:
-            results = self._search_artifacts(
-                query=query,
+            results, warning = self._search_artifacts(
+                queries=queries,
                 artifact_types=artifact_types,
                 lifecycle_states=lifecycle_states,
                 created_by=created_by,
@@ -58,12 +66,16 @@ class SearchWorkspaceTool(BaseTool):
                 limit=limit,
             )
 
+            data: dict[str, Any] = {
+                "results": results,
+                "total_count": len(results),
+            }
+            if warning:
+                data["warning"] = warning
+
             return ToolResult(
                 success=True,
-                data={
-                    "results": results,
-                    "total_count": len(results),
-                },
+                data=data,
             )
 
         except Exception as e:
@@ -71,18 +83,19 @@ class SearchWorkspaceTool(BaseTool):
 
     def _search_artifacts(
         self,
-        query: str | None = None,
+        queries: list[str] | None = None,
         artifact_types: list[str] | None = None,
         lifecycle_states: list[str] | None = None,
         created_by: str | None = None,
         created_after: str | None = None,
         related_to: str | None = None,
         limit: int = 20,
-    ) -> list[dict[str, Any]]:
-        """Search artifacts with filters."""
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Search artifacts with filters. Returns (results, warning)."""
         if not self._context.project:
-            return []
+            return [], None
         conn = self._context.project._get_connection()
+        warning: str | None = None
 
         # Build query dynamically
         sql = """
@@ -118,10 +131,18 @@ class SearchWorkspaceTool(BaseTool):
         # TODO: LIKE on JSON data is inefficient for large datasets.
         # Consider implementing FTS5 (Full-Text Search) for better performance.
         # See: https://www.sqlite.org/fts5.html
-        if query:
-            # Search both artifact ID and JSON payload for the query fragment
-            sql += " AND (_id LIKE ? OR data LIKE ?)"
-            params.extend([f"%{query}%", f"%{query}%"])
+        if queries:
+            if len(queries) > 1:
+                # Multiple queries: search for each with OR
+                or_clauses = " OR ".join("(_id LIKE ? OR data LIKE ?)" for _ in queries)
+                sql += f" AND ({or_clauses})"
+                for term in queries:
+                    params.extend([f"%{term}%", f"%{term}%"])
+            else:
+                # Single term - original behavior
+                # Search both artifact ID and JSON payload for the query fragment
+                sql += " AND (_id LIKE ? OR data LIKE ?)"
+                params.extend([f"%{queries[0]}%", f"%{queries[0]}%"])
 
         # Order and limit
         sql += " ORDER BY _updated_at DESC LIMIT ?"
@@ -154,7 +175,7 @@ class SearchWorkspaceTool(BaseTool):
                 }
             )
 
-        return results
+        return results, warning
 
     def _build_summary(self, artifact_type: str, data: dict[str, Any]) -> str:
         """Build a human-readable summary of an artifact."""

--- a/tests/runtime/tools/test_save_artifact.py
+++ b/tests/runtime/tools/test_save_artifact.py
@@ -474,10 +474,11 @@ class TestGetArtifactTool:
         )
         tool = GetArtifactTool(definition, context)
 
-        result = await tool.execute({"artifact_id": "section_001"})
+        result = await tool.execute({"artifact_ids": "section_001"})
 
         assert result.success is True
-        assert result.data["artifact"]["title"] == "Test Section"
+        assert result.data["count"] == 1
+        assert result.data["artifacts"][0]["title"] == "Test Section"
 
     @pytest.mark.asyncio
     async def test_get_artifact_not_found(self, project_with_artifact: Project):
@@ -492,10 +493,32 @@ class TestGetArtifactTool:
         )
         tool = GetArtifactTool(definition, context)
 
-        result = await tool.execute({"artifact_id": "nonexistent"})
+        result = await tool.execute({"artifact_ids": "nonexistent"})
 
         assert result.success is False
-        assert "not found" in result.error
+        assert "nonexistent" in result.error
+        assert result.data["not_found"] == ["nonexistent"]
+
+    @pytest.mark.asyncio
+    async def test_get_multiple_artifacts(self, project_with_artifact: Project):
+        """Retrieve multiple artifacts by ID list."""
+        studio = MagicMock()
+        studio.artifact_types = []
+
+        definition = make_mock_definition("get_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project_with_artifact,
+        )
+        tool = GetArtifactTool(definition, context)
+
+        # Request multiple IDs (one exists, one doesn't)
+        result = await tool.execute({"artifact_ids": ["section_001", "nonexistent"]})
+
+        assert result.success is True
+        assert result.data["count"] == 1
+        assert result.data["not_found"] == ["nonexistent"]
+        assert result.data["artifacts"][0]["title"] == "Test Section"
 
 
 class TestListArtifactsTool:


### PR DESCRIPTION
## Summary
Fixes #185

- **Bug 1 - Search Tool Misuse**: Scene_smith concatenated artifact IDs into a single query string which failed with LIKE matching. Fixed by:
  - Adding `get_artifact` tool schema with `artifact_ids: str | list[str]`
  - `GetArtifactTool` now accepts single ID or array of IDs
  - `search_workspace` now accepts `query: str | list[str]` for OR matching

- **Bug 2 - Cancel Not Working**: Ctrl+C left turns in `streaming` status with null output. Fixed by:
  - Adding `TurnStatus.CANCELLED` and `Turn.cancel()` method
  - Adding `Session.cancel_turn()` with database persistence
  - CLI KeyboardInterrupt handler now properly cancels in-progress turns

## Test plan
- [x] `get_artifact(artifact_ids="single_id")` returns `{artifacts: [...], count: 1}`
- [x] `get_artifact(artifact_ids=["id1", "id2"])` returns `{artifacts: [...], not_found: [...]}`
- [x] `search_workspace(query=["term1", "term2"])` performs OR search
- [x] All 59 tests pass (23 artifact + 36 session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)