### PR TITLE
fix(tools): improve save_artifact validation feedback structure

### DIFF
--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -432,35 +432,130 @@ class SaveArtifactTool(BaseTool):
         """
         Build actionable feedback for LLM self-correction.
 
-        Format follows the validate-with-feedback pattern from meta/docs:
-        - success: bool
-        - error_count: number of errors
-        - errors: detailed error entries with field/issue/provided/expected
-        - required_fields: list of {name, type, description} for required fields
-        - optional_fields: list of {name, type, description} for optional fields
-        - hint: guidance on how to fix
+        Structure separates three concerns (following PR #220 pattern):
+        - action_outcome: what happened to the save attempt (saved/rejected)
+        - rejection_reason: why it was rejected (validation_failed, etc.)
+        - recovery_action: directive for next step
         """
-        feedback: dict[str, Any] = {
-            "success": valid,
-            "error_count": len(errors) if errors else 0,
-            "errors": errors or [],
-            "warnings": warnings or [],
-        }
+        if valid:
+            return {
+                "action_outcome": "saved",
+                "error_count": 0,
+                "errors": [],
+                "warnings": warnings or [],
+            }
 
-        if schema_info:
-            feedback["required_fields"] = schema_info.get("required_fields", [])
-            feedback["optional_fields"] = schema_info.get("optional_fields", [])
-            if "provided_fields" in schema_info:
-                feedback["provided_fields"] = schema_info["provided_fields"]
+        # Extract field corrections and missing fields from errors
+        field_corrections: dict[str, str] = {}
+        missing_required: list[str] = []
 
-        if not valid and artifact_type_id:
-            feedback["hint"] = (
-                f"Review the errors above. Check field names and types against the "
-                f"'{artifact_type_id}' artifact type schema. Use consult_schema('{artifact_type_id}') "
-                f"for detailed field definitions."
+        if schema_info and errors:
+            required_names = {f["name"] for f in schema_info.get("required_fields", [])}
+            provided_names = set(schema_info.get("provided_fields", []))
+
+            # Find missing required fields
+            for err in errors or []:
+                if "Required field" in err.get("issue", "") and err.get("field"):
+                    missing_required.append(err["field"])
+
+            # Find field corrections via fuzzy matching
+            field_corrections = self._find_field_corrections(
+                provided_names, required_names, schema_info.get("required_fields", [])
             )
 
+        # Count corrections vs truly missing
+        correctable = len(field_corrections)
+        truly_missing = len(missing_required) - correctable
+
+        # Build recovery action message
+        parts = []
+        if correctable > 0:
+            parts.append(f"rename {correctable} field(s)")
+        if truly_missing > 0:
+            parts.append(f"add {truly_missing} missing field(s)")
+
+        action_summary = " and ".join(parts) if parts else "fix errors"
+        recovery_action = (
+            f"{action_summary.capitalize()}, then retry. "
+            f"Call consult_schema('{artifact_type_id}') for field definitions."
+        )
+
+        feedback: dict[str, Any] = {
+            "action_outcome": "rejected",
+            "rejection_reason": "validation_failed",
+            "recovery_action": recovery_action,
+        }
+
+        # Add field corrections if any detected
+        if field_corrections:
+            feedback["field_corrections"] = field_corrections
+
+        # Add missing required (excluding those with corrections)
+        corrected_fields = set(field_corrections.values())
+        truly_missing_fields = [f for f in missing_required if f not in corrected_fields]
+        if truly_missing_fields:
+            feedback["missing_required"] = truly_missing_fields
+
+        # Add counts and detailed errors at the end
+        feedback["error_count"] = len(errors) if errors else 0
+        feedback["errors"] = errors or []
+        feedback["warnings"] = warnings or []
+
         return feedback
+
+    def _find_field_corrections(
+        self,
+        provided: set[str],
+        required: set[str],
+        required_fields: list[dict[str, Any]],
+    ) -> dict[str, str]:
+        """
+        Find likely field name corrections via fuzzy matching.
+
+        Detects cases like:
+        - section_title → title (suffix match)
+        - content → prose (common synonyms)
+        """
+        corrections: dict[str, str] = {}
+
+        # Build lookup for required field names
+        required_lookup = {f["name"]: f for f in required_fields}
+
+        for provided_name in provided:
+            if provided_name in required:
+                continue  # Exact match, no correction needed
+
+            # Check for suffix/prefix matches
+            for req_name in required:
+                if req_name in required_lookup:
+                    # Check if provided ends with required (e.g., section_title → title)
+                    if provided_name.endswith(f"_{req_name}") or provided_name.endswith(req_name):
+                        corrections[provided_name] = f"rename to '{req_name}'"
+                        break
+                    # Check if provided starts with required (e.g., title_text → title)
+                    if provided_name.startswith(f"{req_name}_") or provided_name.startswith(
+                        req_name
+                    ):
+                        corrections[provided_name] = f"rename to '{req_name}'"
+                        break
+
+        # Common semantic mappings
+        semantic_mappings = {
+            "content": ["prose", "text", "body"],
+            "text": ["prose", "content", "body"],
+            "body": ["prose", "content", "text"],
+        }
+
+        for provided_name in provided:
+            if provided_name in corrections:
+                continue
+            if provided_name in semantic_mappings:
+                for candidate in semantic_mappings[provided_name]:
+                    if candidate in required and candidate not in corrections.values():
+                        corrections[provided_name] = f"rename to '{candidate}'"
+                        break
+
+        return corrections
 
     def _error_entry(
         self,

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -446,7 +446,8 @@ class SaveArtifactTool(BaseTool):
             }
 
         # Extract field corrections and missing fields from errors
-        field_corrections: dict[str, str] = {}
+        # field_correction_map: {provided_name: target_required_name}
+        field_correction_map: dict[str, str] = {}
         missing_required: list[str] = []
 
         if schema_info and errors:
@@ -454,25 +455,28 @@ class SaveArtifactTool(BaseTool):
             provided_names = set(schema_info.get("provided_fields", []))
 
             # Find missing required fields
-            for err in errors or []:
+            for err in errors:
                 if "Required field" in err.get("issue", "") and err.get("field"):
                     missing_required.append(err["field"])
 
             # Find field corrections via fuzzy matching
-            field_corrections = self._find_field_corrections(
-                provided_names, required_names, schema_info.get("required_fields", [])
-            )
+            # Returns {provided_name: target_name} e.g. {"section_title": "title"}
+            field_correction_map = self._find_field_corrections(provided_names, required_names)
+
+        # Determine truly missing fields (those without corrections)
+        corrected_target_fields = set(field_correction_map.values())
+        truly_missing_fields = [f for f in missing_required if f not in corrected_target_fields]
 
         # Count corrections vs truly missing
-        correctable = len(field_corrections)
-        truly_missing = len(missing_required) - correctable
+        correctable = len(field_correction_map)
+        truly_missing_count = len(truly_missing_fields)
 
         # Build recovery action message
         parts = []
         if correctable > 0:
             parts.append(f"rename {correctable} field(s)")
-        if truly_missing > 0:
-            parts.append(f"add {truly_missing} missing field(s)")
+        if truly_missing_count > 0:
+            parts.append(f"add {truly_missing_count} missing field(s)")
 
         action_summary = " and ".join(parts) if parts else "fix errors"
         recovery_action = (
@@ -486,13 +490,13 @@ class SaveArtifactTool(BaseTool):
             "recovery_action": recovery_action,
         }
 
-        # Add field corrections if any detected
-        if field_corrections:
-            feedback["field_corrections"] = field_corrections
+        # Add field corrections with human-readable format
+        if field_correction_map:
+            feedback["field_corrections"] = {
+                k: f"rename to '{v}'" for k, v in field_correction_map.items()
+            }
 
-        # Add missing required (excluding those with corrections)
-        corrected_fields = set(field_corrections.values())
-        truly_missing_fields = [f for f in missing_required if f not in corrected_fields]
+        # Add truly missing required fields
         if truly_missing_fields:
             feedback["missing_required"] = truly_missing_fields
 
@@ -507,52 +511,57 @@ class SaveArtifactTool(BaseTool):
         self,
         provided: set[str],
         required: set[str],
-        required_fields: list[dict[str, Any]],
     ) -> dict[str, str]:
         """
         Find likely field name corrections via fuzzy matching.
 
+        Returns a mapping of provided field name to target required field name.
+        Example: {"section_title": "title", "content": "prose"}
+
         Detects cases like:
-        - section_title → title (suffix match)
+        - section_title → title (suffix match with underscore separator)
         - content → prose (common synonyms)
         """
         corrections: dict[str, str] = {}
-
-        # Build lookup for required field names
-        required_lookup = {f["name"]: f for f in required_fields}
+        matched_targets: set[str] = set()  # Track which required fields are already matched
 
         for provided_name in provided:
             if provided_name in required:
                 continue  # Exact match, no correction needed
 
-            # Check for suffix/prefix matches
+            # Check for suffix/prefix matches (require underscore separator to avoid false positives)
             for req_name in required:
-                if req_name in required_lookup:
-                    # Check if provided ends with required (e.g., section_title → title)
-                    if provided_name.endswith(f"_{req_name}") or provided_name.endswith(req_name):
-                        corrections[provided_name] = f"rename to '{req_name}'"
-                        break
-                    # Check if provided starts with required (e.g., title_text → title)
-                    if provided_name.startswith(f"{req_name}_") or provided_name.startswith(
-                        req_name
-                    ):
-                        corrections[provided_name] = f"rename to '{req_name}'"
-                        break
+                if req_name in matched_targets:
+                    continue  # Already matched to another provided field
 
-        # Common semantic mappings
-        semantic_mappings = {
-            "content": ["prose", "text", "body"],
-            "text": ["prose", "content", "body"],
-            "body": ["prose", "content", "text"],
-        }
+                # Check if provided ends with required (e.g., section_title → title)
+                if provided_name.endswith(f"_{req_name}"):
+                    corrections[provided_name] = req_name
+                    matched_targets.add(req_name)
+                    break
+                # Check if provided starts with required (e.g., title_text → title)
+                if provided_name.startswith(f"{req_name}_"):
+                    corrections[provided_name] = req_name
+                    matched_targets.add(req_name)
+                    break
+
+        # Common semantic mappings (generate from synonym groups)
+        synonym_groups = [
+            {"content", "prose", "text", "body"},
+        ]
+        semantic_mappings: dict[str, list[str]] = {}
+        for group in synonym_groups:
+            for word in group:
+                semantic_mappings[word] = sorted(group - {word})
 
         for provided_name in provided:
             if provided_name in corrections:
                 continue
             if provided_name in semantic_mappings:
                 for candidate in semantic_mappings[provided_name]:
-                    if candidate in required and candidate not in corrections.values():
-                        corrections[provided_name] = f"rename to '{candidate}'"
+                    if candidate in required and candidate not in matched_targets:
+                        corrections[provided_name] = candidate
+                        matched_targets.add(candidate)
                         break
 
         return corrections

--- a/tests/runtime/tools/test_save_artifact.py
+++ b/tests/runtime/tools/test_save_artifact.py
@@ -133,7 +133,7 @@ class TestSaveArtifactTool:
         assert "artifact" in result.data
         assert "artifact_id" in result.data
         assert result.data["store"] == "workspace"
-        assert result.data["feedback"]["success"] is True
+        assert result.data["feedback"]["action_outcome"] == "saved"
 
         # Verify artifact was saved
         artifact_id = result.data["artifact_id"]
@@ -166,7 +166,7 @@ class TestSaveArtifactTool:
 
         assert result.success is True
         assert result.data["artifact_id"] == "section_001"
-        assert result.data["feedback"]["success"] is True
+        assert result.data["feedback"]["action_outcome"] == "saved"
 
         saved = project.get_artifact("section_001")
         assert saved is not None
@@ -193,7 +193,7 @@ class TestSaveArtifactTool:
 
         assert result.success is False
         assert "Unknown artifact type" in result.error
-        assert result.data["feedback"]["success"] is False
+        assert result.data["feedback"]["action_outcome"] == "rejected"
 
     @pytest.mark.asyncio
     async def test_save_artifact_validation_failure(self, project: Project):
@@ -218,7 +218,7 @@ class TestSaveArtifactTool:
 
         assert result.success is False
         assert "feedback" in result.data
-        assert result.data["feedback"]["success"] is False
+        assert result.data["feedback"]["action_outcome"] == "rejected"
         assert len(result.data["validation_errors"]) > 0
 
     @pytest.mark.asyncio
@@ -248,34 +248,84 @@ class TestSaveArtifactTool:
         assert result.success is False
         feedback = result.data["feedback"]
 
-        # Verify actionable feedback format
-        assert feedback["success"] is False
+        # Verify actionable feedback format (PR #220 pattern)
+        assert feedback["action_outcome"] == "rejected"
+        assert feedback["rejection_reason"] == "validation_failed"
+        assert "recovery_action" in feedback
         assert feedback["error_count"] >= 1
         assert "errors" in feedback
-        assert "required_fields" in feedback
-        assert "optional_fields" in feedback
-        assert "provided_fields" in feedback
-        assert "hint" in feedback
 
-        # Verify required/optional field info
-        required_names = [f["name"] for f in feedback["required_fields"]]
-        assert "title" in required_names
+        # Verify recovery action references consult_schema
+        assert "consult_schema" in feedback["recovery_action"]
+        assert "section" in feedback["recovery_action"]
 
-        optional_names = [f["name"] for f in feedback["optional_fields"]]
-        assert "body" in optional_names
-
-        # Verify provided fields tracked
-        assert "wrong_field" in feedback["provided_fields"]
-
-        # Verify hint references artifact type
-        assert "section" in feedback["hint"]
-        assert "consult_schema" in feedback["hint"]
+        # Verify missing required fields are listed
+        assert "missing_required" in feedback
+        assert "title" in feedback["missing_required"]
 
         # Verify errors have actionable structure
         for error in feedback["errors"]:
             assert "field" in error
             assert "issue" in error
             assert "provided" in error  # Shows what was provided or "(missing)"
+
+    @pytest.mark.asyncio
+    async def test_save_artifact_field_corrections(self, project: Project):
+        """Verify feedback includes field name corrections (Scene Smith scenario)."""
+        # Create artifact type with title/prose fields (like real section)
+        artifact_type = MagicMock()
+        artifact_type.id = "section"
+        artifact_type.name = "Section"
+        artifact_type.default_store = None
+
+        field_title = MagicMock()
+        field_title.name = "title"
+        field_title.type = FieldType.STRING
+        field_title.required = True
+        field_title.description = "Human-readable section title"
+
+        field_prose = MagicMock()
+        field_prose.name = "prose"
+        field_prose.type = FieldType.TEXT
+        field_prose.required = True
+        field_prose.description = "Narrative paragraphs"
+
+        artifact_type.fields = [field_title, field_prose]
+        artifact_type.lifecycle = None
+
+        studio = MagicMock()
+        studio.artifact_types = [artifact_type]
+
+        definition = make_mock_definition("save_artifact")
+        context = ToolContext(
+            studio=studio,
+            project=project,
+        )
+        tool = SaveArtifactTool(definition, context)
+
+        # Simulate Scene Smith's mistake: section_title instead of title, content instead of prose
+        result = await tool.execute(
+            {
+                "artifact_type": "section",
+                "data": {
+                    "section_title": "The Mysterious Arrival",
+                    "content": "The evening mist clung to the cobblestones...",
+                },
+            }
+        )
+
+        assert result.success is False
+        feedback = result.data["feedback"]
+
+        # Verify field corrections are detected
+        assert "field_corrections" in feedback
+        assert "section_title" in feedback["field_corrections"]
+        assert "title" in feedback["field_corrections"]["section_title"]
+        assert "content" in feedback["field_corrections"]
+        assert "prose" in feedback["field_corrections"]["content"]
+
+        # Recovery action should mention the corrections
+        assert "rename" in feedback["recovery_action"].lower()
 
     @pytest.mark.asyncio
     async def test_save_artifact_wrong_store(self, project: Project):
@@ -304,7 +354,7 @@ class TestSaveArtifactTool:
 
         assert result.success is False
         assert "does not accept" in result.error
-        assert result.data["feedback"]["success"] is False
+        assert result.data["feedback"]["action_outcome"] == "rejected"
 
     @pytest.mark.asyncio
     async def test_save_artifact_exclusive_writer_warning(self, project: Project):
@@ -387,7 +437,7 @@ class TestSaveArtifactTool:
 
         assert result.success is True
         assert result.data["artifact_id"] == "section_custom1234"
-        assert result.data["feedback"]["success"] is True
+        assert result.data["feedback"]["action_outcome"] == "saved"
 
 
 class TestUpdateArtifactTool:

--- a/tests/runtime/tools/test_save_artifact.py
+++ b/tests/runtime/tools/test_save_artifact.py
@@ -324,6 +324,9 @@ class TestSaveArtifactTool:
         assert "content" in feedback["field_corrections"]
         assert "prose" in feedback["field_corrections"]["content"]
 
+        # Since all missing fields have corrections, missing_required should be empty
+        assert "missing_required" not in feedback or not feedback["missing_required"]
+
         # Recovery action should mention the corrections
         assert "rename" in feedback["recovery_action"].lower()
 


### PR DESCRIPTION
## Summary

Refactors validation feedback to be more actionable, following the PR #220 pattern of separating concerns:

- **`action_outcome`**: "rejected" | "saved" — what happened to the save attempt
- **`rejection_reason`**: "validation_failed" — why it was rejected  
- **`recovery_action`**: directive at top, not buried "hint"
- **`field_corrections`**: explicit mapping via fuzzy matching
- **`missing_required`**: only truly missing fields

### Before (vague, buried action)
```json
{
  "success": false,
  "error_count": 4,
  "errors": [...],
  "hint": "Review the errors above..."
}
```

### After (action-first, semantic)
```json
{
  "action_outcome": "rejected",
  "rejection_reason": "validation_failed",
  "recovery_action": "Rename 2 field(s) and add 2 missing field(s), then retry.",
  "field_corrections": {
    "section_title": "rename to 'title'",
    "content": "rename to 'prose'"
  },
  "missing_required": ["anchor", "choices"],
  "error_count": 4,
  "errors": [...]
}
```

### Fuzzy matching

Detects common field name mistakes:
- **Suffix matches**: `section_title` → `title`
- **Semantic synonyms**: `content` → `prose`

This addresses Scene Smith's failure to recover from validation errors by providing clearer, action-first feedback.

## Test plan

- [x] All 817 tests pass
- [x] New test for field corrections scenario (Scene Smith case)
- [ ] Manual test: run workflow and verify feedback is actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)