### PR TITLE
feat(runtime): implement agent memory for tool interactions

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -33,7 +33,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from questfoundry.cli_output import StatusReporter, create_log_handler
+from questfoundry.cli_output import DelegationResultInfo, StatusReporter, create_log_handler
 
 # Global verbosity level (set by callback)
 _verbosity: int = 0
@@ -659,6 +659,35 @@ async def _setup_runtime(
     else:
         logger.debug("Could not determine context size for %s, using default", model_to_use)
 
+    # Create tool call callback for UI updates
+    def on_tool_call(
+        tool_id: str,
+        success: bool,
+        agent_id: str,
+        turn_number: int | None,
+        execution_time_ms: float | None,
+        result: Any,
+    ) -> None:
+        """Callback from runtime when a tool is executed."""
+        if _status_reporter:
+            _status_reporter.tool_call(
+                tool_id=tool_id,
+                success=success,
+                agent_id=agent_id,
+                turn_number=turn_number or 0,
+                execution_time_ms=execution_time_ms,
+            )
+            # Track artifact creation from save_artifact tool
+            if tool_id == "save_artifact" and success and result:
+                _status_reporter.artifact_created(
+                    artifact_id=result.get("artifact_id", "unknown"),
+                    artifact_type=result.get("artifact", {}).get("_type", "unknown"),
+                    store=result.get("store", "unknown"),
+                    created_by=agent_id,
+                    turn_number=turn_number or 0,
+                    lifecycle_state=result.get("lifecycle_state", "draft"),
+                )
+
     # Create runtime
     runtime = AgentRuntime(
         provider=provider,
@@ -672,6 +701,7 @@ async def _setup_runtime(
         interactive=interactive,
         checkpoint_manager=checkpoint_manager,
         context_limit=context_limit,
+        on_tool_call=on_tool_call,
     )
 
     # Get entry agent
@@ -800,6 +830,50 @@ async def _handle_orchestrator_follow_up(
     responses = await runtime.get_delegation_responses(agent.id)
     if not responses:
         return ""
+
+    # Display structured results from each delegation
+    if _status_reporter and responses:
+        console.print()
+        console.print("[dim]─── Delegation Results ───[/dim]")
+        for msg in responses:
+            payload = msg.payload or {}
+            success = payload.get("success", False)
+            result_data = payload.get("result", {})
+
+            # Extract structured fields from return_to_orchestrator
+            task_completion = result_data.get(
+                "task_completion", "completed" if success else "failed"
+            )
+            result_info = result_data.get("result", {})
+            assessment = result_info.get("assessment", "info")
+            recommendation = result_data.get("recommendation", "proceed")
+            summary = result_info.get("summary") or result_data.get("summary", "No summary")
+
+            # Artifacts
+            artifacts = payload.get("artifacts_produced", [])
+            ready_for_review = result_data.get("artifacts_ready_for_review", [])
+
+            # Blockers/issues
+            details = result_info.get("details", [])
+            blockers = []
+            for d in details:
+                if isinstance(d, dict):
+                    blockers.append(d.get("description", str(d)))
+                else:
+                    blockers.append(str(d))
+
+            result_info_obj = DelegationResultInfo(
+                from_agent=msg.from_agent,
+                task_completion=task_completion,
+                assessment=assessment,
+                recommendation=recommendation,
+                summary=summary,
+                artifacts_produced=artifacts,
+                artifacts_ready_for_review=ready_for_review,
+                blockers=blockers,
+            )
+            _status_reporter.delegation_result(result_info_obj)
+        console.print()
 
     # Build follow-up prompt with delegation results
     follow_up_prompt = runtime.build_delegation_response_prompt(responses)
@@ -1000,25 +1074,8 @@ async def _invoke_response(
 
     duration_ms = (time.time() - start_time) * 1000
 
-    # Report tool calls and artifacts via StatusReporter
-    if _status_reporter and result.tool_calls:
-        for tc in result.tool_calls:
-            _status_reporter.tool_call(
-                tool_id=tc.tool_id,
-                success=tc.success,
-                agent_id=agent.id,
-                turn_number=result.turn.turn_number,
-                execution_time_ms=tc.execution_time_ms,
-            )
-            # Check if this was a save_artifact call
-            if tc.tool_id == "save_artifact" and tc.success and tc.result:
-                _status_reporter.artifact_created(
-                    artifact_id=tc.result.get("artifact_id", "unknown"),
-                    artifact_type=tc.result.get("artifact", {}).get("_type", "unknown"),
-                    store=tc.result.get("store", "unknown"),
-                    created_by=agent.id,
-                    turn_number=result.turn.turn_number,
-                )
+    # Note: Tool calls and artifacts are now reported via the on_tool_call callback
+    # which is called during runtime._execute_tool_calls()
 
     # Report turn completion
     if _status_reporter:

--- a/src/questfoundry/cli_output.py
+++ b/src/questfoundry/cli_output.py
@@ -35,6 +35,7 @@ class ArtifactEvent:
     store: str
     created_by: str
     turn_number: int
+    lifecycle_state: str = "draft"  # draft, review, approved, cold
     timestamp: datetime = field(default_factory=datetime.now)
 
 
@@ -60,6 +61,20 @@ class DelegationEvent:
     success: bool
     turn_number: int
     timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class DelegationResultInfo:
+    """Structured result from return_to_orchestrator."""
+
+    from_agent: str
+    task_completion: str  # completed | blocked
+    assessment: str  # pass | partial | fail | skip | info
+    recommendation: str  # proceed | rework | escalate | hold
+    summary: str
+    artifacts_produced: list[str] = field(default_factory=list)
+    artifacts_ready_for_review: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -313,17 +328,18 @@ class StatusReporter:
         )
         self._tool_calls.append(event)
 
+        # Track on current turn if available
         if self._current_turn:
             self._current_turn.tool_calls += 1
 
         if self.quiet:
             return
 
-        # Only show tool calls at verbosity >= 1, or always show failures
+        # Show tool calls at INFO level (-v) or always show failures
         if self.verbosity >= 1 or not success:
-            status = "[green]OK[/green]" if success else "[red]FAIL[/red]"
-            time_str = f" ({execution_time_ms:.0f}ms)" if execution_time_ms else ""
-            self.console.print(f"  [dim]tool:[/dim] {tool_id} {status}{time_str}")
+            status_icon = "[green]✓[/green]" if success else "[red]✗[/red]"
+            time_str = f" [dim]({execution_time_ms:.0f}ms)[/dim]" if execution_time_ms else ""
+            self.console.print(f"  [dim]tool:[/dim] {tool_id} {status_icon}{time_str}")
             # Show result preview at higher verbosity
             if result_preview and self.verbosity >= 2:
                 preview = (
@@ -342,6 +358,7 @@ class StatusReporter:
         store: str,
         created_by: str,
         turn_number: int,
+        lifecycle_state: str = "draft",
     ) -> None:
         """Report artifact creation."""
         event = ArtifactEvent(
@@ -350,6 +367,7 @@ class StatusReporter:
             store=store,
             created_by=created_by,
             turn_number=turn_number,
+            lifecycle_state=lifecycle_state,
         )
         self._artifacts.append(event)
 
@@ -359,10 +377,21 @@ class StatusReporter:
         if self.quiet:
             return
 
+        # Lifecycle state indicator
+        state_colors = {
+            "draft": "yellow",
+            "review": "blue",
+            "approved": "green",
+            "cold": "cyan",
+        }
+        state_color = state_colors.get(lifecycle_state, "dim")
+
         # Always show artifact creation (this is what user wants to see)
         self.console.print(
             f"  [bold green]+[/bold green] {artifact_type}: "
-            f"[cyan]{artifact_id}[/cyan] [dim]-> {store}[/dim]"
+            f"[cyan]{artifact_id}[/cyan] "
+            f"[{state_color}]({lifecycle_state})[/{state_color}] "
+            f"[dim]-> {store}[/dim]"
         )
 
     # -------------------------------------------------------------------------
@@ -398,7 +427,7 @@ class StatusReporter:
         error: str | None = None,
     ) -> None:
         """Report delegation completion."""
-        task_preview = task[:50] + "..." if len(task) > 50 else task
+        task_preview = task[:80] + "..." if len(task) > 80 else task
 
         event = DelegationEvent(
             from_agent=from_agent,
@@ -415,10 +444,72 @@ class StatusReporter:
         if self.quiet:
             return
 
-        status = "[green]OK[/green]" if success else "[red]FAIL[/red]"
-        self.console.print(f"  [dim]result:[/dim] {to_agent} {status}")
+        # Show delegation with task - this is key info users want to see
+        status_icon = "[green]✓[/green]" if success else "[red]✗[/red]"
+        self.console.print(f"  [dim]delegate:[/dim] [cyan]{to_agent}[/cyan] {status_icon}")
+        # Always show task preview (this is what SR asked specialist to do)
+        self.console.print(f"    [dim]task:[/dim] {task_preview}")
         if not success and error:
-            self.console.print(f"    [red]{error}[/red]")
+            self.console.print(f"    [red]error: {error}[/red]")
+
+    def delegation_result(self, result: DelegationResultInfo) -> None:
+        """
+        Display structured result from return_to_orchestrator.
+
+        Shows what the specialist accomplished: assessment, recommendation,
+        summary, and any artifacts or blockers.
+        """
+        if self.quiet:
+            return
+
+        # Assessment color coding
+        assessment_colors = {
+            "pass": "green",
+            "partial": "yellow",
+            "fail": "red",
+            "skip": "dim",
+            "info": "blue",
+        }
+        assessment_color = assessment_colors.get(result.assessment, "white")
+
+        # Recommendation color coding
+        rec_colors = {
+            "proceed": "green",
+            "rework": "yellow",
+            "escalate": "red",
+            "hold": "yellow",
+        }
+        rec_color = rec_colors.get(result.recommendation, "white")
+
+        # Task completion indicator
+        completion_icon = "✓" if result.task_completion == "completed" else "⏸"
+        completion_color = "green" if result.task_completion == "completed" else "yellow"
+
+        # Header line with agent and completion status
+        self.console.print(
+            f"  [{completion_color}]{completion_icon}[/{completion_color}] "
+            f"[cyan]{result.from_agent}[/cyan] "
+            f"[{assessment_color}]{result.assessment}[/{assessment_color}] → "
+            f"[{rec_color}]{result.recommendation}[/{rec_color}]"
+        )
+
+        # Summary (always shown)
+        summary_text = result.summary[:100] + "..." if len(result.summary) > 100 else result.summary
+        self.console.print(f"    [dim]{summary_text}[/dim]")
+
+        # Artifacts produced (if any)
+        if result.artifacts_produced:
+            artifacts_str = ", ".join(result.artifacts_produced[:3])
+            if len(result.artifacts_produced) > 3:
+                artifacts_str += f" (+{len(result.artifacts_produced) - 3} more)"
+            self.console.print(f"    [green]+[/green] artifacts: {artifacts_str}")
+
+        # Blockers (if any)
+        if result.blockers:
+            blockers_str = "; ".join(result.blockers[:2])
+            if len(result.blockers) > 2:
+                blockers_str += f" (+{len(result.blockers) - 2} more)"
+            self.console.print(f"    [yellow]![/yellow] blockers: {blockers_str}")
 
     # -------------------------------------------------------------------------
     # Summary Table
@@ -432,6 +523,16 @@ class StatusReporter:
         table.add_column("Tools", justify="right")
         table.add_column("Artifacts", justify="right")
         table.add_column("Tokens", justify="right", style="dim")
+
+        # Aggregate tool/artifact counts by turn from event lists
+        # This handles out-of-order tracking for delegated agents
+        tools_by_turn: dict[int, int] = {}
+        for tc in self._tool_calls:
+            tools_by_turn[tc.turn_number] = tools_by_turn.get(tc.turn_number, 0) + 1
+
+        artifacts_by_turn: dict[int, int] = {}
+        for art in self._artifacts:
+            artifacts_by_turn[art.turn_number] = artifacts_by_turn.get(art.turn_number, 0) + 1
 
         total_tokens = 0
         total_artifacts = 0
@@ -447,11 +548,15 @@ class StatusReporter:
                 total_tokens += tokens
                 tokens_str = f"{tokens:,}"
 
-            artifacts_str = str(turn.artifacts_created) if turn.artifacts_created else "-"
-            tools_str = str(turn.tool_calls) if turn.tool_calls else "-"
+            # Get counts from aggregated event lists
+            turn_tools = tools_by_turn.get(turn.turn_number, 0)
+            turn_artifacts = artifacts_by_turn.get(turn.turn_number, 0)
 
-            total_artifacts += turn.artifacts_created
-            total_tools += turn.tool_calls
+            artifacts_str = str(turn_artifacts) if turn_artifacts else "-"
+            tools_str = str(turn_tools) if turn_tools else "-"
+
+            total_artifacts += turn_artifacts
+            total_tools += turn_tools
 
             table.add_row(
                 str(turn.turn_number),
@@ -478,9 +583,17 @@ class StatusReporter:
         if self._artifacts:
             self.console.print()
             self.console.print("[bold]Artifacts Created:[/bold]")
+            state_colors = {
+                "draft": "yellow",
+                "review": "blue",
+                "approved": "green",
+                "cold": "cyan",
+            }
             for art in self._artifacts:
+                state_color = state_colors.get(art.lifecycle_state, "dim")
                 self.console.print(
                     f"  [cyan]{art.artifact_id}[/cyan] ({art.artifact_type}) "
+                    f"[{state_color}]{art.lifecycle_state}[/{state_color}] "
                     f"[dim]-> {art.store}[/dim]"
                 )
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -130,6 +130,7 @@ class AgentRuntime:
         checkpoint_manager: CheckpointManager | None = None,
         playbook_tracker: PlaybookTracker | None = None,
         turn_validation_config: TurnValidationConfig | None = None,
+        on_tool_call: Any | None = None,
     ):
         """
         Initialize agent runtime.
@@ -148,6 +149,7 @@ class AgentRuntime:
             checkpoint_manager: Optional checkpoint manager for auto-checkpointing
             playbook_tracker: Optional playbook tracker for checkpoint state
             turn_validation_config: Optional configuration for orchestrator enforcement
+            on_tool_call: Optional callback(tool_id, success, agent_id, turn_number, execution_time_ms, result)
         """
         self._provider = provider
         self._studio = studio
@@ -161,6 +163,7 @@ class AgentRuntime:
         self._interactive = interactive
         self._checkpoint_manager = checkpoint_manager
         self._playbook_tracker = playbook_tracker
+        self._on_tool_call = on_tool_call
 
         # Context usage tracking per agent
         self._context_usage: dict[str, ContextUsage] = {}
@@ -480,6 +483,20 @@ class AgentRuntime:
                 logger.warning(f"Tool call failed: {tc.name} - {e}")
 
             results.append(tool_call)
+
+            # Notify UI callback if registered
+            if self._on_tool_call:
+                try:
+                    self._on_tool_call(
+                        tool_id=tool_call.tool_id,
+                        success=tool_call.success,
+                        agent_id=agent.id,
+                        turn_number=turn_number,
+                        execution_time_ms=tool_call.execution_time_ms,
+                        result=tool_call.result,
+                    )
+                except Exception as e:
+                    logger.debug(f"Tool callback failed: {e}")
 
         return results
 

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -36,7 +36,7 @@ from questfoundry.runtime.agent.turn_validator import (
     TurnValidationConfig,
     TurnValidator,
 )
-from questfoundry.runtime.context import Secretary, SummarizationPolicy
+from questfoundry.runtime.context import ContextSecretary, Secretary, SummarizationPolicy
 from questfoundry.runtime.observability import EventType
 from questfoundry.runtime.providers import (
     ContextOverflowError,
@@ -72,6 +72,29 @@ class ToolCall:
     success: bool = False
     error: str | None = None
     execution_time_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "tool_id": self.tool_id,
+            "args": self.args,
+            "result": self.result,
+            "success": self.success,
+            "error": self.error,
+            "execution_time_ms": self.execution_time_ms,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolCall:
+        """Create from dictionary."""
+        return cls(
+            tool_id=data["tool_id"],
+            args=data.get("args", {}),
+            result=data.get("result"),
+            success=data.get("success", False),
+            error=data.get("error"),
+            execution_time_ms=data.get("execution_time_ms"),
+        )
 
 
 @dataclass
@@ -192,6 +215,13 @@ class AgentRuntime:
         )
         self._secretary_initialized = False
 
+        # Context Secretary for full conversation summarization (Level 2)
+        # Summarizes older turns when context pressure reaches FULL threshold (90%)
+        self._context_secretary = ContextSecretary(
+            preserve_recent_turns=3,  # Always preserve last 3 turns
+            min_turns_to_summarize=5,  # Need at least 5 older turns before summarizing
+        )
+
         # Turn validator for orchestrator enforcement
         self._turn_validator = TurnValidator(studio, turn_validation_config)
 
@@ -239,6 +269,11 @@ class AgentRuntime:
     def secretary(self) -> Secretary:
         """Get the Secretary for context management."""
         return self._secretary
+
+    @property
+    def context_secretary(self) -> ContextSecretary:
+        """Get the ContextSecretary for conversation summarization."""
+        return self._context_secretary
 
     def get_agent_tools(self, agent: Agent, session_id: str | None = None) -> list[BaseTool]:
         """
@@ -375,7 +410,7 @@ class AgentRuntime:
         agent: Agent,
         user_input: str,
         context: AgentContext | None = None,
-        history: list[dict[str, str]] | None = None,
+        history: list[dict[str, Any]] | None = None,
         tool_schemas: list[dict[str, Any]] | None = None,
     ) -> list[LLMMessage]:
         """
@@ -385,7 +420,8 @@ class AgentRuntime:
             agent: The agent to activate
             user_input: User's input message
             context: Pre-built context (built if not provided)
-            history: Conversation history [{role, content}, ...]
+            history: Conversation history - supports both simple {role, content}
+                     and rich format with tool_calls, tool_call_id, name
             tool_schemas: Optional list of tool schemas to include in prompt
 
         Returns:
@@ -412,10 +448,30 @@ class AgentRuntime:
         # System message
         messages.append(LLMMessage(role="system", content=prompt.text))
 
-        # History
+        # History - handle both simple and rich formats
         if history:
             for h in history:
-                messages.append(LLMMessage(role=h["role"], content=h["content"]))
+                # Reconstruct ToolCallRequest objects if present
+                tool_calls = None
+                if h.get("tool_calls"):
+                    tool_calls = [
+                        ToolCallRequest(
+                            id=tc["id"],
+                            name=tc["name"],
+                            arguments=tc.get("arguments", {}),
+                        )
+                        for tc in h["tool_calls"]
+                    ]
+
+                messages.append(
+                    LLMMessage(
+                        role=h["role"],
+                        content=h.get("content", ""),
+                        tool_call_id=h.get("tool_call_id"),
+                        name=h.get("name"),
+                        tool_calls=tool_calls,
+                    )
+                )
 
         # User input
         messages.append(LLMMessage(role="user", content=user_input))
@@ -1093,7 +1149,7 @@ class AgentRuntime:
                 # Update context size for next iteration's summarization decision (per-agent)
                 self._secretary.update_context_size(self.estimate_tokens(messages), agent.id)
 
-            # Complete turn
+            # Complete turn with full message trace and tool calls
             usage = TokenUsage(
                 prompt_tokens=total_prompt_tokens or response.prompt_tokens if response else None,
                 completion_tokens=total_completion_tokens or response.completion_tokens
@@ -1104,7 +1160,9 @@ class AgentRuntime:
                 else None,
             )
             final_content = response.content if response else ""
-            session.complete_turn(turn, final_content, usage)
+            session.complete_turn(
+                turn, final_content, usage, messages=messages, tool_calls=all_tool_calls
+            )
             duration_ms = (time.time() - start_time) * 1000
 
             # Log turn completion
@@ -1277,6 +1335,7 @@ class AgentRuntime:
             full_content = ""
             final_usage: TokenUsage | None = None
             consecutive_failures = 0
+            all_tool_calls: list[ToolCall] = []  # Track all tool calls for memory
 
             # Streaming loop with enforcement
             for iteration in range(max_iterations):
@@ -1353,6 +1412,7 @@ class AgentRuntime:
                     tool_results = await self._execute_tool_calls(
                         pending_tool_calls, agent, session.id, turn.turn_number
                     )
+                    all_tool_calls.extend(tool_results)  # Track for memory
 
                     # Validate turn with TurnValidator (checks for terminating tools)
                     # Note: This orchestrator enforcement runs independently of enforce_tool_usage.
@@ -1504,8 +1564,10 @@ class AgentRuntime:
                 # No enforcement or no tools - we're done
                 break
 
-            # Complete turn after streaming finishes
-            session.complete_turn(turn, full_content, final_usage)
+            # Complete turn after streaming finishes with full message trace
+            session.complete_turn(
+                turn, full_content, final_usage, messages=messages, tool_calls=all_tool_calls
+            )
             duration_ms = (time.time() - start_time) * 1000
 
             # Log completion

--- a/src/questfoundry/runtime/context/secretary.py
+++ b/src/questfoundry/runtime/context/secretary.py
@@ -843,21 +843,27 @@ class ContextSecretary:
         """
         Check if a turn should be preserved (not summarized).
 
+        Supports two formats:
+        - LLMMessage format: {role, content, tool_calls: [{name, ...}]} from get_history()
+        - Turn format: {output, tool_calls: [{tool_id, ...}]} from Turn.to_dict()
+
         Args:
-            turn: Conversation turn dict
+            turn: Conversation turn dict (either format)
 
         Returns:
             True if turn should be preserved
         """
         # Check for delegation-related content
-        content = str(turn.get("content", ""))
+        # Support both "content" (LLMMessage) and "output" (Turn) fields
+        content = str(turn.get("content", turn.get("output", "")))
         if "delegation" in content.lower():
             return True
 
         # Check for tool calls that created artifacts
+        # Support both "name" (ToolCallRequest) and "tool_id" (ToolCall) fields
         tool_calls = turn.get("tool_calls", [])
         for tc in tool_calls:
-            tool_name = tc.get("name", "")
+            tool_name = tc.get("name", tc.get("tool_id", ""))
             if tool_name in ("save_artifact", "create_artifact"):
                 return True
 

--- a/src/questfoundry/runtime/messaging/broker.py
+++ b/src/questfoundry/runtime/messaging/broker.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.runtime.messaging.mailbox import AsyncMailbox
 from questfoundry.runtime.messaging.message import Message
-from questfoundry.runtime.messaging.types import MessageStatus
+from questfoundry.runtime.messaging.types import MessageStatus, MessageType
 
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.logger import MessageLogger
@@ -319,11 +321,6 @@ class AsyncMessageBroker:
                 _, preserved = self._mailbox_secretary.select_messages_for_summarization(messages)
 
                 # Create a digest message from the summary
-                import uuid
-                from datetime import datetime
-
-                from questfoundry.runtime.messaging.types import MessageType
-
                 digest = Message(
                     id=str(uuid.uuid4()),
                     type=MessageType.DIGEST,

--- a/src/questfoundry/runtime/messaging/broker.py
+++ b/src/questfoundry/runtime/messaging/broker.py
@@ -53,6 +53,15 @@ class AsyncMessageBroker:
         self._lock = asyncio.Lock()
         self._current_turn = 0
 
+        # Mailbox Secretary for message summarization when mailboxes get large
+        # Lazy import to avoid circular dependency
+        from questfoundry.runtime.context import MailboxSecretary
+
+        self._mailbox_secretary = MailboxSecretary(
+            auto_summarize_threshold=20,  # Summarize when > 20 messages
+            preserve_recent_n=5,  # Always preserve last 5 messages
+        )
+
     def set_project(self, project: Project) -> None:
         """Set project for persistence after initialization."""
         self._project = project
@@ -287,16 +296,59 @@ class AsyncMessageBroker:
         """
         Get all pending messages for an agent.
 
-        Used for building agent context.
+        Used for building agent context. When mailbox exceeds the
+        auto_summarize_threshold, older low-priority messages are
+        summarized into a digest message to prevent context overflow.
 
         Args:
             agent_id: Agent ID
 
         Returns:
-            List of pending messages
+            List of pending messages (possibly with digest summary)
         """
         mailbox = await self.get_mailbox(agent_id)
-        return await mailbox.get_all_pending()
+        messages = await mailbox.get_all_pending()
+
+        # Apply mailbox summarization if needed
+        if self._mailbox_secretary.should_summarize(len(messages)):
+            result = self._mailbox_secretary.summarize_mailbox(
+                messages, current_turn=self._current_turn
+            )
+            if result.digest_created and result.summary_text:
+                # Get the preserved messages only
+                _, preserved = self._mailbox_secretary.select_messages_for_summarization(messages)
+
+                # Create a digest message from the summary
+                import uuid
+                from datetime import datetime
+
+                from questfoundry.runtime.messaging.types import MessageType
+
+                digest = Message(
+                    id=str(uuid.uuid4()),
+                    type=MessageType.DIGEST,
+                    from_agent="system",
+                    to_agent=agent_id,
+                    timestamp=datetime.now(),
+                    payload={
+                        "summary": result.summary_text,
+                        "action_items": result.action_items,
+                        "messages_summarized": result.messages_summarized,
+                    },
+                    priority=0,  # Low priority - just context
+                )
+
+                logger.info(
+                    "Mailbox %s: created digest for %d messages, preserved %d",
+                    agent_id,
+                    result.messages_summarized,
+                    result.messages_preserved,
+                )
+
+                # Return digest + preserved messages (digest first for context)
+                return [digest] + preserved
+
+        return messages
 
     async def wait_for_response(
         self,

--- a/src/questfoundry/runtime/providers/base.py
+++ b/src/questfoundry/runtime/providers/base.py
@@ -44,6 +44,23 @@ class ToolCallRequest:
     name: str  # Tool name/ID
     arguments: dict[str, Any]  # Parsed arguments
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "arguments": self.arguments,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolCallRequest:
+        """Create from dictionary."""
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            arguments=data.get("arguments", {}),
+        )
+
 
 @dataclass
 class LLMMessage:
@@ -54,6 +71,34 @@ class LLMMessage:
     tool_call_id: str | None = None  # For tool result messages
     name: str | None = None  # Tool name for tool result messages
     tool_calls: list[ToolCallRequest] | None = None  # For assistant messages with tool calls
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {
+            "role": self.role,
+            "content": self.content,
+        }
+        if self.tool_call_id is not None:
+            result["tool_call_id"] = self.tool_call_id
+        if self.name is not None:
+            result["name"] = self.name
+        if self.tool_calls is not None:
+            result["tool_calls"] = [tc.to_dict() for tc in self.tool_calls]
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LLMMessage:
+        """Create from dictionary."""
+        tool_calls = None
+        if data.get("tool_calls"):
+            tool_calls = [ToolCallRequest.from_dict(tc) for tc in data["tool_calls"]]
+        return cls(
+            role=data["role"],
+            content=data.get("content", ""),
+            tool_call_id=data.get("tool_call_id"),
+            name=data.get("name"),
+            tool_calls=tool_calls,
+        )
 
 
 @dataclass

--- a/src/questfoundry/runtime/session/session.py
+++ b/src/questfoundry/runtime/session/session.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 from questfoundry.runtime.session.turn import TokenUsage, Turn, TurnStatus
 
 if TYPE_CHECKING:
+    from questfoundry.runtime.agent.runtime import ToolCall
+    from questfoundry.runtime.providers.base import LLMMessage
     from questfoundry.runtime.storage import Project
 
 
@@ -105,11 +107,15 @@ class Session:
             _project=project,
         )
 
+        # Import at runtime to avoid circular imports
+        from questfoundry.runtime.agent.runtime import ToolCall as ToolCallCls
+        from questfoundry.runtime.providers.base import LLMMessage as LLMMessageCls
+
         # Load turns
         turn_rows = conn.execute(
             """
             SELECT id, session_id, turn_number, agent_id, input, output,
-                   started_at, ended_at, token_usage, status
+                   started_at, ended_at, token_usage, status, messages, tool_calls
             FROM turns
             WHERE session_id = ?
             ORDER BY turn_number
@@ -130,6 +136,17 @@ class Session:
             else:
                 status = TurnStatus.COMPLETED if turn_row["output"] else TurnStatus.PENDING
 
+            # Load messages and tool_calls
+            messages = []
+            if turn_row["messages"]:
+                messages_data = json.loads(turn_row["messages"])
+                messages = [LLMMessageCls.from_dict(m) for m in messages_data]
+
+            tool_calls = []
+            if turn_row["tool_calls"]:
+                tool_calls_data = json.loads(turn_row["tool_calls"])
+                tool_calls = [ToolCallCls.from_dict(tc) for tc in tool_calls_data]
+
             turn = Turn(
                 db_id=turn_row["id"],
                 turn_number=turn_row["turn_number"],
@@ -143,6 +160,8 @@ class Session:
                 ),
                 usage=usage,
                 status=status,
+                messages=messages,
+                tool_calls=tool_calls,
             )
             session.turns.append(turn)
 
@@ -218,6 +237,8 @@ class Session:
         turn: Turn,
         output: str,
         usage: TokenUsage | None = None,
+        messages: list[LLMMessage] | None = None,
+        tool_calls: list[ToolCall] | None = None,
     ) -> None:
         """
         Complete a turn with output.
@@ -226,16 +247,30 @@ class Session:
             turn: The turn to complete
             output: The agent's output
             usage: Optional token usage stats
+            messages: Full message trace for this turn
+            tool_calls: Executed tool calls for this turn
         """
         turn.complete(output, usage)
+
+        # Store messages and tool_calls on the turn
+        if messages is not None:
+            turn.messages = messages
+        if tool_calls is not None:
+            turn.tool_calls = tool_calls
 
         # Persist to database
         if self._project and turn.db_id:
             conn = self._project._get_connection()
+
+            # Serialize messages and tool_calls
+            messages_json = json.dumps([m.to_dict() for m in turn.messages])
+            tool_calls_json = json.dumps([tc.to_dict() for tc in turn.tool_calls])
+
             conn.execute(
                 """
                 UPDATE turns
-                SET output = ?, ended_at = ?, token_usage = ?, status = ?
+                SET output = ?, ended_at = ?, token_usage = ?, status = ?,
+                    messages = ?, tool_calls = ?
                 WHERE id = ?
                 """,
                 (
@@ -243,6 +278,8 @@ class Session:
                     turn.ended_at.isoformat() if turn.ended_at else None,
                     json.dumps(usage.to_dict()) if usage else None,
                     turn.status.value,
+                    messages_json,
+                    tool_calls_json,
                     turn.db_id,
                 ),
             )
@@ -337,18 +374,27 @@ class Session:
                 total += turn.usage.total_tokens
         return total
 
-    def get_history(self) -> list[dict[str, str]]:
+    def get_history(self) -> list[dict[str, Any]]:
         """
-        Get conversation history for context.
+        Get full conversation history including tool interactions.
 
-        Returns list of {role, content} dicts for LLM context.
+        Returns list of message dicts for LLM context, excluding system prompts.
+        Each turn's full message trace (user, assistant with tool_calls, tool results)
+        is included for proper context reconstruction.
         """
-        history: list[dict[str, str]] = []
+        history: list[dict[str, Any]] = []
         for turn in self.turns:
-            if turn.input:
-                history.append({"role": "user", "content": turn.input})
-            if turn.output and turn.status == TurnStatus.COMPLETED:
-                history.append({"role": "assistant", "content": turn.output})
+            if turn.messages:
+                # Use stored message trace (includes tool interactions)
+                for msg in turn.messages:
+                    if msg.role != "system":  # Skip system prompts
+                        history.append(msg.to_dict())
+            else:
+                # Fallback for turns without stored messages (legacy data)
+                if turn.input:
+                    history.append({"role": "user", "content": turn.input})
+                if turn.output and turn.status == TurnStatus.COMPLETED:
+                    history.append({"role": "assistant", "content": turn.output})
         return history
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/questfoundry/runtime/session/turn.py
+++ b/src/questfoundry/runtime/session/turn.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.agent.runtime import ToolCall
+    from questfoundry.runtime.providers.base import LLMMessage
 
 
 class TurnStatus(str, Enum):
@@ -54,6 +58,7 @@ class Turn:
     A single turn in a session.
 
     Represents one agent invocation with input, output, and metadata.
+    Stores full message trace and tool calls for context reconstruction.
     """
 
     turn_number: int
@@ -66,6 +71,10 @@ class Turn:
     usage: TokenUsage | None = None
     status: TurnStatus = TurnStatus.PENDING
     db_id: int | None = None  # SQLite row ID
+    # Full message trace for context reconstruction
+    messages: list[LLMMessage] = field(default_factory=list)
+    # Executed tool calls for this turn
+    tool_calls: list[ToolCall] = field(default_factory=list)
 
     def start(self) -> None:
         """Mark turn as started/streaming."""
@@ -115,14 +124,28 @@ class Turn:
             "ended_at": self.ended_at.isoformat() if self.ended_at else None,
             "usage": self.usage.to_dict() if self.usage else None,
             "status": self.status.value,
+            "messages": [m.to_dict() for m in self.messages],
+            "tool_calls": [tc.to_dict() for tc in self.tool_calls],
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Turn:
         """Create from dictionary."""
+        # Import at runtime to avoid circular imports
+        from questfoundry.runtime.agent.runtime import ToolCall
+        from questfoundry.runtime.providers.base import LLMMessage
+
         usage = None
         if data.get("usage"):
             usage = TokenUsage.from_dict(data["usage"])
+
+        messages = []
+        if data.get("messages"):
+            messages = [LLMMessage.from_dict(m) for m in data["messages"]]
+
+        tool_calls = []
+        if data.get("tool_calls"):
+            tool_calls = [ToolCall.from_dict(tc) for tc in data["tool_calls"]]
 
         return cls(
             turn_number=data["turn_number"],
@@ -135,4 +158,6 @@ class Turn:
             usage=usage,
             status=TurnStatus(data.get("status", "pending")),
             db_id=data.get("db_id"),
+            messages=messages,
+            tool_calls=tool_calls,
         )

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -292,6 +292,8 @@ class Project:
                 ended_at TEXT,
                 token_usage JSON,
                 status TEXT DEFAULT 'pending',
+                messages JSON NOT NULL DEFAULT '[]',
+                tool_calls JSON NOT NULL DEFAULT '[]',
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
 

--- a/tests/runtime/session/test_agent_memory.py
+++ b/tests/runtime/session/test_agent_memory.py
@@ -1,0 +1,537 @@
+"""
+Tests for agent memory - persisting and reconstructing tool interactions.
+
+This tests the core agent memory feature (Issue #224):
+- Messages and tool_calls are persisted on Turn
+- History reconstruction includes full message traces
+- Session.load() properly deserializes stored data
+"""
+
+from datetime import datetime
+
+from questfoundry.runtime.agent.runtime import ToolCall
+from questfoundry.runtime.providers.base import LLMMessage, ToolCallRequest
+from questfoundry.runtime.session import Session, TokenUsage, Turn, TurnStatus
+
+
+class TestTurnMessagePersistence:
+    """Test that Turn correctly stores and serializes messages/tool_calls."""
+
+    def test_turn_with_messages_to_dict(self):
+        """Test Turn.to_dict() includes messages field."""
+        messages = [
+            LLMMessage(role="user", content="Hello"),
+            LLMMessage(role="assistant", content="Hi there"),
+        ]
+        turn = Turn(
+            turn_number=1,
+            agent_id="test_agent",
+            session_id="sess_1",
+            input="Hello",
+            output="Hi there",
+            messages=messages,
+        )
+
+        data = turn.to_dict()
+
+        assert "messages" in data
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][0]["content"] == "Hello"
+        assert data["messages"][1]["role"] == "assistant"
+        assert data["messages"][1]["content"] == "Hi there"
+
+    def test_turn_with_tool_calls_to_dict(self):
+        """Test Turn.to_dict() includes tool_calls field."""
+        tool_calls = [
+            ToolCall(
+                tool_id="save_artifact",
+                args={"artifact_type": "chapter"},
+                result={"success": True, "id": "art_123"},
+                success=True,
+                execution_time_ms=150.0,
+            )
+        ]
+        turn = Turn(
+            turn_number=1,
+            agent_id="test_agent",
+            session_id="sess_1",
+            tool_calls=tool_calls,
+        )
+
+        data = turn.to_dict()
+
+        assert "tool_calls" in data
+        assert len(data["tool_calls"]) == 1
+        assert data["tool_calls"][0]["tool_id"] == "save_artifact"
+        assert data["tool_calls"][0]["success"] is True
+        assert data["tool_calls"][0]["result"]["id"] == "art_123"
+
+    def test_turn_from_dict_with_messages(self):
+        """Test Turn.from_dict() reconstructs messages."""
+        data = {
+            "turn_number": 1,
+            "agent_id": "test_agent",
+            "session_id": "sess_1",
+            "input": "Hello",
+            "output": "Hi",
+            "started_at": datetime.now().isoformat(),
+            "status": "completed",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ],
+            "tool_calls": [],
+        }
+
+        turn = Turn.from_dict(data)
+
+        assert len(turn.messages) == 2
+        assert isinstance(turn.messages[0], LLMMessage)
+        assert turn.messages[0].role == "user"
+        assert turn.messages[1].content == "Hi"
+
+    def test_turn_from_dict_with_tool_calls(self):
+        """Test Turn.from_dict() reconstructs tool_calls."""
+        data = {
+            "turn_number": 1,
+            "agent_id": "test_agent",
+            "session_id": "sess_1",
+            "started_at": datetime.now().isoformat(),
+            "status": "completed",
+            "messages": [],
+            "tool_calls": [
+                {
+                    "tool_id": "delegate",
+                    "args": {"to": "scene_smith", "task": "write chapter"},
+                    "result": {"delegation_id": "del_123"},
+                    "success": True,
+                    "error": None,
+                    "execution_time_ms": 50.0,
+                }
+            ],
+        }
+
+        turn = Turn.from_dict(data)
+
+        assert len(turn.tool_calls) == 1
+        assert isinstance(turn.tool_calls[0], ToolCall)
+        assert turn.tool_calls[0].tool_id == "delegate"
+        assert turn.tool_calls[0].args["to"] == "scene_smith"
+        assert turn.tool_calls[0].success is True
+
+    def test_turn_with_tool_call_requests_in_messages(self):
+        """Test messages with tool_calls (assistant requesting tools)."""
+        messages = [
+            LLMMessage(role="user", content="Create a chapter"),
+            LLMMessage(
+                role="assistant",
+                content="I'll create that for you.",
+                tool_calls=[
+                    ToolCallRequest(
+                        id="call_1",
+                        name="save_artifact",
+                        arguments={"artifact_type": "chapter"},
+                    )
+                ],
+            ),
+            LLMMessage(
+                role="tool",
+                content='{"success": true}',
+                tool_call_id="call_1",
+                name="save_artifact",
+            ),
+        ]
+        turn = Turn(
+            turn_number=1,
+            agent_id="scene_smith",
+            session_id="sess_1",
+            messages=messages,
+        )
+
+        data = turn.to_dict()
+
+        # Verify assistant message has tool_calls
+        assistant_msg = data["messages"][1]
+        assert assistant_msg["tool_calls"] is not None
+        assert len(assistant_msg["tool_calls"]) == 1
+        assert assistant_msg["tool_calls"][0]["name"] == "save_artifact"
+
+        # Verify tool result message
+        tool_msg = data["messages"][2]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_1"
+
+        # Round-trip
+        turn2 = Turn.from_dict(data)
+        assert len(turn2.messages) == 3
+        assert turn2.messages[1].tool_calls is not None
+        assert turn2.messages[2].tool_call_id == "call_1"
+
+
+class TestHistoryReconstruction:
+    """Test that get_history() returns full message traces."""
+
+    def test_get_history_with_tool_interactions(self):
+        """Test get_history() includes tool interactions from messages."""
+
+        class MockProject:
+            """Minimal mock for project."""
+
+            class MockInfo:
+                id = "test_project"
+
+            info = MockInfo()
+
+            def _get_connection(self):
+                return None
+
+        # Create session without actual DB
+        session = Session(
+            id="sess_1",
+            project_id="test_project",
+            entry_agent="showrunner",
+            _project=None,
+        )
+
+        # Create a turn with full message trace
+        messages = [
+            LLMMessage(role="user", content="Write a chapter"),
+            LLMMessage(
+                role="assistant",
+                content="I'll delegate this.",
+                tool_calls=[
+                    ToolCallRequest(
+                        id="call_1",
+                        name="delegate",
+                        arguments={"to": "scene_smith"},
+                    )
+                ],
+            ),
+            LLMMessage(
+                role="tool",
+                content='{"delegation_id": "del_123"}',
+                tool_call_id="call_1",
+                name="delegate",
+            ),
+            LLMMessage(
+                role="assistant",
+                content="I've delegated to Scene Smith.",
+            ),
+        ]
+
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="sess_1",
+            input="Write a chapter",
+            output="I've delegated to Scene Smith.",
+            status=TurnStatus.COMPLETED,
+            messages=messages,
+        )
+        session.turns.append(turn)
+
+        history = session.get_history()
+
+        # Should have 4 entries (excluding system)
+        assert len(history) == 4
+
+        # Check user message
+        assert history[0]["role"] == "user"
+        assert history[0]["content"] == "Write a chapter"
+
+        # Check assistant message with tool_calls
+        assert history[1]["role"] == "assistant"
+        assert "tool_calls" in history[1]
+        assert len(history[1]["tool_calls"]) == 1
+        assert history[1]["tool_calls"][0]["name"] == "delegate"
+
+        # Check tool result
+        assert history[2]["role"] == "tool"
+        assert history[2]["tool_call_id"] == "call_1"
+
+        # Check final assistant message
+        assert history[3]["role"] == "assistant"
+        assert "delegated" in history[3]["content"]
+
+    def test_get_history_excludes_system_prompts(self):
+        """Test that system prompts are excluded from history."""
+        session = Session(
+            id="sess_1",
+            project_id="test_project",
+            entry_agent="showrunner",
+            _project=None,
+        )
+
+        messages = [
+            LLMMessage(role="system", content="You are the Showrunner..."),
+            LLMMessage(role="user", content="Hello"),
+            LLMMessage(role="assistant", content="Hi"),
+        ]
+
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="sess_1",
+            status=TurnStatus.COMPLETED,
+            messages=messages,
+        )
+        session.turns.append(turn)
+
+        history = session.get_history()
+
+        # System message should be excluded
+        assert len(history) == 2
+        assert all(h["role"] != "system" for h in history)
+
+    def test_get_history_fallback_for_legacy_data(self):
+        """Test fallback for turns without stored messages."""
+        session = Session(
+            id="sess_1",
+            project_id="test_project",
+            entry_agent="showrunner",
+            _project=None,
+        )
+
+        # Legacy turn with no messages stored
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="sess_1",
+            input="Hello",
+            output="Hi there",
+            status=TurnStatus.COMPLETED,
+            messages=[],  # No messages stored
+        )
+        session.turns.append(turn)
+
+        history = session.get_history()
+
+        # Should fall back to input/output
+        assert len(history) == 2
+        assert history[0]["role"] == "user"
+        assert history[0]["content"] == "Hello"
+        assert history[1]["role"] == "assistant"
+        assert history[1]["content"] == "Hi there"
+
+
+class TestToolCallSerialization:
+    """Test ToolCall serialization for storage."""
+
+    def test_toolcall_to_dict(self):
+        """Test ToolCall.to_dict() serializes all fields."""
+        tc = ToolCall(
+            tool_id="save_artifact",
+            args={"artifact_type": "chapter", "content": "Once upon a time..."},
+            result={"success": True, "artifact_id": "art_123"},
+            success=True,
+            error=None,
+            execution_time_ms=250.5,
+        )
+
+        data = tc.to_dict()
+
+        assert data["tool_id"] == "save_artifact"
+        assert data["args"]["artifact_type"] == "chapter"
+        assert data["result"]["artifact_id"] == "art_123"
+        assert data["success"] is True
+        assert data["error"] is None
+        assert data["execution_time_ms"] == 250.5
+
+    def test_toolcall_from_dict(self):
+        """Test ToolCall.from_dict() deserializes correctly."""
+        data = {
+            "tool_id": "delegate",
+            "args": {"to": "plotwright", "task": "outline story"},
+            "result": {"delegation_id": "del_456"},
+            "success": True,
+            "error": None,
+            "execution_time_ms": 100.0,
+        }
+
+        tc = ToolCall.from_dict(data)
+
+        assert tc.tool_id == "delegate"
+        assert tc.args["to"] == "plotwright"
+        assert tc.result["delegation_id"] == "del_456"
+        assert tc.success is True
+
+    def test_toolcall_with_error(self):
+        """Test ToolCall with error serializes correctly."""
+        tc = ToolCall(
+            tool_id="validate_artifact",
+            args={"artifact_id": "art_bad"},
+            result=None,
+            success=False,
+            error="Artifact not found",
+            execution_time_ms=10.0,
+        )
+
+        data = tc.to_dict()
+        tc2 = ToolCall.from_dict(data)
+
+        assert tc2.success is False
+        assert tc2.error == "Artifact not found"
+        assert tc2.result is None
+
+
+class TestLLMMessageSerialization:
+    """Test LLMMessage serialization with tool_calls."""
+
+    def test_message_with_tool_calls_roundtrip(self):
+        """Test LLMMessage with tool_calls serializes/deserializes."""
+        msg = LLMMessage(
+            role="assistant",
+            content="Let me check that.",
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_abc",
+                    name="consult_knowledge",
+                    arguments={"query": "world history"},
+                ),
+                ToolCallRequest(
+                    id="call_def",
+                    name="consult_schema",
+                    arguments={"artifact_type": "chapter"},
+                ),
+            ],
+        )
+
+        data = msg.to_dict()
+        msg2 = LLMMessage.from_dict(data)
+
+        assert msg2.tool_calls is not None
+        assert len(msg2.tool_calls) == 2
+        assert msg2.tool_calls[0].id == "call_abc"
+        assert msg2.tool_calls[0].name == "consult_knowledge"
+        assert msg2.tool_calls[1].id == "call_def"
+
+    def test_tool_result_message_roundtrip(self):
+        """Test tool result message serializes correctly."""
+        msg = LLMMessage(
+            role="tool",
+            content='{"lore": "The kingdom was founded in 1234..."}',
+            tool_call_id="call_abc",
+            name="consult_knowledge",
+        )
+
+        data = msg.to_dict()
+        msg2 = LLMMessage.from_dict(data)
+
+        assert msg2.role == "tool"
+        assert msg2.tool_call_id == "call_abc"
+        assert msg2.name == "consult_knowledge"
+        assert "kingdom" in msg2.content
+
+
+class TestSessionCompleteTurn:
+    """Test that complete_turn persists messages and tool_calls."""
+
+    def test_complete_turn_stores_messages(self):
+        """Test complete_turn accepts and stores messages."""
+        session = Session(
+            id="sess_1",
+            project_id="test_project",
+            entry_agent="showrunner",
+            _project=None,  # No DB - just verify in-memory storage
+        )
+
+        turn = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="sess_1",
+            input="Hello",
+            status=TurnStatus.STREAMING,
+        )
+        session.turns.append(turn)
+
+        messages = [
+            LLMMessage(role="user", content="Hello"),
+            LLMMessage(role="assistant", content="Hi there!"),
+        ]
+        tool_calls = [
+            ToolCall(
+                tool_id="test_tool",
+                args={},
+                result={"ok": True},
+                success=True,
+            )
+        ]
+
+        session.complete_turn(
+            turn,
+            output="Hi there!",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            messages=messages,
+            tool_calls=tool_calls,
+        )
+
+        # Verify stored on turn
+        assert len(turn.messages) == 2
+        assert len(turn.tool_calls) == 1
+        assert turn.messages[0].role == "user"
+        assert turn.tool_calls[0].tool_id == "test_tool"
+        assert turn.status == TurnStatus.COMPLETED
+
+
+class TestMultiTurnHistory:
+    """Test history reconstruction across multiple turns."""
+
+    def test_multi_turn_history_preserves_tool_context(self):
+        """Test that multi-turn history includes all tool interactions."""
+        session = Session(
+            id="sess_1",
+            project_id="test_project",
+            entry_agent="showrunner",
+            _project=None,
+        )
+
+        # Turn 1: User asks, agent delegates
+        turn1_messages = [
+            LLMMessage(role="user", content="Write chapter 1"),
+            LLMMessage(
+                role="assistant",
+                content="Delegating...",
+                tool_calls=[
+                    ToolCallRequest(id="t1", name="delegate", arguments={"to": "scene_smith"})
+                ],
+            ),
+            LLMMessage(role="tool", content='{"id":"d1"}', tool_call_id="t1", name="delegate"),
+            LLMMessage(role="assistant", content="Done."),
+        ]
+        turn1 = Turn(
+            turn_number=1,
+            agent_id="showrunner",
+            session_id="sess_1",
+            status=TurnStatus.COMPLETED,
+            messages=turn1_messages,
+        )
+        session.turns.append(turn1)
+
+        # Turn 2: User asks for status
+        turn2_messages = [
+            LLMMessage(role="user", content="What's the status?"),
+            LLMMessage(role="assistant", content="Chapter 1 is complete."),
+        ]
+        turn2 = Turn(
+            turn_number=2,
+            agent_id="showrunner",
+            session_id="sess_1",
+            status=TurnStatus.COMPLETED,
+            messages=turn2_messages,
+        )
+        session.turns.append(turn2)
+
+        history = session.get_history()
+
+        # Total: 4 from turn1 + 2 from turn2 = 6
+        assert len(history) == 6
+
+        # Verify turn 1 tool interaction is preserved
+        assert history[1]["tool_calls"] is not None
+        assert history[2]["role"] == "tool"
+        assert history[2]["tool_call_id"] == "t1"
+
+        # Verify turn 2 follows correctly
+        assert history[4]["content"] == "What's the status?"
+        assert history[5]["content"] == "Chapter 1 is complete."

--- a/tests/runtime/session/test_agent_memory.py
+++ b/tests/runtime/session/test_agent_memory.py
@@ -174,18 +174,6 @@ class TestHistoryReconstruction:
 
     def test_get_history_with_tool_interactions(self):
         """Test get_history() includes tool interactions from messages."""
-
-        class MockProject:
-            """Minimal mock for project."""
-
-            class MockInfo:
-                id = "test_project"
-
-            info = MockInfo()
-
-            def _get_connection(self):
-                return None
-
         # Create session without actual DB
         session = Session(
             id="sess_1",


### PR DESCRIPTION
## Summary

Fixes the critical agent memory issue where agents had no memory of tool interactions across turns (#224).

**Key changes:**
- Extended Turn dataclass with `messages` (list[LLMMessage]) and `tool_calls` (list[ToolCall]) fields
- Updated SQLite schema with JSON columns for persistence
- `activate()` and `activate_streaming()` now capture and pass messages to `complete_turn()`
- `get_history()` returns full message trace including tool interactions
- Wired ContextSecretary and MailboxSecretary for summarization when context fills up

## Test plan

- [x] Added 15 new unit tests in `tests/runtime/session/test_agent_memory.py`
- [x] All 816 tests pass
- [x] Pre-commit hooks pass (mypy, ruff)

Closes #224
Part of Epic #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)