### PR TITLE
feat(meta): Add lifecycle_policy and relationship schemas (#252)

### DIFF
--- a/meta/docs/artifact-conventions.md
+++ b/meta/docs/artifact-conventions.md
@@ -109,3 +109,13 @@ These conventions align with the semantic axes defined in `semantic-conventions.
 - Lifecycle states describe **artifact state**, not action outcomes
 - The `cold` state corresponds to the `lifecycle_state: cold` defined in `_definitions.schema.json`
 - Transitions are requested via `request_lifecycle_transition` and return `transition_result` (committed/rejected/deferred)
+
+## Runtime Enforcement
+
+The `lifecycle_policy` block in artifact-type.schema.json defines automatic enforcement behavior:
+
+- **Edit demotion**: Editing non-draft artifacts can auto-demote them (see `edit_policy`)
+- **Store migration**: Transitions can trigger automatic store changes (see `target_store`)
+- **Relationship cascades**: Parent changes can cascade to children (see `relationship.schema.json`)
+
+See [lifecycle-policy.md](lifecycle-policy.md) for detailed documentation on runtime enforcement.

--- a/meta/docs/lifecycle-policy.md
+++ b/meta/docs/lifecycle-policy.md
@@ -99,7 +99,17 @@ Key points:
 
 - Relationships define cascade behavior (parent edit → child impact)
 - The `impact_policy.on_parent_edit` can trigger child demotion
-- Cascade demotion uses the child's `lifecycle_policy.demote_target_state` and `demote_target_store`
+- Cascade demotion uses the child's `lifecycle_policy.demote_target_state`
+
+### Store Precedence for Cascade Demotion
+
+When a child artifact is demoted via cascade, the target store is determined by this precedence order:
+
+1. `relationship.impact_policy.demote_target_store` (if set on the relationship)
+2. `child_artifact_type.lifecycle_policy.demote_target_store` (if set on the child's type)
+3. `child_artifact_type.default_store` (fallback)
+
+This allows relationships to override the child's default demotion behavior when needed.
 
 ### Example Flow
 
@@ -116,7 +126,8 @@ Key points:
 When an artifact edit request arrives:
 
 1. **Check lifecycle_policy.edit_policy**
-   - If `disallow` and current state in trigger states → reject
+   - Determine trigger states: use `demote_trigger_states` if specified, otherwise all states except `initial_state`
+   - If `disallow` and current state in trigger states → reject edit
    - If `demote` and current state in trigger states → flag for demotion
 
 2. **Apply content changes**

--- a/meta/docs/lifecycle-policy.md
+++ b/meta/docs/lifecycle-policy.md
@@ -1,0 +1,167 @@
+# Lifecycle Policy
+
+> **Purpose**: Document the declarative lifecycle policy system for runtime enforcement of edit behavior and artifact relationships.
+
+## Overview
+
+The lifecycle policy system separates two concerns:
+
+1. **Lifecycle** (`lifecycle` in artifact-type.schema.json): Defines the state machine - states, transitions, and who can make them
+2. **Lifecycle Policy** (`lifecycle_policy` in artifact-type.schema.json): Defines runtime enforcement behavior - what happens automatically when artifacts are edited
+
+This separation reduces cognitive load on LLM agents. Agents focus on content creation; the runtime enforces invariants.
+
+## Edit Policies
+
+The `edit_policy` field controls what happens when an artifact in a non-initial state is edited:
+
+| Policy | Behavior |
+|--------|----------|
+| `allow` | Edit proceeds normally (default). No automatic state changes. |
+| `demote` | Edit succeeds, but artifact is automatically transitioned to `demote_target_state` and optionally migrated to `demote_target_store`. |
+| `disallow` | Edit is rejected with an error. Use for truly immutable terminal states. |
+
+### Example: Section with Demote Policy
+
+```json
+{
+  "id": "section",
+  "lifecycle": {
+    "states": [
+      { "id": "draft", "description": "LLM agents actively working" },
+      { "id": "review", "description": "Studio work complete" },
+      { "id": "cold", "description": "Canonized", "terminal": true }
+    ],
+    "initial_state": "draft",
+    "transitions": [...]
+  },
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_target_state": "draft",
+    "demote_target_store": "workspace"
+  }
+}
+```
+
+With this policy:
+
+- Editing a `draft` section: Normal (no demotion needed)
+- Editing a `review` section: Succeeds, but section demoted to `draft` and moved to `workspace`
+- Editing a `cold` section: Succeeds, but section demoted to `draft` and moved to `workspace`
+
+### Demote Trigger States
+
+By default, demotion triggers for all states except `initial_state`. Use `demote_trigger_states` to customize:
+
+```json
+{
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_trigger_states": ["cold"],
+    "demote_target_state": "review"
+  }
+}
+```
+
+This demotes only when editing `cold` artifacts, and demotes to `review` instead of `draft`.
+
+## Store Migration on Transitions
+
+The `target_store` field on transitions generalizes the cold-store migration pattern. Any transition can trigger store migration:
+
+```json
+{
+  "transitions": [
+    {
+      "from": "review",
+      "to": "cold",
+      "allowed_agents": ["gatekeeper"],
+      "requires_validation": ["integrity", "style"],
+      "target_store": "manuscript"
+    }
+  ]
+}
+```
+
+When this transition executes:
+
+1. `_lifecycle_state` changes from `review` to `cold`
+2. `_store` changes to `manuscript`
+3. Both updates are atomic
+
+This replaces the previous hardcoded cold-migration logic in the runtime.
+
+## Artifact Relationships
+
+Relationships between artifact types are defined separately in `relationship.schema.json`. See [semantic-conventions.md](semantic-conventions.md) for relationship kinds and impact policies.
+
+Key points:
+
+- Relationships define cascade behavior (parent edit → child impact)
+- The `impact_policy.on_parent_edit` can trigger child demotion
+- Cascade demotion uses the child's `lifecycle_policy.demote_target_state` and `demote_target_store`
+
+### Example Flow
+
+1. User edits a `section_brief` in `ready` state
+2. Runtime applies the brief's `lifecycle_policy`:
+   - If `edit_policy: "demote"`, brief is demoted to `draft`
+3. Runtime checks relationships where `section_brief` is `from_type`
+4. Finds `section_from_brief` relationship with `on_parent_edit: "demote"`
+5. Queries for all `section` artifacts with matching `brief_ref`
+6. Demotes each child section using its own `lifecycle_policy`
+
+## Runtime Enforcement Order
+
+When an artifact edit request arrives:
+
+1. **Check lifecycle_policy.edit_policy**
+   - If `disallow` and current state in trigger states → reject
+   - If `demote` and current state in trigger states → flag for demotion
+
+2. **Apply content changes**
+   - Update artifact data
+
+3. **Apply demotion if flagged**
+   - Set `_lifecycle_state` to `demote_target_state`
+   - Set `_store` to `demote_target_store` (if specified)
+
+4. **Apply relationship cascades**
+   - Find relationships where this artifact's type is `from_type`
+   - For each relationship with `on_parent_edit: "demote"`:
+     - Query child artifacts using `link_field` and `link_resolution`
+     - Demote each child using its `lifecycle_policy`
+
+5. **Return success**
+   - Include demotion/cascade info in response for observability
+
+## Design Rationale
+
+### Why Separate from Lifecycle?
+
+The `lifecycle` block defines what transitions are *possible*. The `lifecycle_policy` block defines what happens *automatically*. Mixing them would conflate:
+
+- State machine definition (declarative, static)
+- Runtime enforcement behavior (imperative, dynamic)
+
+### Why Runtime Enforcement?
+
+LLM agents have limited working memory and can "forget" to manage lifecycle states correctly. By enforcing invariants in the runtime:
+
+- Agents focus on content, not bookkeeping
+- Invariants are guaranteed, not hoped-for
+- Prompts are simpler
+
+### Why Relationships Are Separate?
+
+Relationships define *inter-artifact* behavior. Embedding them in artifact types would:
+
+- Create circular reference problems
+- Make it hard to see all relationships in a studio
+- Couple structure (artifact type) with behavior (cascade policy)
+
+## See Also
+
+- [artifact-conventions.md](artifact-conventions.md) - Lifecycle state naming conventions
+- [semantic-conventions.md](semantic-conventions.md) - Relationship kinds and message types
+- [store-semantics.md](store-semantics.md) - Store types and workflow intent

--- a/meta/docs/semantic-conventions.md
+++ b/meta/docs/semantic-conventions.md
@@ -116,7 +116,7 @@ Defines runtime behavior when parent artifact changes:
 |-------|---------|
 | `none` | No effect on children (default) |
 | `flag_stale` | Set `_stale_parent=true` on children (advisory, no state change) |
-| `demote` | Demote children to their `initial_state` (enforced) |
+| `demote` | Demote children to their `lifecycle_policy.demote_target_state` (enforced) |
 
 **`on_parent_delete`** — What happens to children when parent is deleted:
 

--- a/meta/docs/semantic-conventions.md
+++ b/meta/docs/semantic-conventions.md
@@ -95,6 +95,50 @@ Assessment of data quality or compliance.
 
 **Banned values**: `completing` — use `in_progress` with high percent_complete instead.
 
+### Relationship Kinds (`kind` in relationship.schema.json)
+
+Defines the semantic nature of artifact-to-artifact relationships:
+
+| Value | Meaning | Typical Cascade |
+|-------|---------|-----------------|
+| `derived_from` | Child is implementation of parent (e.g., section from brief) | Parent edit → demote children |
+| `depends_on` | Child requires parent to function (hard dependency) | Parent delete → block or cascade |
+| `supersedes` | Child replaces parent (versioning, retcon) | New version → archive old |
+| `references` | Informational link only | No automatic cascade |
+
+### Impact Policies (`impact_policy` in relationship.schema.json)
+
+Defines runtime behavior when parent artifact changes:
+
+**`on_parent_edit`** — What happens to children when parent is edited:
+
+| Value | Meaning |
+|-------|---------|
+| `none` | No effect on children (default) |
+| `flag_stale` | Set `_stale_parent=true` on children (advisory, no state change) |
+| `demote` | Demote children to their `initial_state` (enforced) |
+
+**`on_parent_delete`** — What happens to children when parent is deleted:
+
+| Value | Meaning |
+|-------|---------|
+| `none` | No effect on children |
+| `orphan` | Clear `link_field` on children (default) |
+| `cascade_delete` | Delete children |
+| `block` | Prevent parent deletion while children exist |
+
+### Edit Policies (`edit_policy` in artifact-type.schema.json)
+
+Defines runtime behavior when artifacts are edited in non-initial states:
+
+| Value | Meaning |
+|-------|---------|
+| `allow` | Edit proceeds normally (default) |
+| `demote` | Edit succeeds, artifact auto-demoted to `demote_target_state` |
+| `disallow` | Edit rejected with error |
+
+See [lifecycle-policy.md](lifecycle-policy.md) for detailed documentation.
+
 ## Content Field Naming
 
 Different text fields serve different purposes. Use consistent names:

--- a/meta/schemas/core/artifact-type.schema.json
+++ b/meta/schemas/core/artifact-type.schema.json
@@ -171,7 +171,7 @@
           "items": {
             "$ref": "_definitions.schema.json#/$defs/id"
           },
-          "description": "States that trigger demotion when edit_policy='demote'. Defaults to all states except initial_state. Explicitly list states to customize (e.g., ['review', 'cold'] but not 'approved')."
+          "description": "States that trigger the edit_policy when set to 'demote' or 'disallow'. Defaults to all states except initial_state. Explicitly list states to customize (e.g., ['review', 'cold'] but not 'approved')."
         },
         "demote_target_state": {
           "$ref": "_definitions.schema.json#/$defs/id",

--- a/meta/schemas/core/artifact-type.schema.json
+++ b/meta/schemas/core/artifact-type.schema.json
@@ -58,7 +58,12 @@
 
     "lifecycle": {
       "$ref": "#/$defs/lifecycle",
-      "description": "Optional lifecycle states for this artifact type"
+      "description": "Optional lifecycle states and transitions for this artifact type"
+    },
+
+    "lifecycle_policy": {
+      "$ref": "#/$defs/lifecycle_policy",
+      "description": "Declarative edit/mutation policies for runtime enforcement. Defines what happens when artifacts are edited in non-initial states."
     },
 
     "validation": {
@@ -137,11 +142,44 @@
                 "type": "array",
                 "items": { "type": "string" },
                 "description": "IDs of quality criteria that must pass for this transition"
+              },
+              "target_store": {
+                "$ref": "_definitions.schema.json#/$defs/store_ref",
+                "description": "Store to migrate artifact to on this transition. Generalizes cold migration - any transition can trigger store migration. Runtime updates both _lifecycle_state and _store atomically."
               }
             },
             "additionalProperties": false
           },
           "description": "Allowed state transitions"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "lifecycle_policy": {
+      "type": "object",
+      "description": "Declarative policies for runtime enforcement of lifecycle behavior. These policies are enforced automatically by the runtime, reducing cognitive load on agents.",
+      "properties": {
+        "edit_policy": {
+          "type": "string",
+          "enum": ["allow", "demote", "disallow"],
+          "default": "allow",
+          "description": "Runtime behavior when artifact content is edited in non-initial states. 'allow': edit proceeds normally (default). 'demote': edit succeeds but artifact is auto-transitioned to demote_target_state. 'disallow': edit is rejected with error."
+        },
+        "demote_trigger_states": {
+          "type": "array",
+          "items": {
+            "$ref": "_definitions.schema.json#/$defs/id"
+          },
+          "description": "States that trigger demotion when edit_policy='demote'. Defaults to all states except initial_state. Explicitly list states to customize (e.g., ['review', 'cold'] but not 'approved')."
+        },
+        "demote_target_state": {
+          "$ref": "_definitions.schema.json#/$defs/id",
+          "description": "State to transition to when demotion is triggered. Defaults to lifecycle.initial_state (typically 'draft')."
+        },
+        "demote_target_store": {
+          "$ref": "_definitions.schema.json#/$defs/store_ref",
+          "description": "Store to migrate artifact to on demotion. Defaults to artifact type's default_store (typically 'workspace')."
         }
       },
       "additionalProperties": false

--- a/meta/schemas/core/relationship.schema.json
+++ b/meta/schemas/core/relationship.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "relationship.schema.json",
+  "title": "Artifact Relationship",
+  "description": "Defines behavioral relationships between artifact types. Runtime uses these for cascade policies (parent edit → child impact) and navigation helpers (get children/parents). Relationships are directional: from_type is the parent (referenced), to_type is the child (holds the reference).\n\nRELATIONSHIP KINDS:\n- derived_from: Child is implementation of parent (e.g., section derived from section_brief)\n- depends_on: Child requires parent to function (hard dependency)\n- supersedes: Child replaces parent (versioning, retcon)\n- references: Informational link only (no cascade behavior)\n\nLINK RESOLUTION:\n- by_artifact_id: link_field on child contains parent's _id directly\n- by_field_match: link_field on child contains a value that matches match_field on parent",
+
+  "type": "object",
+  "required": ["id", "from_type", "to_type", "kind", "link_field"],
+
+  "properties": {
+    "id": {
+      "$ref": "_definitions.schema.json#/$defs/id",
+      "description": "Unique identifier for this relationship"
+    },
+
+    "name": {
+      "$ref": "_definitions.schema.json#/$defs/name",
+      "description": "Human-readable name for this relationship"
+    },
+
+    "description": {
+      "$ref": "_definitions.schema.json#/$defs/description",
+      "description": "Explanation of what this relationship represents"
+    },
+
+    "from_type": {
+      "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
+      "description": "Parent artifact type (the one being referenced)"
+    },
+
+    "to_type": {
+      "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
+      "description": "Child artifact type (the one holding the reference)"
+    },
+
+    "kind": {
+      "type": "string",
+      "enum": ["derived_from", "depends_on", "supersedes", "references"],
+      "description": "Relationship semantics determining cascade behavior and runtime enforcement"
+    },
+
+    "link_field": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+      "description": "JSON path on child artifact that references parent. Use dot notation for nested fields (e.g., 'brief_ref' or 'source.pack_id'). Runtime uses json_extract with this path for queries."
+    },
+
+    "link_resolution": {
+      "type": "string",
+      "enum": ["by_artifact_id", "by_field_match"],
+      "default": "by_field_match",
+      "description": "How the link resolves to the parent artifact. 'by_artifact_id': link_field contains parent's _id. 'by_field_match': link_field contains a value matching match_field on parent."
+    },
+
+    "match_field": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+      "description": "For link_resolution='by_field_match': field on parent artifact to match against. E.g., if child.brief_ref='SB-001' and parent.brief_id='SB-001', set link_field='brief_ref' and match_field='brief_id'."
+    },
+
+    "impact_policy": {
+      "$ref": "#/$defs/impact_policy",
+      "description": "Defines runtime behavior when parent artifact changes"
+    }
+  },
+
+  "additionalProperties": false,
+
+  "if": {
+    "properties": {
+      "link_resolution": { "const": "by_field_match" }
+    }
+  },
+  "then": {
+    "required": ["match_field"]
+  },
+
+  "$defs": {
+    "impact_policy": {
+      "type": "object",
+      "description": "Defines what happens to child artifacts when parent changes. Runtime enforces these policies automatically.",
+      "properties": {
+        "on_parent_edit": {
+          "type": "string",
+          "enum": ["none", "flag_stale", "demote"],
+          "default": "none",
+          "description": "Action when parent artifact is edited. 'none': no effect on children. 'flag_stale': set _stale_parent=true on children (advisory). 'demote': transition children to their initial_state (enforced)."
+        },
+        "on_parent_delete": {
+          "type": "string",
+          "enum": ["none", "orphan", "cascade_delete", "block"],
+          "default": "orphan",
+          "description": "Action when parent artifact is deleted. 'none': no effect. 'orphan': clear link_field on children. 'cascade_delete': delete children. 'block': prevent parent deletion while children exist."
+        },
+        "demote_target_store": {
+          "$ref": "_definitions.schema.json#/$defs/store_ref",
+          "description": "For on_parent_edit='demote': store to migrate demoted children to. Defaults to child artifact type's default_store."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/meta/schemas/core/relationship.schema.json
+++ b/meta/schemas/core/relationship.schema.json
@@ -84,7 +84,7 @@
           "type": "string",
           "enum": ["none", "flag_stale", "demote"],
           "default": "none",
-          "description": "Action when parent artifact is edited. 'none': no effect on children. 'flag_stale': set _stale_parent=true on children (advisory). 'demote': transition children to their initial_state (enforced)."
+          "description": "Action when parent artifact is edited. 'none': no effect on children. 'flag_stale': set _stale_parent=true on children (advisory). 'demote': transition children to their lifecycle_policy.demote_target_state (enforced)."
         },
         "on_parent_delete": {
           "type": "string",
@@ -94,7 +94,7 @@
         },
         "demote_target_store": {
           "$ref": "_definitions.schema.json#/$defs/store_ref",
-          "description": "For on_parent_edit='demote': store to migrate demoted children to. Defaults to child artifact type's default_store."
+          "description": "For on_parent_edit='demote': optional store override for demoted children. Takes precedence over child's lifecycle_policy.demote_target_store. If not set, uses child's lifecycle_policy.demote_target_store (or child artifact type's default_store if that is also unset)."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Implements Epic 1: Schema Extensions for Lifecycle Policies (#252).

### Changes

**New schema: `relationship.schema.json`**
- Defines behavioral relationships between artifact types (parent → child)
- Supports four relationship kinds: `derived_from`, `depends_on`, `supersedes`, `references`
- Two link resolution modes: `by_artifact_id` (direct _id) and `by_field_match` (field value matching)
- Impact policies define cascade behavior (`on_parent_edit`, `on_parent_delete`)

**Extended: `artifact-type.schema.json`**
- Added `lifecycle_policy` block for runtime enforcement behavior:
  - `edit_policy`: `allow` | `demote` | `disallow`
  - `demote_trigger_states`: which states trigger demotion
  - `demote_target_state` / `demote_target_store`: where demoted artifacts go
- Added `target_store` to transitions for generalized store migration

**Documentation**
- New `lifecycle-policy.md` with detailed runtime enforcement documentation
- Updated `semantic-conventions.md` with relationship kinds and impact policies
- Updated `artifact-conventions.md` with runtime enforcement section

### Design Decisions

- **Separate relationship schema**: Relationships are defined separately from artifact types to avoid circular references and make all relationships visible in one place per studio
- **Lifecycle vs lifecycle_policy separation**: State machine definition (what transitions exist) vs runtime enforcement (what happens automatically)
- **Field-match resolution**: Supports both direct `_id` references and field value matching (e.g., `brief_ref` → `brief_id`)

### Related Issues

- Closes #252 (Epic 1: Schema Extensions)
- Provides schema foundation for #253 (Runtime Policy Enforcement)
- Provides schema foundation for #254 (Domain Migration)
- Provides schema foundation for #255 (Runtime Cascade Implementation)

## Test plan

- [ ] Validate JSON schemas with a JSON Schema validator
- [ ] Review schema documentation for clarity
- [ ] Verify schema references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)