### PR TITLE
feat(domain): Simplify section lifecycle and add relationship definitions (#254)

### DIFF
--- a/domain-v4/artifact-types/canon_pack.json
+++ b/domain-v4/artifact-types/canon_pack.json
@@ -176,5 +176,12 @@
     ]
   },
 
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_trigger_states": ["ready"],
+    "demote_target_state": "draft",
+    "demote_target_store": "workspace"
+  },
+
   "default_store": "canon"
 }

--- a/domain-v4/artifact-types/codex_entry.json
+++ b/domain-v4/artifact-types/codex_entry.json
@@ -146,7 +146,7 @@
 
   "lifecycle_policy": {
     "edit_policy": "demote",
-    "demote_trigger_states": ["review", "validated"],
+    "demote_trigger_states": ["review", "validated", "published"],
     "demote_target_state": "draft",
     "demote_target_store": "workspace"
   },

--- a/domain-v4/artifact-types/codex_entry.json
+++ b/domain-v4/artifact-types/codex_entry.json
@@ -144,5 +144,12 @@
     ]
   },
 
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_trigger_states": ["review", "validated"],
+    "demote_target_state": "draft",
+    "demote_target_store": "workspace"
+  },
+
   "default_store": "codex"
 }

--- a/domain-v4/artifact-types/section.json
+++ b/domain-v4/artifact-types/section.json
@@ -206,6 +206,7 @@
 
   "lifecycle_policy": {
     "edit_policy": "demote",
+    "demote_trigger_states": ["review"],
     "demote_target_state": "draft",
     "demote_target_store": "workspace"
   },

--- a/domain-v4/artifact-types/section.json
+++ b/domain-v4/artifact-types/section.json
@@ -166,49 +166,48 @@
       {
         "id": "draft",
         "name": "Draft",
-        "description": "Section is being written by Scene Smith"
+        "description": "LLM agents actively working on content"
       },
       {
         "id": "review",
         "name": "Review",
-        "description": "Section is under Style Lead review"
-      },
-      {
-        "id": "gatecheck",
-        "name": "Gatecheck",
-        "description": "Section is awaiting Gatekeeper validation"
-      },
-      {
-        "id": "approved",
-        "name": "Approved",
-        "description": "Section has passed gatecheck, ready for Cold merge"
+        "description": "Studio work complete; ready for human review"
       },
       {
         "id": "cold",
         "name": "Cold",
-        "description": "Section is merged to Cold SoT, player-safe",
+        "description": "Canonized and immutable",
         "terminal": true
       }
     ],
     "initial_state": "draft",
     "transitions": [
-      { "from": "draft", "to": "review" },
-      { "from": "review", "to": "draft" },
-      { "from": "review", "to": "gatecheck" },
-      { "from": "gatecheck", "to": "draft" },
-      { "from": "gatecheck", "to": "approved" },
       {
-        "from": "gatecheck",
-        "to": "cold",
-        "allowed_agents": ["gatekeeper"],
-        "requires_validation": ["integrity", "reachability", "style", "presentation"]
+        "from": "draft",
+        "to": "review",
+        "allowed_agents": ["showrunner", "gatekeeper"],
+        "description": "Studio work complete"
       },
       {
-        "from": "approved",
+        "from": "review",
+        "to": "draft",
+        "description": "Explicit rework requested"
+      },
+      {
+        "from": "review",
         "to": "cold",
-        "requires_validation": ["integrity", "reachability", "style", "presentation"]
+        "allowed_agents": ["gatekeeper"],
+        "requires_validation": ["integrity", "reachability", "style", "presentation"],
+        "target_store": "manuscript",
+        "description": "Human-approved canonization"
       }
     ]
+  },
+
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_target_state": "draft",
+    "demote_target_store": "workspace"
   },
 
   "validation": {

--- a/domain-v4/artifact-types/section_brief.json
+++ b/domain-v4/artifact-types/section_brief.json
@@ -207,7 +207,7 @@
 
   "lifecycle_policy": {
     "edit_policy": "demote",
-    "demote_trigger_states": ["ready", "in_use"],
+    "demote_trigger_states": ["ready", "in_use", "archived"],
     "demote_target_state": "draft",
     "demote_target_store": "workspace"
   },

--- a/domain-v4/artifact-types/section_brief.json
+++ b/domain-v4/artifact-types/section_brief.json
@@ -205,5 +205,12 @@
     ]
   },
 
+  "lifecycle_policy": {
+    "edit_policy": "demote",
+    "demote_trigger_states": ["ready", "in_use"],
+    "demote_target_state": "draft",
+    "demote_target_store": "workspace"
+  },
+
   "default_store": "workspace"
 }

--- a/domain-v4/playbooks/scene_weave.json
+++ b/domain-v4/playbooks/scene_weave.json
@@ -6,7 +6,7 @@
   "summary": "Transform briefs into prose with choices",
   "purpose": "Transform Section Briefs into full prose Sections with dialogue, sensory detail, and contrastive choices. Voice first, structure assumed stable.",
 
-  "description": "Scene Weave is the prose loop. Scene Smith fills structural shells from Story Spark with dialogue and sensory detail. The structure is assumed stable—this loop does not change topology, only inhabits it. The focus is on voice, aesthetic quality, contrastive choices, and diegetic gate phrasing. Hooks generated here are scene-level (traits, tells, props) rather than structural.",
+  "description": "Scene Weave is the prose loop. Scene Smith fills structural shells from Story Spark with dialogue and sensory detail. The structure is assumed stable—this loop does not change topology, only inhabits it. The focus is on voice, aesthetic quality, contrastive choices, and diegetic gate phrasing. Hooks generated here are scene-level (traits, tells, props) rather than structural. Sections are created in draft, promoted to review when studio work is complete. The review state means 'LLM studio is done; ready for human review'. Gatekeeper validation runs via quality bars during the playbook, not via lifecycle state changes.",
 
   "triggers": [
     {
@@ -52,7 +52,7 @@
       {
         "type": "section",
         "alias": "sections",
-        "description": "Full prose Sections with choices and gates (created in `draft`, intended to be promoted to lifecycle states like `review`/`approved` via lifecycle tools after gatecheck)",
+        "description": "Full prose Sections with choices and gates. Created in draft, promoted to review when playbook completes successfully. The review state indicates studio work is complete and sections are ready for human review or canonization.",
         "state": "review"
       }
     ],
@@ -271,7 +271,7 @@
       ],
 
       "on_success": {
-        "message": "Sections approved. Ready for Cold merge after full pipeline (Lore, Codex, etc.).",
+        "message": "Sections approved and promoted to review state. Ready for human review or canonization (review -> cold) via separate approval flow.",
         "end_playbook": true,
         "followups": {
           "runtime_actions": [

--- a/domain-v4/relationships/codex_from_canon.json
+++ b/domain-v4/relationships/codex_from_canon.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../meta/schemas/core/relationship.schema.json",
+  "id": "codex_from_canon",
+  "name": "Codex from Canon",
+  "description": "Codex entries are derived from canon packs. When canon is edited, codex entries should be flagged for review.",
+  "from_type": "canon_pack",
+  "to_type": "codex_entry",
+  "kind": "derived_from",
+  "link_field": "canon_source.pack_id",
+  "link_resolution": "by_field_match",
+  "match_field": "pack_id",
+  "impact_policy": {
+    "on_parent_edit": "flag_stale",
+    "on_parent_delete": "orphan"
+  }
+}

--- a/domain-v4/relationships/section_from_brief.json
+++ b/domain-v4/relationships/section_from_brief.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../meta/schemas/core/relationship.schema.json",
+  "id": "section_from_brief",
+  "name": "Section from Brief",
+  "description": "Sections are derived from section briefs. When a brief is edited, derived sections should be demoted to draft for review.",
+  "from_type": "section_brief",
+  "to_type": "section",
+  "kind": "derived_from",
+  "link_field": "brief_ref",
+  "link_resolution": "by_field_match",
+  "match_field": "brief_id",
+  "impact_policy": {
+    "on_parent_edit": "demote",
+    "on_parent_delete": "orphan"
+  }
+}

--- a/domain-v4/studio.json
+++ b/domain-v4/studio.json
@@ -95,6 +95,11 @@
     "tools/request_lifecycle_transition.json"
   ],
 
+  "relationships": [
+    "relationships/section_from_brief.json",
+    "relationships/codex_from_canon.json"
+  ],
+
   "quality_criteria": [
     "governance/quality-criteria/integrity.json",
     "governance/quality-criteria/reachability.json",

--- a/meta/schemas/core/artifact-type.schema.json
+++ b/meta/schemas/core/artifact-type.schema.json
@@ -146,6 +146,10 @@
               "target_store": {
                 "$ref": "_definitions.schema.json#/$defs/store_ref",
                 "description": "Store to migrate artifact to on this transition. Generalizes cold migration - any transition can trigger store migration. Runtime updates both _lifecycle_state and _store atomically."
+              },
+              "description": {
+                "$ref": "_definitions.schema.json#/$defs/description",
+                "description": "Human-readable description of this transition"
               }
             },
             "additionalProperties": false

--- a/meta/schemas/core/studio.schema.json
+++ b/meta/schemas/core/studio.schema.json
@@ -135,6 +135,18 @@
       "description": "Quality criteria used to validate work. Can be inline objects or file paths."
     },
 
+    "relationships": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string", "description": "File path to relationship definition" },
+          { "$ref": "relationship.schema.json" }
+        ]
+      },
+      "default": [],
+      "description": "Relationships between artifact types defining derivation chains and impact policies. Can be inline objects or file paths."
+    },
+
     "knowledge": {
       "type": "array",
       "items": {

--- a/tests/runtime/tools/test_consult_schema.py
+++ b/tests/runtime/tools/test_consult_schema.py
@@ -20,23 +20,55 @@ def make_mock_artifact_type():
     artifact_type.category = "document"
 
     # Fields (use lowercase names to match typical field identifiers)
+    # NOTE: Must explicitly set nested attributes to None to prevent MagicMock
+    # from auto-creating them (which causes infinite recursion in _field_to_dict)
     field1 = MagicMock()
     field1.name = "title"
     field1.type = FieldType.STRING
     field1.required = True
     field1.description = "Section title"
+    field1.enum = None
+    field1.format = None
+    field1.min_length = None
+    field1.max_length = None
+    field1.min = None
+    field1.max = None
+    field1.ref_target = None
+    field1.properties = None
+    field1.items = None
+    field1.items_type = None
 
     field2 = MagicMock()
     field2.name = "body"
     field2.type = FieldType.TEXT
     field2.required = True
     field2.description = "Section content"
+    field2.enum = None
+    field2.format = None
+    field2.min_length = None
+    field2.max_length = None
+    field2.min = None
+    field2.max = None
+    field2.ref_target = None
+    field2.properties = None
+    field2.items = None
+    field2.items_type = None
 
     field3 = MagicMock()
     field3.name = "tags"
     field3.type = FieldType.ARRAY
     field3.required = False
     field3.description = "Optional tags"
+    field3.enum = None
+    field3.format = None
+    field3.min_length = None
+    field3.max_length = None
+    field3.min = None
+    field3.max = None
+    field3.ref_target = None
+    field3.properties = None
+    field3.items = None
+    field3.items_type = None
 
     artifact_type.fields = [field1, field2, field3]
 


### PR DESCRIPTION
## Summary

- Simplify section lifecycle from 5 states to 3 states (draft → review → cold)
- Add `lifecycle_policy` blocks to artifact types for runtime edit-demotion enforcement
- Create relationship definitions for parent-child artifact cascades
- Update scene_weave playbook to reflect new lifecycle semantics

## Details

### Section Lifecycle Simplification

| Before | After |
|--------|-------|
| draft → review → gatecheck → approved → cold | draft → review → cold |

The `gatecheck` and `approved` states are removed. Gatekeeper validation now happens via quality bars during playbook execution, not lifecycle state changes.

### Lifecycle Policy Additions

| Artifact Type | Edit Policy | Demote Target |
|---------------|-------------|---------------|
| `section` | demote | draft (workspace) |
| `section_brief` | demote | draft (workspace) |
| `codex_entry` | demote | draft (workspace) |
| `canon_pack` | demote | draft (workspace) |

### Relationship Definitions

| Relationship | Parent → Child | Cascade Policy |
|--------------|---------------|----------------|
| `section_from_brief` | section_brief → section | demote on parent edit |
| `codex_from_canon` | canon_pack → codex_entry | flag_stale on parent edit |

### Other Changes

- Added `relationships` array to `studio.json`
- Added `target_store: "manuscript"` on section's review→cold transition
- Updated `scene_weave.json` description to clarify review = "studio done"

## Test Plan

- [x] All JSON files validate against their schemas (pre-commit hook passed)
- [ ] Runtime loads domain correctly (pending #253 implementation)
- [ ] Lifecycle policy enforcement works (pending #253 implementation)

## Migration Notes

For existing projects with artifacts in `gatecheck` or `approved` states, run:
```sql
UPDATE artifacts 
SET _lifecycle_state = 'review' 
WHERE _type = 'section' AND _lifecycle_state IN ('gatecheck', 'approved');
```

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)