### PR TITLE
feat(runtime): Runtime policy enforcement - Epic 2 (#253)

### DIFF
--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -62,7 +62,7 @@ from questfoundry.runtime.providers import (
     ToolCallRequest,
 )
 from questfoundry.runtime.session import Session, TokenUsage, Turn
-from questfoundry.runtime.storage import LifecycleManager, StoreManager
+from questfoundry.runtime.storage import LifecycleManager, RelationshipManager, StoreManager
 
 if TYPE_CHECKING:
     from questfoundry.runtime.checkpoint import CheckpointManager, ContextUsage
@@ -252,6 +252,7 @@ class AgentRuntime:
         self._tool_registry: ToolRegistry | None = None
         self._store_manager: StoreManager | None = None
         self._lifecycle_manager: LifecycleManager | None = None
+        self._relationship_manager: RelationshipManager | None = None
         try:
             self._store_manager = StoreManager.from_studio(studio)
         except (KeyError, ValueError) as exc:  # pragma: no cover - defensive logging
@@ -262,6 +263,14 @@ class AgentRuntime:
             self._lifecycle_manager = LifecycleManager.from_artifact_types(studio.artifact_types)
         except (KeyError, ValueError, AttributeError) as exc:  # pragma: no cover - defensive
             logger.warning("Failed to load lifecycle manager from studio definition: %s", exc)
+
+        # Initialize relationship manager from relationships
+        try:
+            if studio.relationships:
+                rel_dicts = [r.model_dump() for r in studio.relationships]
+                self._relationship_manager = RelationshipManager.from_definitions(rel_dicts)
+        except (KeyError, ValueError, AttributeError) as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to load relationship manager from studio definition: %s", exc)
 
         # Secretary for tiered context management
         # context_limit from model determines when to start summarizing
@@ -305,6 +314,7 @@ class AgentRuntime:
                     interactive=self._interactive,
                     store_manager=self._store_manager,
                     lifecycle_manager=self._lifecycle_manager,
+                    relationship_manager=self._relationship_manager,
                 )
             except ImportError:
                 logger.warning("Tools module not available, tool execution disabled", exc_info=True)

--- a/src/questfoundry/runtime/domain/loader.py
+++ b/src/questfoundry/runtime/domain/loader.py
@@ -33,6 +33,7 @@ from questfoundry.runtime.models.base import (
     KnowledgeEntry,
     Playbook,
     QualityCriteria,
+    RelationshipDef,
     Store,
     Studio,
     Tool,
@@ -160,6 +161,7 @@ async def _resolve_all_refs(
         "artifact_types": ArtifactType,
         "asset_types": AssetType,
         "quality_criteria": QualityCriteria,
+        "relationships": RelationshipDef,
     }
 
     for key, _model_class in ref_keys.items():
@@ -376,6 +378,12 @@ def _build_studio(resolved: dict[str, Any]) -> Studio:
         qc_data = _strip_schema_field(qc_data)
         quality_criteria.append(QualityCriteria.model_validate(qc_data))
 
+    # Build relationships
+    relationships = []
+    for rel_data in resolved.get("relationships", []):
+        rel_data = _strip_schema_field(rel_data)
+        relationships.append(RelationshipDef.model_validate(rel_data))
+
     # Build knowledge entries dict
     knowledge: dict[str, KnowledgeEntry] = {}
     for entry_id, entry_data in resolved.get("knowledge", {}).items():
@@ -395,6 +403,7 @@ def _build_studio(resolved: dict[str, Any]) -> Studio:
     studio_data["artifact_types"] = artifact_types
     studio_data["asset_types"] = asset_types
     studio_data["quality_criteria"] = quality_criteria
+    studio_data["relationships"] = relationships
     studio_data["knowledge"] = knowledge
 
     return Studio.model_validate(studio_data)

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -352,9 +352,11 @@ class RelationshipDef(BaseModel):
     from_type: str  # Parent artifact type (referenced)
     to_type: str  # Child artifact type (holds reference)
     kind: Literal["derived_from", "depends_on", "supersedes", "references"]
-    link_field: str  # JSON path on child referencing parent
+    link_field: str = Field(pattern=r"^[a-z_][a-z0-9_]*(\.[a-z_][a-z0-9_]*)*$")
     link_resolution: Literal["by_artifact_id", "by_field_match"] = "by_field_match"
-    match_field: str | None = None  # For by_field_match resolution
+    match_field: str | None = Field(
+        default=None, pattern=r"^[a-z_][a-z0-9_]*(\.[a-z_][a-z0-9_]*)*$"
+    )
     impact_policy: RelationshipImpactPolicy | None = None
 
 

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -325,6 +325,39 @@ class QualityCriteria(BaseModel):
     failure_guidance: str | None = None
 
 
+# =============================================================================
+# Relationship Models
+# =============================================================================
+
+
+class RelationshipImpactPolicy(BaseModel):
+    """Defines cascade behavior when a parent artifact changes."""
+
+    on_parent_edit: Literal["none", "flag_stale", "demote"] = "none"
+    on_parent_delete: Literal["none", "orphan", "cascade_delete", "block"] = "orphan"
+    demote_target_store: str | None = None
+
+
+class RelationshipDef(BaseModel):
+    """
+    Relationship definition from relationship.schema.json.
+
+    Defines behavioral relationships between artifact types for cascade
+    policies and navigation.
+    """
+
+    id: str
+    name: str | None = None
+    description: str | None = None
+    from_type: str  # Parent artifact type (referenced)
+    to_type: str  # Child artifact type (holds reference)
+    kind: Literal["derived_from", "depends_on", "supersedes", "references"]
+    link_field: str  # JSON path on child referencing parent
+    link_resolution: Literal["by_artifact_id", "by_field_match"] = "by_field_match"
+    match_field: str | None = None  # For by_field_match resolution
+    impact_policy: RelationshipImpactPolicy | None = None
+
+
 class KnowledgeContent(BaseModel):
     """Knowledge content definition."""
 
@@ -434,6 +467,7 @@ class Studio(BaseModel):
     artifact_types: list[ArtifactType] = Field(default_factory=list)
     asset_types: list[AssetType] = Field(default_factory=list)
     quality_criteria: list[QualityCriteria] = Field(default_factory=list)
+    relationships: list[RelationshipDef] = Field(default_factory=list)
 
     # Knowledge system
     knowledge_config: dict[str, Any] | None = None  # Layer configuration from layers.json

--- a/src/questfoundry/runtime/storage/__init__.py
+++ b/src/questfoundry/runtime/storage/__init__.py
@@ -8,11 +8,13 @@ Provides:
 - Message storage for agent communication
 - StoreManager: Registry for store definitions
 - LifecycleManager: Artifact lifecycle state machines
+- RelationshipManager: Artifact relationship cascade handling
 """
 
 from questfoundry.runtime.storage.lifecycle import (
     ArtifactLifecycle,
     LifecycleManager,
+    LifecyclePolicy,
     LifecycleState,
     LifecycleTransition,
 )
@@ -21,6 +23,11 @@ from questfoundry.runtime.storage.project import (
     ProjectInfo,
     ProjectStatusSummary,
     list_projects,
+)
+from questfoundry.runtime.storage.relationship import (
+    ImpactPolicy,
+    Relationship,
+    RelationshipManager,
 )
 from questfoundry.runtime.storage.store_manager import (
     AssetStorageConfig,
@@ -45,6 +52,11 @@ __all__ = [
     # Lifecycle management
     "LifecycleManager",
     "ArtifactLifecycle",
+    "LifecyclePolicy",
     "LifecycleState",
     "LifecycleTransition",
+    # Relationship management
+    "RelationshipManager",
+    "Relationship",
+    "ImpactPolicy",
 ]

--- a/src/questfoundry/runtime/storage/__init__.py
+++ b/src/questfoundry/runtime/storage/__init__.py
@@ -9,8 +9,13 @@ Provides:
 - StoreManager: Registry for store definitions
 - LifecycleManager: Artifact lifecycle state machines
 - RelationshipManager: Artifact relationship cascade handling
+- EditPolicyGuard: Edit policy enforcement
 """
 
+from questfoundry.runtime.storage.edit_policy import (
+    EditPolicyGuard,
+    EditPolicyResult,
+)
 from questfoundry.runtime.storage.lifecycle import (
     ArtifactLifecycle,
     LifecycleManager,
@@ -59,4 +64,7 @@ __all__ = [
     "RelationshipManager",
     "Relationship",
     "ImpactPolicy",
+    # Edit policy enforcement
+    "EditPolicyGuard",
+    "EditPolicyResult",
 ]

--- a/src/questfoundry/runtime/storage/edit_policy.py
+++ b/src/questfoundry/runtime/storage/edit_policy.py
@@ -1,0 +1,228 @@
+"""
+Edit policy enforcement for artifact modifications.
+
+Enforces lifecycle policies and relationship cascade rules when
+artifacts are edited.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.runtime.storage.lifecycle import LifecycleManager
+    from questfoundry.runtime.storage.project import Project
+    from questfoundry.runtime.storage.relationship import RelationshipManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EditPolicyResult:
+    """Result of checking edit policy for an artifact."""
+
+    allowed: bool
+    reason: str | None = None
+    demote_to_state: str | None = None
+    demote_to_store: str | None = None
+    cascade_demotions: list[dict[str, Any]] | None = None
+
+
+class EditPolicyGuard:
+    """
+    Enforces edit policies based on lifecycle and relationship rules.
+
+    Checks whether an artifact can be edited and determines any
+    automatic consequences (demotion, cascade to children).
+    """
+
+    def __init__(
+        self,
+        lifecycle_manager: LifecycleManager,
+        relationship_manager: RelationshipManager,
+    ) -> None:
+        """
+        Initialize the edit policy guard.
+
+        Args:
+            lifecycle_manager: Manager for artifact lifecycle state machines
+            relationship_manager: Manager for artifact relationships
+        """
+        self._lifecycle_manager = lifecycle_manager
+        self._relationship_manager = relationship_manager
+
+    def check_edit(
+        self,
+        artifact: dict[str, Any],
+        project: Project,
+    ) -> EditPolicyResult:
+        """
+        Check if an artifact can be edited and determine consequences.
+
+        Evaluates:
+        1. Lifecycle policy for the artifact type (allow/demote/disallow)
+        2. Relationship cascade policies for any children
+
+        Args:
+            artifact: The artifact being edited
+            project: The project containing the artifact
+
+        Returns:
+            EditPolicyResult with allowed status and any required actions
+        """
+        artifact_type = artifact.get("_type")
+        if not artifact_type:
+            # No type - allow edit
+            return EditPolicyResult(allowed=True)
+
+        current_state = artifact.get("_lifecycle_state", "draft")
+
+        # Get lifecycle for this artifact type
+        lifecycle = self._lifecycle_manager.get_lifecycle(artifact_type)
+        if lifecycle is None:
+            # No lifecycle defined - edits always allowed
+            return EditPolicyResult(allowed=True)
+
+        # Check edit policy based on current state
+        edit_policy = lifecycle.get_edit_policy(current_state)
+
+        if edit_policy == "disallow":
+            return EditPolicyResult(
+                allowed=False,
+                reason=f"Edits not allowed for {artifact_type} in state '{current_state}'",
+            )
+
+        if edit_policy == "allow":
+            # Still need to check for cascade effects
+            cascades = self._get_cascade_demotions(artifact, project)
+            return EditPolicyResult(
+                allowed=True,
+                cascade_demotions=cascades if cascades else None,
+            )
+
+        # edit_policy == "demote"
+        demote_state, demote_store = lifecycle.get_demote_target()
+        cascades = self._get_cascade_demotions(artifact, project)
+
+        return EditPolicyResult(
+            allowed=True,
+            demote_to_state=demote_state,
+            demote_to_store=demote_store,
+            cascade_demotions=cascades if cascades else None,
+        )
+
+    def _get_cascade_demotions(
+        self,
+        parent_artifact: dict[str, Any],
+        project: Project,
+    ) -> list[dict[str, Any]]:
+        """
+        Find children that need demotion due to parent edit.
+
+        Looks up relationships where this artifact type is the parent
+        and impact_policy.on_parent_edit is "demote".
+
+        Args:
+            parent_artifact: The parent artifact being edited
+            project: The project containing artifacts
+
+        Returns:
+            List of dicts with child_id, demote_to_state, demote_to_store
+        """
+        demotions: list[dict[str, Any]] = []
+        parent_type = parent_artifact.get("_type")
+        if not parent_type:
+            return demotions
+
+        # Get relationships where this type is the parent
+        relationships = self._relationship_manager.get_relationships_from_type(parent_type)
+
+        for rel in relationships:
+            if rel.impact_policy.on_parent_edit != "demote":
+                continue
+
+            # Find children linked via this relationship
+            children = project.get_children_by_relationship(parent_artifact, rel)
+
+            for child in children:
+                child_id = child.get("_id")
+                child_type = child.get("_type")
+                if not child_type:
+                    continue
+                child_state = child.get("_lifecycle_state", "draft")
+
+                # Get child's lifecycle to determine demotion target
+                child_lifecycle = self._lifecycle_manager.get_lifecycle(child_type)
+                if child_lifecycle is None:
+                    continue
+
+                # Skip if already in initial state
+                if child_state == child_lifecycle.initial_state:
+                    continue
+
+                # Determine demotion target
+                demote_state = child_lifecycle.initial_state
+                demote_store = (
+                    rel.impact_policy.demote_target_store or child_lifecycle.default_store
+                )
+
+                demotions.append(
+                    {
+                        "child_id": child_id,
+                        "child_type": child_type,
+                        "relationship_id": rel.id,
+                        "demote_to_state": demote_state,
+                        "demote_to_store": demote_store,
+                    }
+                )
+
+        return demotions
+
+    def apply_demotions(
+        self,
+        policy_result: EditPolicyResult,
+        artifact: dict[str, Any],
+        project: Project,
+        agent_id: str | None = None,
+    ) -> None:
+        """
+        Apply demotion effects from an edit policy result.
+
+        Updates the edited artifact and any cascade children to their
+        demoted states.
+
+        Args:
+            policy_result: Result from check_edit()
+            artifact: The artifact being edited
+            project: The project containing artifacts
+            agent_id: Agent making the edit
+        """
+        artifact_id = artifact.get("_id")
+
+        # Apply self-demotion if required
+        if policy_result.demote_to_state:
+            update_fields: dict[str, Any] = {"_lifecycle_state": policy_result.demote_to_state}
+            if policy_result.demote_to_store:
+                update_fields["_store"] = policy_result.demote_to_store
+
+            if artifact_id:
+                logger.info(
+                    f"Demoting artifact {artifact_id} to state '{policy_result.demote_to_state}'"
+                )
+                project.update_artifact(artifact_id, update_fields, _updated_by=agent_id)
+
+        # Apply cascade demotions
+        if policy_result.cascade_demotions:
+            for demotion in policy_result.cascade_demotions:
+                child_id: str = demotion["child_id"]
+                child_update: dict[str, Any] = {"_lifecycle_state": demotion["demote_to_state"]}
+                if demotion.get("demote_to_store"):
+                    child_update["_store"] = demotion["demote_to_store"]
+
+                logger.info(
+                    f"Cascade demoting child {child_id} to state "
+                    f"'{demotion['demote_to_state']}' (via {demotion['relationship_id']})"
+                )
+                project.update_artifact(child_id, child_update, _updated_by=agent_id)

--- a/src/questfoundry/runtime/storage/edit_policy.py
+++ b/src/questfoundry/runtime/storage/edit_policy.py
@@ -95,7 +95,10 @@ class EditPolicyGuard:
             )
 
         if edit_policy == "allow":
-            # Still need to check for cascade effects
+            # Still need to check for cascade effects.
+            # Cascades are determined by the relationship's impact_policy, not the parent's
+            # edit_policy. This means children can be demoted even when the parent is
+            # freely editable - the relationship defines how changes propagate.
             cascades = self._get_cascade_demotions(artifact, project)
             return EditPolicyResult(
                 allowed=True,
@@ -214,6 +217,25 @@ class EditPolicyGuard:
                 project.update_artifact(artifact_id, update_fields, _updated_by=agent_id)
 
         # Apply cascade demotions
+        self.apply_cascade_demotions(policy_result, project, agent_id)
+
+    def apply_cascade_demotions(
+        self,
+        policy_result: EditPolicyResult,
+        project: Project,
+        agent_id: str | None = None,
+    ) -> None:
+        """
+        Apply cascade demotion effects to children.
+
+        This is called after the parent artifact has been updated to demote
+        any children that require demotion due to the relationship policy.
+
+        Args:
+            policy_result: Result from check_edit()
+            project: The project containing artifacts
+            agent_id: Agent making the edit
+        """
         if policy_result.cascade_demotions:
             for demotion in policy_result.cascade_demotions:
                 child_id: str = demotion["child_id"]

--- a/src/questfoundry/runtime/storage/lifecycle.py
+++ b/src/questfoundry/runtime/storage/lifecycle.py
@@ -9,9 +9,48 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
+
+
+def _to_dict(obj: Any) -> dict[str, Any] | None:
+    """
+    Convert an object to a dictionary.
+
+    Handles Pydantic v2 (.model_dump), Pydantic v1 (.dict),
+    and custom objects with .to_dict() method.
+
+    Args:
+        obj: Object to convert
+
+    Returns:
+        Dictionary representation or None if conversion not possible
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return cast(dict[str, Any], obj)
+
+    # Prefer Pydantic v2-style export
+    if hasattr(obj, "model_dump"):
+        try:
+            return cast(dict[str, Any], obj.model_dump(by_alias=True))
+        except TypeError:  # pragma: no cover - defensive
+            return cast(dict[str, Any], obj.model_dump())
+
+    # Fallback to Pydantic v1-style export
+    if hasattr(obj, "dict"):
+        try:
+            return cast(dict[str, Any], obj.dict(by_alias=True))
+        except TypeError:  # pragma: no cover - defensive
+            return cast(dict[str, Any], obj.dict())
+
+    # Generic custom object export
+    if hasattr(obj, "to_dict"):
+        return cast(dict[str, Any], obj.to_dict())
+
+    return None
 
 
 @dataclass
@@ -397,30 +436,9 @@ class LifecycleManager:
                 policy_data = getattr(artifact_type, "lifecycle_policy", None)
                 default_store = getattr(artifact_type, "default_store", None)
 
-                # If lifecycle is an object, convert to a plain dict so that
-                # ArtifactLifecycle.from_dict always sees primitive structures.
-                # This handles:
-                # - Pydantic v2 models (.model_dump)
-                # - Pydantic v1 models (.dict)
-                # - Custom objects exposing .to_dict()
+                # Convert lifecycle_data to dict if needed
                 if lifecycle_data and not isinstance(lifecycle_data, dict):
-                    lifecycle_dict: dict[str, Any] | None = None
-                    # Prefer Pydantic v2-style export
-                    if hasattr(lifecycle_data, "model_dump"):
-                        try:
-                            lifecycle_dict = lifecycle_data.model_dump(by_alias=True)
-                        except TypeError:  # pragma: no cover - defensive
-                            lifecycle_dict = lifecycle_data.model_dump()
-                    # Fallback to Pydantic v1-style export
-                    elif hasattr(lifecycle_data, "dict"):
-                        try:
-                            lifecycle_dict = lifecycle_data.dict(by_alias=True)
-                        except TypeError:  # pragma: no cover - defensive
-                            lifecycle_dict = lifecycle_data.dict()
-                    # Generic custom object export
-                    elif hasattr(lifecycle_data, "to_dict"):
-                        lifecycle_dict = lifecycle_data.to_dict()
-
+                    lifecycle_dict = _to_dict(lifecycle_data)
                     if lifecycle_dict is not None:
                         lifecycle_data = lifecycle_dict
                     else:
@@ -432,20 +450,25 @@ class LifecycleManager:
                             "transitions": getattr(lifecycle_data, "transitions", []),
                         }
 
-                # Convert policy_data from object to dict if needed
+                # Convert policy_data to dict if needed
                 if policy_data and not isinstance(policy_data, dict):
-                    if hasattr(policy_data, "model_dump"):
-                        try:
-                            policy_data = policy_data.model_dump(by_alias=True)
-                        except TypeError:
-                            policy_data = policy_data.model_dump()
-                    elif hasattr(policy_data, "dict"):
-                        try:
-                            policy_data = policy_data.dict(by_alias=True)
-                        except TypeError:
-                            policy_data = policy_data.dict()
-                    elif hasattr(policy_data, "to_dict"):
-                        policy_data = policy_data.to_dict()
+                    policy_dict = _to_dict(policy_data)
+                    if policy_dict is not None:
+                        policy_data = policy_dict
+                    else:
+                        # Last-resort attribute access for policy objects
+                        policy_data = {
+                            "edit_policy": getattr(policy_data, "edit_policy", "allow"),
+                            "demote_trigger_states": getattr(
+                                policy_data, "demote_trigger_states", None
+                            ),
+                            "demote_target_state": getattr(
+                                policy_data, "demote_target_state", None
+                            ),
+                            "demote_target_store": getattr(
+                                policy_data, "demote_target_store", None
+                            ),
+                        }
 
             if type_id and lifecycle_data:
                 lifecycle = ArtifactLifecycle.from_dict(

--- a/src/questfoundry/runtime/storage/lifecycle.py
+++ b/src/questfoundry/runtime/storage/lifecycle.py
@@ -42,6 +42,7 @@ class LifecycleTransition:
     to_state: str
     allowed_agents: list[str] = field(default_factory=list)
     requires_validation: list[str] = field(default_factory=list)
+    target_store: str | None = None  # Store migration on transition
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> LifecycleTransition:
@@ -51,6 +52,7 @@ class LifecycleTransition:
             to_state=data["to"],
             allowed_agents=data.get("allowed_agents", []),
             requires_validation=data.get("requires_validation", []),
+            target_store=data.get("target_store"),
         )
 
     def is_agent_allowed(self, agent_id: str | None) -> bool:
@@ -62,21 +64,55 @@ class LifecycleTransition:
 
 
 @dataclass
+class LifecyclePolicy:
+    """
+    Runtime enforcement behavior for an artifact type.
+
+    Defines what happens automatically when artifacts are edited,
+    separate from the state machine definition.
+    """
+
+    edit_policy: str = "allow"  # "allow", "demote", "disallow"
+    demote_trigger_states: list[str] | None = None  # None = all except initial
+    demote_target_state: str | None = None  # Defaults to initial_state
+    demote_target_store: str | None = None  # Defaults to artifact's default_store
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> LifecyclePolicy:
+        """Create from dictionary."""
+        if data is None:
+            return cls()
+        return cls(
+            edit_policy=data.get("edit_policy", "allow"),
+            demote_trigger_states=data.get("demote_trigger_states"),
+            demote_target_state=data.get("demote_target_state"),
+            demote_target_store=data.get("demote_target_store"),
+        )
+
+
+@dataclass
 class ArtifactLifecycle:
     """
     Lifecycle state machine for an artifact type.
 
-    Tracks states and valid transitions between them.
+    Tracks states and valid transitions between them, plus
+    runtime enforcement policy for edit behavior.
     """
 
     artifact_type_id: str
     states: dict[str, LifecycleState] = field(default_factory=dict)
     transitions: list[LifecycleTransition] = field(default_factory=list)
     initial_state: str = "draft"
+    policy: LifecyclePolicy | None = None  # Runtime enforcement behavior
+    default_store: str | None = None  # Fallback for demotion store
 
     @classmethod
     def from_dict(
-        cls, artifact_type_id: str, data: dict[str, Any] | None
+        cls,
+        artifact_type_id: str,
+        data: dict[str, Any] | None,
+        policy_data: dict[str, Any] | None = None,
+        default_store: str | None = None,
     ) -> ArtifactLifecycle | None:
         """
         Create lifecycle from artifact type definition.
@@ -84,6 +120,8 @@ class ArtifactLifecycle:
         Args:
             artifact_type_id: ID of the artifact type
             data: Lifecycle section from artifact type definition
+            policy_data: lifecycle_policy section from artifact type definition
+            default_store: default_store from artifact type definition
 
         Returns:
             ArtifactLifecycle or None if no lifecycle defined
@@ -110,11 +148,16 @@ class ArtifactLifecycle:
                 # Already a LifecycleTransition object
                 transitions.append(trans_data)
 
+        # Parse lifecycle policy
+        policy = LifecyclePolicy.from_dict(policy_data) if policy_data else None
+
         return cls(
             artifact_type_id=artifact_type_id,
             states=states,
             transitions=transitions,
             initial_state=data.get("initial_state", "draft"),
+            policy=policy,
+            default_store=default_store,
         )
 
     def get_state(self, state_id: str) -> LifecycleState | None:
@@ -191,6 +234,59 @@ class ArtifactLifecycle:
     def list_states(self) -> list[LifecycleState]:
         """List all states in order of definition."""
         return list(self.states.values())
+
+    def get_edit_policy(self, current_state: str) -> str:
+        """
+        Get edit policy for the given state.
+
+        Args:
+            current_state: Current lifecycle state of the artifact
+
+        Returns:
+            "allow", "demote", or "disallow"
+        """
+        if self.policy is None:
+            return "allow"
+
+        # Determine which states trigger the policy
+        trigger_states = self.policy.demote_trigger_states
+        if trigger_states is None:
+            # Default: all states except initial trigger demotion
+            trigger_states = [s for s in self.states if s != self.initial_state]
+
+        if current_state not in trigger_states:
+            return "allow"
+
+        return self.policy.edit_policy
+
+    def get_demote_target(self) -> tuple[str, str | None]:
+        """
+        Get target state and store for demotion.
+
+        Returns:
+            Tuple of (target_state, target_store). target_store may be None.
+        """
+        if self.policy is None:
+            return (self.initial_state, self.default_store)
+
+        target_state = self.policy.demote_target_state or self.initial_state
+        target_store = self.policy.demote_target_store or self.default_store
+
+        return (target_state, target_store)
+
+    def get_transition_store(self, from_state: str, to_state: str) -> str | None:
+        """
+        Get target_store for a transition, if specified.
+
+        Args:
+            from_state: Current state
+            to_state: Target state
+
+        Returns:
+            Store ID if transition specifies target_store, None otherwise
+        """
+        transition = self.get_transition(from_state, to_state)
+        return transition.target_store if transition else None
 
 
 class LifecycleManager:
@@ -293,9 +389,14 @@ class LifecycleManager:
             if isinstance(artifact_type, dict):
                 type_id = artifact_type.get("id")
                 lifecycle_data = artifact_type.get("lifecycle")
+                policy_data = artifact_type.get("lifecycle_policy")
+                default_store = artifact_type.get("default_store")
             else:
                 type_id = getattr(artifact_type, "id", None)
                 lifecycle_data = getattr(artifact_type, "lifecycle", None)
+                policy_data = getattr(artifact_type, "lifecycle_policy", None)
+                default_store = getattr(artifact_type, "default_store", None)
+
                 # If lifecycle is an object, convert to a plain dict so that
                 # ArtifactLifecycle.from_dict always sees primitive structures.
                 # This handles:
@@ -331,8 +432,25 @@ class LifecycleManager:
                             "transitions": getattr(lifecycle_data, "transitions", []),
                         }
 
+                # Convert policy_data from object to dict if needed
+                if policy_data and not isinstance(policy_data, dict):
+                    if hasattr(policy_data, "model_dump"):
+                        try:
+                            policy_data = policy_data.model_dump(by_alias=True)
+                        except TypeError:
+                            policy_data = policy_data.model_dump()
+                    elif hasattr(policy_data, "dict"):
+                        try:
+                            policy_data = policy_data.dict(by_alias=True)
+                        except TypeError:
+                            policy_data = policy_data.dict()
+                    elif hasattr(policy_data, "to_dict"):
+                        policy_data = policy_data.to_dict()
+
             if type_id and lifecycle_data:
-                lifecycle = ArtifactLifecycle.from_dict(type_id, lifecycle_data)
+                lifecycle = ArtifactLifecycle.from_dict(
+                    type_id, lifecycle_data, policy_data, default_store
+                )
                 if lifecycle:
                     manager.register_lifecycle(lifecycle)
 

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -452,17 +452,28 @@ class Project:
         now = datetime.now().isoformat()
         new_version = existing["_version"] + 1
 
-        # Merge data
+        # Merge data (excluding system fields that have dedicated columns)
         existing_data = {k: v for k, v in existing.items() if not k.startswith("_")}
         merged_data = {**existing_data, **data}
+
+        # Extract system field updates (these need to update both JSON and dedicated columns)
+        new_lifecycle_state = data.get("_lifecycle_state", existing["_lifecycle_state"])
+        new_store = data.get("_store", existing["_store"])
 
         conn.execute(
             """
             UPDATE artifacts
-            SET _version = ?, _updated_at = ?, data = ?
+            SET _version = ?, _updated_at = ?, _lifecycle_state = ?, _store = ?, data = ?
             WHERE _id = ?
             """,
-            (new_version, now, json.dumps(merged_data), artifact_id),
+            (
+                new_version,
+                now,
+                new_lifecycle_state,
+                new_store,
+                json.dumps(merged_data),
+                artifact_id,
+            ),
         )
         conn.commit()
 
@@ -588,7 +599,11 @@ class Project:
         if relationship.link_resolution == "by_artifact_id":
             parent_value = parent_artifact.get("_id")
         else:  # by_field_match
-            parent_value = self._extract_field(parent_artifact, relationship.match_field)
+            # Default to _id if no match_field specified
+            if relationship.match_field:
+                parent_value = self._extract_field(parent_artifact, relationship.match_field)
+            else:
+                parent_value = parent_artifact.get("_id")
 
         if parent_value is None:
             return []

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -561,6 +561,103 @@ class Project:
 
         return results
 
+    def get_children_by_relationship(
+        self,
+        parent_artifact: dict[str, Any],
+        relationship: Any,  # Relationship from relationship.py
+    ) -> list[dict[str, Any]]:
+        """
+        Find child artifacts linked to parent via relationship.
+
+        Handles both link_resolution modes:
+        - by_artifact_id: child.link_field == parent._id
+        - by_field_match: child.link_field == parent.match_field
+
+        Args:
+            parent_artifact: The parent artifact dict
+            relationship: Relationship definition
+
+        Returns:
+            List of child artifacts matching the relationship
+        """
+        parent_type = parent_artifact.get("_type")
+        if parent_type != relationship.from_type:
+            return []
+
+        # Determine the value to match on
+        if relationship.link_resolution == "by_artifact_id":
+            parent_value = parent_artifact.get("_id")
+        else:  # by_field_match
+            parent_value = self._extract_field(parent_artifact, relationship.match_field)
+
+        if parent_value is None:
+            return []
+
+        # Build SQLite query with json_extract for nested paths
+        conn = self._get_connection()
+        json_path = self._to_json_path(relationship.link_field)
+
+        query = """
+            SELECT * FROM artifacts
+            WHERE _type = ?
+            AND json_extract(data, ?) = ?
+        """
+        params = [relationship.to_type, json_path, parent_value]
+
+        rows = conn.execute(query, params).fetchall()
+
+        results = []
+        for row in rows:
+            data = json.loads(row["data"])
+            results.append(
+                {
+                    "_id": row["_id"],
+                    "_type": row["_type"],
+                    "_version": row["_version"],
+                    "_created_at": row["_created_at"],
+                    "_updated_at": row["_updated_at"],
+                    "_created_by": row["_created_by"],
+                    "_lifecycle_state": row["_lifecycle_state"],
+                    "_store": row["_store"],
+                    **data,
+                }
+            )
+
+        return results
+
+    def _to_json_path(self, field_path: str) -> str:
+        """
+        Convert dot-notation field path to SQLite json_extract path.
+
+        Examples:
+            "brief_ref" -> "$.brief_ref"
+            "canon_source.pack_id" -> "$.canon_source.pack_id"
+        """
+        return f"$.{field_path}"
+
+    def _extract_field(self, artifact: dict[str, Any], field_path: str | None) -> Any:
+        """
+        Extract a value from an artifact using dot-notation path.
+
+        Args:
+            artifact: The artifact dict
+            field_path: Dot-notation path (e.g., "brief_id" or "source.pack_id")
+
+        Returns:
+            The extracted value, or None if not found
+        """
+        if field_path is None:
+            return None
+
+        parts = field_path.split(".")
+        value: Any = artifact
+        for part in parts:
+            if isinstance(value, dict):
+                value = value.get(part)
+            else:
+                return None
+        return value
+
     # Version history operations
 
     def save_version(

--- a/src/questfoundry/runtime/storage/relationship.py
+++ b/src/questfoundry/runtime/storage/relationship.py
@@ -1,0 +1,167 @@
+"""
+Artifact relationship management.
+
+Loads relationship definitions from domain and provides cascade
+policy enforcement when parent artifacts change.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ImpactPolicy:
+    """
+    Defines cascade behavior when a parent artifact changes.
+
+    Used by the runtime to automatically apply effects to child
+    artifacts when their parent is edited or deleted.
+    """
+
+    on_parent_edit: str = "none"  # "none", "flag_stale", "demote"
+    on_parent_delete: str = "orphan"  # "none", "orphan", "cascade_delete", "block"
+    demote_target_store: str | None = None  # Optional store override for demoted children
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ImpactPolicy:
+        """Create from dictionary."""
+        if data is None:
+            return cls()
+        return cls(
+            on_parent_edit=data.get("on_parent_edit", "none"),
+            on_parent_delete=data.get("on_parent_delete", "orphan"),
+            demote_target_store=data.get("demote_target_store"),
+        )
+
+
+@dataclass
+class Relationship:
+    """
+    Defines a relationship between artifact types.
+
+    Relationships are directional:
+    - from_type is the parent (referenced)
+    - to_type is the child (holds the reference)
+
+    The link_field on the child artifact references the parent.
+    """
+
+    id: str
+    from_type: str  # Parent artifact type (referenced)
+    to_type: str  # Child artifact type (holds reference)
+    kind: str  # "derived_from", "depends_on", "supersedes", "references"
+    link_field: str  # JSON path on child (e.g., "brief_ref" or "canon_source.pack_id")
+    link_resolution: str = "by_field_match"  # "by_artifact_id" or "by_field_match"
+    match_field: str | None = None  # Field on parent to match (for by_field_match)
+    name: str | None = None
+    description: str | None = None
+    impact_policy: ImpactPolicy = field(default_factory=ImpactPolicy)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Relationship:
+        """Create from dictionary."""
+        return cls(
+            id=data["id"],
+            from_type=data["from_type"],
+            to_type=data["to_type"],
+            kind=data["kind"],
+            link_field=data["link_field"],
+            link_resolution=data.get("link_resolution", "by_field_match"),
+            match_field=data.get("match_field"),
+            name=data.get("name"),
+            description=data.get("description"),
+            impact_policy=ImpactPolicy.from_dict(data.get("impact_policy")),
+        )
+
+
+class RelationshipManager:
+    """
+    Manages artifact relationships and provides cascade lookup.
+
+    Maintains indexes for efficient lookup by parent type (from_type)
+    and child type (to_type).
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty relationship manager."""
+        self._relationships: dict[str, Relationship] = {}
+        self._by_from_type: dict[str, list[Relationship]] = defaultdict(list)
+        self._by_to_type: dict[str, list[Relationship]] = defaultdict(list)
+
+    def register(self, relationship: Relationship) -> None:
+        """
+        Register a relationship and update indexes.
+
+        Args:
+            relationship: The relationship to register
+        """
+        self._relationships[relationship.id] = relationship
+        self._by_from_type[relationship.from_type].append(relationship)
+        self._by_to_type[relationship.to_type].append(relationship)
+        logger.debug(
+            f"Registered relationship: {relationship.id} "
+            f"({relationship.from_type} -> {relationship.to_type})"
+        )
+
+    def get_relationship(self, relationship_id: str) -> Relationship | None:
+        """Get a relationship by ID."""
+        return self._relationships.get(relationship_id)
+
+    def get_relationships_from_type(self, artifact_type: str) -> list[Relationship]:
+        """
+        Get all relationships where this type is the parent.
+
+        Use this to find children that may need cascade updates
+        when a parent artifact changes.
+
+        Args:
+            artifact_type: The parent artifact type
+
+        Returns:
+            List of relationships where from_type matches
+        """
+        return self._by_from_type.get(artifact_type, [])
+
+    def get_relationships_to_type(self, artifact_type: str) -> list[Relationship]:
+        """
+        Get all relationships where this type is the child.
+
+        Use this to find parent artifacts when traversing
+        in the reverse direction.
+
+        Args:
+            artifact_type: The child artifact type
+
+        Returns:
+            List of relationships where to_type matches
+        """
+        return self._by_to_type.get(artifact_type, [])
+
+    def list_relationships(self) -> list[Relationship]:
+        """List all registered relationships."""
+        return list(self._relationships.values())
+
+    @classmethod
+    def from_definitions(cls, relationship_defs: list[dict[str, Any]]) -> RelationshipManager:
+        """
+        Create manager from relationship definitions.
+
+        Args:
+            relationship_defs: List of relationship definition dicts
+
+        Returns:
+            RelationshipManager with all relationships registered
+        """
+        manager = cls()
+
+        for rel_def in relationship_defs:
+            relationship = Relationship.from_dict(rel_def)
+            manager.register(relationship)
+
+        return manager

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -16,7 +16,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Studio, Tool
-    from questfoundry.runtime.storage import LifecycleManager, Project, StoreManager
+    from questfoundry.runtime.storage import (
+        LifecycleManager,
+        Project,
+        RelationshipManager,
+        StoreManager,
+    )
 
 
 class ToolError(Exception):
@@ -92,6 +97,7 @@ class ToolContext:
     # Storage infrastructure (Phase 4)
     store_manager: StoreManager | None = None
     lifecycle_manager: LifecycleManager | None = None
+    relationship_manager: RelationshipManager | None = None
 
     # Additional context that may be needed
     domain_path: Path | None = None  # Path to domain directory

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -162,11 +162,29 @@ class RequestLifecycleTransitionTool(BaseTool):
             if cold_result is not None:
                 return cold_result
 
+        # Check if transition has a target_store for store migration
+        target_store = None
+        if lifecycle_manager and artifact_type:
+            lifecycle = lifecycle_manager.get_lifecycle(artifact_type)
+            if lifecycle:
+                target_store = lifecycle.get_transition_store(current_state, target_state)
+
         # Perform the transition
         try:
+            update_data: dict[str, Any] = {"_lifecycle_state": target_state}
+
+            # Include store migration if transition specifies target_store
+            if target_store:
+                current_store = artifact.get("_store", "workspace")
+                update_data["_store"] = target_store
+                logger.info(
+                    f"Store migration: {artifact_id} {current_store} -> {target_store} "
+                    f"(via transition to {target_state})"
+                )
+
             updated = self._context.project.update_artifact(
                 artifact_id=artifact_id,
-                data={"_lifecycle_state": target_state},
+                data=update_data,
             )
 
             if updated:
@@ -175,16 +193,23 @@ class RequestLifecycleTransitionTool(BaseTool):
                     f"(by {self._context.agent_id})"
                 )
 
+                result_data: dict[str, Any] = {
+                    "result": "committed",
+                    "artifact_id": artifact_id,
+                    "previous_state": current_state,
+                    "new_state": target_state,
+                    "transitioned": True,
+                    "transitioned_by": self._context.agent_id,
+                }
+
+                # Include store migration info if applicable
+                if target_store:
+                    result_data["previous_store"] = artifact.get("_store", "workspace")
+                    result_data["new_store"] = target_store
+
                 return ToolResult(
                     success=True,
-                    data={
-                        "result": "committed",
-                        "artifact_id": artifact_id,
-                        "previous_state": current_state,
-                        "new_state": target_state,
-                        "transitioned": True,
-                        "transitioned_by": self._context.agent_id,
-                    },
+                    data=result_data,
                 )
             else:
                 return ToolResult(

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -204,7 +204,7 @@ class RequestLifecycleTransitionTool(BaseTool):
 
                 # Include store migration info if applicable
                 if target_store:
-                    result_data["previous_store"] = artifact.get("_store", "workspace")
+                    result_data["previous_store"] = current_store
                     result_data["new_store"] = target_store
 
                 return ToolResult(

--- a/src/questfoundry/runtime/tools/registry.py
+++ b/src/questfoundry/runtime/tools/registry.py
@@ -25,7 +25,12 @@ from questfoundry.runtime.tools.base import (
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Agent, Studio, Tool
-    from questfoundry.runtime.storage import LifecycleManager, Project, StoreManager
+    from questfoundry.runtime.storage import (
+        LifecycleManager,
+        Project,
+        RelationshipManager,
+        StoreManager,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +121,7 @@ class ToolRegistry:
         interactive: bool = True,
         store_manager: StoreManager | None = None,
         lifecycle_manager: LifecycleManager | None = None,
+        relationship_manager: RelationshipManager | None = None,
     ):
         """
         Initialize tool registry.
@@ -128,6 +134,7 @@ class ToolRegistry:
             interactive: Whether running in interactive mode (disables human-input tools if False)
             store_manager: Store manager for artifact storage
             lifecycle_manager: Lifecycle manager for artifact state transitions
+            relationship_manager: Relationship manager for artifact relationships
         """
         self._studio = studio
         self._project = project
@@ -136,6 +143,7 @@ class ToolRegistry:
         self._interactive = interactive
         self._store_manager = store_manager
         self._lifecycle_manager = lifecycle_manager
+        self._relationship_manager = relationship_manager
         self._tool_cache: dict[str, BaseTool] = {}
 
     def get_tool_definition(self, tool_id: str) -> Tool | None:
@@ -192,6 +200,7 @@ class ToolRegistry:
             interactive=self._interactive,
             store_manager=self._store_manager,
             lifecycle_manager=self._lifecycle_manager,
+            relationship_manager=self._relationship_manager,
         )
 
         # Get implementation class

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -12,6 +12,7 @@ import uuid
 from enum import Enum
 from typing import Any
 
+from questfoundry.runtime.storage.edit_policy import EditPolicyGuard
 from questfoundry.runtime.tools.base import BaseTool, ToolResult
 from questfoundry.runtime.tools.registry import register_tool
 
@@ -799,9 +800,8 @@ class UpdateArtifactTool(BaseTool):
 
         # Check edit policy if managers are available
         policy_result = None
+        guard = None
         if self._context.lifecycle_manager and self._context.relationship_manager:
-            from questfoundry.runtime.storage.edit_policy import EditPolicyGuard
-
             guard = EditPolicyGuard(
                 self._context.lifecycle_manager,
                 self._context.relationship_manager,
@@ -829,9 +829,16 @@ class UpdateArtifactTool(BaseTool):
                 )
                 logger.debug(f"Saved version {version_saved} for {artifact_id}")
 
+            # Include demotion in the update data for atomicity
+            update_data = dict(data)
+            if policy_result and policy_result.demote_to_state:
+                update_data["_lifecycle_state"] = policy_result.demote_to_state
+                if policy_result.demote_to_store:
+                    update_data["_store"] = policy_result.demote_to_store
+
             updated = self._context.project.update_artifact(
                 artifact_id=artifact_id,
-                data=data,
+                data=update_data,
             )
 
             if updated:
@@ -842,17 +849,10 @@ class UpdateArtifactTool(BaseTool):
                 if version_saved is not None:
                     result_data["version_saved"] = version_saved
 
-                # Apply demotions if policy requires
-                if policy_result and self._context.lifecycle_manager:
-                    from questfoundry.runtime.storage.edit_policy import EditPolicyGuard
-
-                    guard = EditPolicyGuard(
-                        self._context.lifecycle_manager,
-                        self._context.relationship_manager,  # type: ignore[arg-type]
-                    )
-                    guard.apply_demotions(
+                # Apply cascade demotions to children (after parent update succeeds)
+                if policy_result and guard:
+                    guard.apply_cascade_demotions(
                         policy_result,
-                        existing,
                         self._context.project,
                         self._context.agent_id,
                     )
@@ -860,10 +860,6 @@ class UpdateArtifactTool(BaseTool):
                     # Add demotion info to result
                     if policy_result.demote_to_state:
                         result_data["demoted_to"] = policy_result.demote_to_state
-                        # Refresh artifact to get updated state
-                        refreshed = self._context.project.get_artifact(artifact_id)
-                        if refreshed:
-                            result_data["artifact"] = refreshed
 
                     if policy_result.cascade_demotions:
                         result_data["cascade_demotions"] = len(policy_result.cascade_demotions)

--- a/src/questfoundry/runtime/tools/save_artifact.py
+++ b/src/questfoundry/runtime/tools/save_artifact.py
@@ -748,6 +748,7 @@ class UpdateArtifactTool(BaseTool):
 
     Merges provided data with existing artifact data.
     Respects store semantics (blocks updates to cold/append_only stores).
+    Enforces lifecycle edit policies (allow/demote/disallow).
     """
 
     async def execute(self, args: dict[str, Any]) -> ToolResult:
@@ -796,6 +797,27 @@ class UpdateArtifactTool(BaseTool):
             if store and store.requires_version_history():
                 save_version = True
 
+        # Check edit policy if managers are available
+        policy_result = None
+        if self._context.lifecycle_manager and self._context.relationship_manager:
+            from questfoundry.runtime.storage.edit_policy import EditPolicyGuard
+
+            guard = EditPolicyGuard(
+                self._context.lifecycle_manager,
+                self._context.relationship_manager,
+            )
+            policy_result = guard.check_edit(existing, self._context.project)
+
+            if not policy_result.allowed:
+                return ToolResult(
+                    success=False,
+                    data={
+                        "artifact_id": artifact_id,
+                        "lifecycle_state": existing.get("_lifecycle_state"),
+                    },
+                    error=policy_result.reason or "Edit not allowed by lifecycle policy",
+                )
+
         # Update artifact
         try:
             # Save version history before update for versioned stores
@@ -813,12 +835,38 @@ class UpdateArtifactTool(BaseTool):
             )
 
             if updated:
-                result_data = {
+                result_data: dict[str, Any] = {
                     "artifact": updated,
                     "artifact_id": artifact_id,
                 }
                 if version_saved is not None:
                     result_data["version_saved"] = version_saved
+
+                # Apply demotions if policy requires
+                if policy_result and self._context.lifecycle_manager:
+                    from questfoundry.runtime.storage.edit_policy import EditPolicyGuard
+
+                    guard = EditPolicyGuard(
+                        self._context.lifecycle_manager,
+                        self._context.relationship_manager,  # type: ignore[arg-type]
+                    )
+                    guard.apply_demotions(
+                        policy_result,
+                        existing,
+                        self._context.project,
+                        self._context.agent_id,
+                    )
+
+                    # Add demotion info to result
+                    if policy_result.demote_to_state:
+                        result_data["demoted_to"] = policy_result.demote_to_state
+                        # Refresh artifact to get updated state
+                        refreshed = self._context.project.get_artifact(artifact_id)
+                        if refreshed:
+                            result_data["artifact"] = refreshed
+
+                    if policy_result.cascade_demotions:
+                        result_data["cascade_demotions"] = len(policy_result.cascade_demotions)
 
                 return ToolResult(
                     success=True,

--- a/tests/runtime/storage/test_edit_policy.py
+++ b/tests/runtime/storage/test_edit_policy.py
@@ -1,0 +1,501 @@
+"""Tests for edit policy enforcement."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from questfoundry.runtime.storage import Project
+from questfoundry.runtime.storage.edit_policy import EditPolicyGuard, EditPolicyResult
+from questfoundry.runtime.storage.lifecycle import (
+    ArtifactLifecycle,
+    LifecycleManager,
+    LifecyclePolicy,
+    LifecycleState,
+    LifecycleTransition,
+)
+from questfoundry.runtime.storage.relationship import (
+    ImpactPolicy,
+    Relationship,
+    RelationshipManager,
+)
+
+
+class TestEditPolicyResult:
+    """Tests for EditPolicyResult."""
+
+    def test_allowed_result(self):
+        """Create result that allows edit."""
+        result = EditPolicyResult(allowed=True)
+        assert result.allowed is True
+        assert result.reason is None
+        assert result.demote_to_state is None
+        assert result.demote_to_store is None
+        assert result.cascade_demotions is None
+
+    def test_disallowed_result(self):
+        """Create result that disallows edit."""
+        result = EditPolicyResult(
+            allowed=False,
+            reason="Artifact is in terminal state",
+        )
+        assert result.allowed is False
+        assert result.reason == "Artifact is in terminal state"
+
+    def test_allowed_with_demotion(self):
+        """Create result that allows edit but requires demotion."""
+        result = EditPolicyResult(
+            allowed=True,
+            demote_to_state="draft",
+            demote_to_store="workspace",
+            cascade_demotions=[
+                {
+                    "child_id": "section_002",
+                    "demote_to_state": "draft",
+                    "relationship_id": "section_from_brief",
+                }
+            ],
+        )
+        assert result.allowed is True
+        assert result.demote_to_state == "draft"
+        assert result.demote_to_store == "workspace"
+        assert len(result.cascade_demotions) == 1
+
+
+class TestEditPolicyGuard:
+    """Tests for EditPolicyGuard."""
+
+    @pytest.fixture
+    def lifecycle_manager(self):
+        """Create lifecycle manager with edit policies."""
+        manager = LifecycleManager()
+
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="review"),
+                LifecycleTransition(from_state="review", to_state="draft"),
+                LifecycleTransition(from_state="review", to_state="approved"),
+                LifecycleTransition(from_state="approved", to_state="cold"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["review", "approved"],
+                demote_target_state="draft",
+                demote_target_store="workspace",
+            ),
+        )
+        manager.register_lifecycle(section_lifecycle)
+
+        # brief - simpler policy (allow edits in all states)
+        brief_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section_brief",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="cold"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="allow",
+            ),
+        )
+        manager.register_lifecycle(brief_lifecycle)
+
+        # locked artifact type (disallow edits except draft)
+        locked_lifecycle = ArtifactLifecycle(
+            artifact_type_id="locked_doc",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "final": LifecycleState(id="final", name="Final", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="final"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="disallow",
+                demote_trigger_states=["final"],
+            ),
+        )
+        manager.register_lifecycle(locked_lifecycle)
+
+        return manager
+
+    @pytest.fixture
+    def relationship_manager(self):
+        """Create relationship manager with cascade policies."""
+        manager = RelationshipManager()
+
+        # section derives from section_brief - demote on parent edit
+        manager.register(
+            Relationship(
+                id="section_from_brief",
+                from_type="section_brief",
+                to_type="section",
+                kind="derived_from",
+                link_field="source_brief",
+                link_resolution="by_field_match",
+                match_field="id",
+                impact_policy=ImpactPolicy(
+                    on_parent_edit="demote",
+                    demote_target_store="workspace",
+                ),
+            )
+        )
+
+        return manager
+
+    @pytest.fixture
+    def project(self):
+        """Create a temporary project with test artifacts."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+
+            # Create test artifacts
+            project.create_artifact(
+                artifact_type="section",
+                data={"_id": "section_001", "title": "Draft Section"},
+                artifact_id="section_001",
+            )
+            project.update_artifact("section_001", {"_lifecycle_state": "draft"})
+
+            project.create_artifact(
+                artifact_type="section",
+                data={"_id": "section_002", "title": "Review Section"},
+                artifact_id="section_002",
+            )
+            project.update_artifact("section_002", {"_lifecycle_state": "review"})
+
+            project.create_artifact(
+                artifact_type="section",
+                data={"_id": "section_003", "title": "Cold Section"},
+                artifact_id="section_003",
+            )
+            project.update_artifact("section_003", {"_lifecycle_state": "cold"})
+
+            project.create_artifact(
+                artifact_type="section_brief",
+                data={"_id": "brief_001", "summary": "A brief"},
+                artifact_id="brief_001",
+            )
+            project.update_artifact("brief_001", {"_lifecycle_state": "draft"})
+
+            project.create_artifact(
+                artifact_type="locked_doc",
+                data={"_id": "locked_001", "content": "Locked content"},
+                artifact_id="locked_001",
+            )
+            project.update_artifact("locked_001", {"_lifecycle_state": "final"})
+
+            yield project
+            project.close()
+
+    @pytest.fixture
+    def guard(self, lifecycle_manager, relationship_manager):
+        """Create edit policy guard."""
+        return EditPolicyGuard(lifecycle_manager, relationship_manager)
+
+    def test_allow_edit_in_draft_state(self, guard, project):
+        """Edits allowed in draft state without demotion."""
+        artifact = project.get_artifact("section_001")
+        result = guard.check_edit(artifact, project)
+
+        assert result.allowed is True
+        assert result.demote_to_state is None  # Already draft
+
+    def test_demote_on_edit_in_review_state(self, guard, project):
+        """Edits in review state trigger demotion to draft."""
+        artifact = project.get_artifact("section_002")
+        result = guard.check_edit(artifact, project)
+
+        assert result.allowed is True
+        assert result.demote_to_state == "draft"
+        assert result.demote_to_store == "workspace"
+
+    def test_disallow_edit_in_terminal_state(self, guard, project):
+        """Edits disallowed in terminal state based on lifecycle policy."""
+        # For cold state, the lifecycle policy decides behavior
+        # The section lifecycle has demote policy, but cold is terminal
+        artifact = project.get_artifact("section_003")
+        result = guard.check_edit(artifact, project)
+
+        # Cold state is not in demote_trigger_states, so it's allowed (no demotion)
+        # unless the policy explicitly disallows it
+        assert result.allowed is True
+
+    def test_disallow_edit_in_locked_state(self, guard, project):
+        """Edits disallowed in disallow_edit_states."""
+        artifact = project.get_artifact("locked_001")
+        result = guard.check_edit(artifact, project)
+
+        # final state is in demote_trigger_states with edit_policy="disallow"
+        assert result.allowed is False
+        assert "not allowed" in result.reason.lower()
+
+    def test_no_type_allows_edit(self, guard, project):
+        """Artifacts without type allow edits (no lifecycle to check)."""
+        artifact = {"_id": "untyped_001", "content": "No type"}
+        result = guard.check_edit(artifact, project)
+
+        assert result.allowed is True
+
+    def test_unknown_type_allows_edit(self, guard, project):
+        """Unknown artifact types allow edits."""
+        artifact = {"_id": "unknown_001", "_type": "unknown_type", "_lifecycle_state": "draft"}
+        result = guard.check_edit(artifact, project)
+
+        assert result.allowed is True
+
+    def test_no_policy_allows_edit(self, guard, project):
+        """Artifact types without policy allow edits."""
+        artifact = project.get_artifact("brief_001")
+        result = guard.check_edit(artifact, project)
+
+        # brief has edit_policy="allow" so edits are always allowed
+        assert result.allowed is True
+
+
+class TestEditPolicyGuardCascades:
+    """Tests for cascade demotion via relationships."""
+
+    @pytest.fixture
+    def lifecycle_manager(self):
+        """Create lifecycle manager with cascade-aware types."""
+        manager = LifecycleManager()
+
+        # section_brief - parent type
+        brief_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section_brief",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="approved"),
+                LifecycleTransition(from_state="approved", to_state="cold"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["approved"],
+                demote_target_state="draft",
+            ),
+        )
+        manager.register_lifecycle(brief_lifecycle)
+
+        # section - child type
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="approved"),
+                LifecycleTransition(from_state="approved", to_state="cold"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["approved"],
+                demote_target_state="draft",
+            ),
+        )
+        manager.register_lifecycle(section_lifecycle)
+
+        return manager
+
+    @pytest.fixture
+    def relationship_manager(self):
+        """Create relationship manager with cascade policies."""
+        manager = RelationshipManager()
+
+        manager.register(
+            Relationship(
+                id="section_from_brief",
+                from_type="section_brief",
+                to_type="section",
+                kind="derived_from",
+                link_field="source_brief",
+                link_resolution="by_field_match",
+                match_field="id",
+                impact_policy=ImpactPolicy(
+                    on_parent_edit="demote",
+                    demote_target_store="workspace",
+                ),
+            )
+        )
+
+        return manager
+
+    @pytest.fixture
+    def project_with_hierarchy(self):
+        """Create project with parent-child artifacts."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+
+            # Parent brief
+            project.create_artifact(
+                artifact_type="section_brief",
+                data={"_id": "brief_001", "id": "brief_001", "summary": "A brief"},
+                artifact_id="brief_001",
+            )
+            project.update_artifact("brief_001", {"_lifecycle_state": "approved"})
+
+            # Child section linked to brief
+            project.create_artifact(
+                artifact_type="section",
+                data={
+                    "_id": "section_001",
+                    "title": "Child Section",
+                    "source_brief": "brief_001",  # Link to parent
+                },
+                artifact_id="section_001",
+            )
+            project.update_artifact("section_001", {"_lifecycle_state": "approved"})
+
+            # Another child section (in draft, should not be demoted)
+            project.create_artifact(
+                artifact_type="section",
+                data={
+                    "_id": "section_002",
+                    "title": "Draft Section",
+                    "source_brief": "brief_001",  # Link to same parent
+                },
+                artifact_id="section_002",
+            )
+            project.update_artifact("section_002", {"_lifecycle_state": "draft"})
+
+            # Unrelated section (different parent)
+            project.create_artifact(
+                artifact_type="section",
+                data={
+                    "_id": "section_003",
+                    "title": "Other Section",
+                    "source_brief": "brief_other",  # Different parent
+                },
+                artifact_id="section_003",
+            )
+            project.update_artifact("section_003", {"_lifecycle_state": "approved"})
+
+            yield project
+            project.close()
+
+    @pytest.fixture
+    def guard(self, lifecycle_manager, relationship_manager):
+        """Create edit policy guard."""
+        return EditPolicyGuard(lifecycle_manager, relationship_manager)
+
+    def test_cascade_demotes_children(self, guard, project_with_hierarchy):
+        """Editing parent triggers cascade demotion of children."""
+        parent = project_with_hierarchy.get_artifact("brief_001")
+        result = guard.check_edit(parent, project_with_hierarchy)
+
+        assert result.allowed is True
+        # Parent itself gets demoted
+        assert result.demote_to_state == "draft"
+
+        # Children in non-draft states get cascade demotion
+        assert result.cascade_demotions is not None
+        demoted_ids = [d["child_id"] for d in result.cascade_demotions]
+        # section_001 should be demoted (approved state)
+        assert "section_001" in demoted_ids
+        # section_002 is already draft, should not appear
+        assert "section_002" not in demoted_ids
+        # section_003 is unrelated (different parent)
+        assert "section_003" not in demoted_ids
+
+    def test_draft_parent_no_cascade(self, guard, project_with_hierarchy):
+        """Editing draft parent doesn't trigger cascade (already draft)."""
+        # First demote the parent to draft
+        project_with_hierarchy.update_artifact("brief_001", {"_lifecycle_state": "draft"})
+
+        parent = project_with_hierarchy.get_artifact("brief_001")
+        result = guard.check_edit(parent, project_with_hierarchy)
+
+        assert result.allowed is True
+        assert result.demote_to_state is None  # Already draft
+
+
+class TestApplyDemotions:
+    """Tests for applying demotion effects."""
+
+    @pytest.fixture
+    def lifecycle_manager(self):
+        """Create lifecycle manager."""
+        manager = LifecycleManager()
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="review"),
+                LifecycleTransition(from_state="review", to_state="draft"),
+            ],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["review"],
+                demote_target_state="draft",
+                demote_target_store="workspace",
+            ),
+        )
+        manager.register_lifecycle(section_lifecycle)
+        return manager
+
+    @pytest.fixture
+    def relationship_manager(self):
+        """Create empty relationship manager."""
+        return RelationshipManager()
+
+    @pytest.fixture
+    def project(self):
+        """Create project with artifact in review state."""
+        with TemporaryDirectory() as tmpdir:
+            project = Project.create(
+                path=Path(tmpdir) / "test_project",
+                name="Test Project",
+            )
+            project.create_artifact(
+                artifact_type="section",
+                data={"_id": "section_001", "title": "Review Section"},
+                artifact_id="section_001",
+            )
+            project.update_artifact("section_001", {"_lifecycle_state": "review"})
+            yield project
+            project.close()
+
+    def test_apply_self_demotion(self, lifecycle_manager, relationship_manager, project):
+        """Apply self-demotion to artifact."""
+        guard = EditPolicyGuard(lifecycle_manager, relationship_manager)
+        artifact = project.get_artifact("section_001")
+
+        result = guard.check_edit(artifact, project)
+        assert result.demote_to_state is not None
+
+        guard.apply_demotions(result, artifact, project, agent_id="scene_smith")
+
+        # Verify artifact was demoted
+        updated = project.get_artifact("section_001")
+        assert updated["_lifecycle_state"] == "draft"
+        assert updated.get("_store") == "workspace"

--- a/tests/runtime/storage/test_lifecycle.py
+++ b/tests/runtime/storage/test_lifecycle.py
@@ -412,3 +412,191 @@ class TestLifecycleManager:
         trans = lifecycle.get_transition("draft", "cold")
         assert trans is not None
         assert trans.is_agent_allowed("gatekeeper")
+
+
+class TestLifecyclePolicy:
+    """Tests for LifecyclePolicy dataclass."""
+
+    def test_from_dict_none(self):
+        """None data returns default policy."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        policy = LifecyclePolicy.from_dict(None)
+        assert policy.edit_policy == "allow"
+        assert policy.demote_trigger_states is None  # None means use default (all except initial)
+        assert policy.demote_target_state is None
+        assert policy.demote_target_store is None
+
+    def test_from_dict_minimal(self):
+        """Minimal dict uses defaults."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        policy = LifecyclePolicy.from_dict({})
+        assert policy.edit_policy == "allow"
+
+    def test_from_dict_demote_policy(self):
+        """Full demote policy from dict."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        policy = LifecyclePolicy.from_dict(
+            {
+                "edit_policy": "demote",
+                "demote_trigger_states": ["review", "approved"],
+                "demote_target_state": "draft",
+                "demote_target_store": "workspace",
+            }
+        )
+        assert policy.edit_policy == "demote"
+        assert policy.demote_trigger_states == ["review", "approved"]
+        assert policy.demote_target_state == "draft"
+        assert policy.demote_target_store == "workspace"
+
+    def test_from_dict_disallow_policy(self):
+        """Disallow policy from dict."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        policy = LifecyclePolicy.from_dict(
+            {
+                "edit_policy": "disallow",
+                "demote_trigger_states": ["final", "archived"],
+            }
+        )
+        assert policy.edit_policy == "disallow"
+        # demote_trigger_states are the states where edit_policy applies
+        assert policy.demote_trigger_states == ["final", "archived"]
+
+
+class TestArtifactLifecycleWithPolicy:
+    """Tests for ArtifactLifecycle with policy support."""
+
+    def test_get_edit_policy_no_policy(self):
+        """Get default edit policy when no policy set."""
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="test",
+            states={"draft": LifecycleState(id="draft", name="Draft")},
+            transitions=[],
+            initial_state="draft",
+        )
+        assert lifecycle.get_edit_policy("draft") == "allow"
+
+    def test_get_edit_policy_with_policy(self):
+        """Get edit policy from lifecycle policy."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="test",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+            },
+            transitions=[],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["review"],
+            ),
+        )
+        # draft is not a trigger state - returns allow
+        assert lifecycle.get_edit_policy("draft") == "allow"
+        # review is a trigger state - returns demote
+        assert lifecycle.get_edit_policy("review") == "demote"
+
+    def test_get_demote_target_with_policy(self):
+        """Get demotion target from policy."""
+        from questfoundry.runtime.storage.lifecycle import LifecyclePolicy
+
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="test",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+            },
+            transitions=[],
+            initial_state="draft",
+            policy=LifecyclePolicy(
+                edit_policy="demote",
+                demote_trigger_states=["review"],
+                demote_target_state="draft",
+                demote_target_store="workspace",
+            ),
+        )
+
+        # get_demote_target returns the policy's target, regardless of current state
+        state, store = lifecycle.get_demote_target()
+        assert state == "draft"
+        assert store == "workspace"
+
+
+class TestLifecycleTransitionWithTargetStore:
+    """Tests for transitions with target_store support."""
+
+    def test_transition_with_target_store(self):
+        """Create transition with target_store."""
+        trans = LifecycleTransition.from_dict(
+            {
+                "from": "approved",
+                "to": "cold",
+                "target_store": "manuscript",
+            }
+        )
+        assert trans.from_state == "approved"
+        assert trans.to_state == "cold"
+        assert trans.target_store == "manuscript"
+
+    def test_get_transition_store(self):
+        """Get target store for transition."""
+        lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+                "cold": LifecycleState(id="cold", name="Cold", terminal=True),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="approved"),
+                LifecycleTransition(
+                    from_state="approved",
+                    to_state="cold",
+                    target_store="manuscript",  # Store migration on cold transition
+                ),
+            ],
+            initial_state="draft",
+        )
+
+        # Transition with target_store
+        store = lifecycle.get_transition_store("approved", "cold")
+        assert store == "manuscript"
+
+        # Transition without target_store
+        store = lifecycle.get_transition_store("draft", "approved")
+        assert store is None
+
+        # Non-existent transition
+        store = lifecycle.get_transition_store("draft", "cold")
+        assert store is None
+
+    def test_from_dict_with_target_store(self):
+        """Load lifecycle with target_store from dict."""
+        data = {
+            "states": [
+                {"id": "draft", "name": "Draft"},
+                {"id": "cold", "name": "Cold", "terminal": True},
+            ],
+            "initial_state": "draft",
+            "transitions": [
+                {
+                    "from": "draft",
+                    "to": "cold",
+                    "target_store": "canon",
+                }
+            ],
+        }
+
+        lifecycle = ArtifactLifecycle.from_dict("test", data)
+        assert lifecycle is not None
+
+        trans = lifecycle.get_transition("draft", "cold")
+        assert trans.target_store == "canon"
+
+        store = lifecycle.get_transition_store("draft", "cold")
+        assert store == "canon"

--- a/tests/runtime/storage/test_relationship.py
+++ b/tests/runtime/storage/test_relationship.py
@@ -1,0 +1,290 @@
+"""Tests for relationship management."""
+
+import pytest
+
+from questfoundry.runtime.storage.relationship import (
+    ImpactPolicy,
+    Relationship,
+    RelationshipManager,
+)
+
+
+class TestImpactPolicy:
+    """Tests for ImpactPolicy dataclass."""
+
+    def test_from_dict_none(self):
+        """None data returns default policy."""
+        policy = ImpactPolicy.from_dict(None)
+        assert policy.on_parent_edit == "none"
+        assert policy.on_parent_delete == "orphan"
+        assert policy.demote_target_store is None
+
+    def test_from_dict_minimal(self):
+        """Minimal dict uses defaults."""
+        policy = ImpactPolicy.from_dict({})
+        assert policy.on_parent_edit == "none"
+        assert policy.on_parent_delete == "orphan"
+
+    def test_from_dict_full(self):
+        """Full dict creates complete policy."""
+        policy = ImpactPolicy.from_dict(
+            {
+                "on_parent_edit": "demote",
+                "on_parent_delete": "cascade_delete",
+                "demote_target_store": "workspace",
+            }
+        )
+        assert policy.on_parent_edit == "demote"
+        assert policy.on_parent_delete == "cascade_delete"
+        assert policy.demote_target_store == "workspace"
+
+
+class TestRelationship:
+    """Tests for Relationship dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Create relationship with minimal data."""
+        rel = Relationship.from_dict(
+            {
+                "id": "section_from_brief",
+                "from_type": "section_brief",
+                "to_type": "section",
+                "kind": "derived_from",
+                "link_field": "source_brief",
+            }
+        )
+        assert rel.id == "section_from_brief"
+        assert rel.from_type == "section_brief"
+        assert rel.to_type == "section"
+        assert rel.kind == "derived_from"
+        assert rel.link_field == "source_brief"
+        assert rel.link_resolution == "by_field_match"  # Default
+        assert rel.match_field is None
+        assert rel.impact_policy is not None  # Default policy
+
+    def test_from_dict_full(self):
+        """Create relationship with full data."""
+        rel = Relationship.from_dict(
+            {
+                "id": "section_from_brief",
+                "name": "Section from Brief",
+                "description": "Sections are derived from briefs",
+                "from_type": "section_brief",
+                "to_type": "section",
+                "kind": "derived_from",
+                "link_field": "source_brief",
+                "link_resolution": "by_field_match",
+                "match_field": "id",
+                "impact_policy": {
+                    "on_parent_edit": "demote",
+                    "on_parent_delete": "orphan",
+                    "demote_target_store": "workspace",
+                },
+            }
+        )
+        assert rel.name == "Section from Brief"
+        assert rel.description == "Sections are derived from briefs"
+        assert rel.link_resolution == "by_field_match"
+        assert rel.match_field == "id"
+        assert rel.impact_policy.on_parent_edit == "demote"
+
+    def test_from_dict_with_by_artifact_id(self):
+        """Create relationship with by_artifact_id resolution."""
+        rel = Relationship.from_dict(
+            {
+                "id": "entry_from_ref",
+                "from_type": "reference_doc",
+                "to_type": "codex_entry",
+                "kind": "derived_from",
+                "link_field": "_parent_id",
+                "link_resolution": "by_artifact_id",
+            }
+        )
+        assert rel.link_resolution == "by_artifact_id"
+
+
+class TestRelationshipManager:
+    """Tests for RelationshipManager."""
+
+    @pytest.fixture
+    def manager(self):
+        """Create manager with test relationships."""
+        manager = RelationshipManager()
+
+        # section derives from section_brief
+        section_from_brief = Relationship(
+            id="section_from_brief",
+            from_type="section_brief",
+            to_type="section",
+            kind="derived_from",
+            link_field="source_brief",
+            link_resolution="by_field_match",
+            match_field="id",
+            impact_policy=ImpactPolicy(on_parent_edit="demote"),
+        )
+        manager.register(section_from_brief)
+
+        # codex_entry derives from canon_pack
+        codex_from_canon = Relationship(
+            id="codex_from_canon",
+            from_type="canon_pack",
+            to_type="codex_entry",
+            kind="derived_from",
+            link_field="_parent_id",
+            link_resolution="by_artifact_id",
+            impact_policy=ImpactPolicy(on_parent_edit="flag_stale"),
+        )
+        manager.register(codex_from_canon)
+
+        return manager
+
+    def test_empty_manager(self):
+        """Empty manager has no relationships."""
+        manager = RelationshipManager()
+        assert manager.get_relationship("nonexistent") is None
+        assert manager.get_relationships_from_type("section") == []
+        assert manager.get_relationships_to_type("section") == []
+
+    def test_register_and_get(self, manager):
+        """Register and retrieve relationship."""
+        rel = manager.get_relationship("section_from_brief")
+        assert rel is not None
+        assert rel.from_type == "section_brief"
+        assert rel.to_type == "section"
+
+    def test_get_relationships_from_type(self, manager):
+        """Get relationships where type is parent."""
+        rels = manager.get_relationships_from_type("section_brief")
+        assert len(rels) == 1
+        assert rels[0].id == "section_from_brief"
+
+        rels = manager.get_relationships_from_type("canon_pack")
+        assert len(rels) == 1
+        assert rels[0].id == "codex_from_canon"
+
+        rels = manager.get_relationships_from_type("unknown")
+        assert len(rels) == 0
+
+    def test_get_relationships_to_type(self, manager):
+        """Get relationships where type is child."""
+        rels = manager.get_relationships_to_type("section")
+        assert len(rels) == 1
+        assert rels[0].id == "section_from_brief"
+
+        rels = manager.get_relationships_to_type("codex_entry")
+        assert len(rels) == 1
+        assert rels[0].id == "codex_from_canon"
+
+    def test_list_relationships(self, manager):
+        """List all registered relationships."""
+        all_rels = manager.list_relationships()
+        assert len(all_rels) == 2
+        ids = {r.id for r in all_rels}
+        assert ids == {"section_from_brief", "codex_from_canon"}
+
+    def test_has_relationship(self, manager):
+        """Check relationship existence via get."""
+        assert manager.get_relationship("section_from_brief") is not None
+        assert manager.get_relationship("codex_from_canon") is not None
+        assert manager.get_relationship("nonexistent") is None
+
+    def test_register_from_dicts(self):
+        """Create manager by registering relationships from dicts."""
+        defs = [
+            {
+                "id": "section_from_brief",
+                "from_type": "section_brief",
+                "to_type": "section",
+                "kind": "derived_from",
+                "link_field": "source_brief",
+            },
+            {
+                "id": "codex_from_canon",
+                "from_type": "canon_pack",
+                "to_type": "codex_entry",
+                "kind": "derived_from",
+                "link_field": "_parent_id",
+            },
+        ]
+
+        manager = RelationshipManager()
+        for d in defs:
+            manager.register(Relationship.from_dict(d))
+
+        assert manager.get_relationship("section_from_brief") is not None
+        assert manager.get_relationship("codex_from_canon") is not None
+
+
+class TestRelationshipManagerCascadeQueries:
+    """Tests for cascade policy queries."""
+
+    @pytest.fixture
+    def manager_with_cascades(self):
+        """Create manager with various cascade policies."""
+        manager = RelationshipManager()
+
+        # Demote children on parent edit
+        manager.register(
+            Relationship(
+                id="section_from_brief",
+                from_type="section_brief",
+                to_type="section",
+                kind="derived_from",
+                link_field="source_brief",
+                link_resolution="by_field_match",
+                match_field="id",
+                impact_policy=ImpactPolicy(
+                    on_parent_edit="demote",
+                    demote_target_store="workspace",
+                ),
+            )
+        )
+
+        # Flag stale on parent edit
+        manager.register(
+            Relationship(
+                id="codex_from_canon",
+                from_type="canon_pack",
+                to_type="codex_entry",
+                kind="derived_from",
+                link_field="_parent_id",
+                link_resolution="by_artifact_id",
+                impact_policy=ImpactPolicy(on_parent_edit="flag_stale"),
+            )
+        )
+
+        # No action on parent edit
+        manager.register(
+            Relationship(
+                id="note_references",
+                from_type="note",
+                to_type="comment",
+                kind="references",
+                link_field="note_id",
+                link_resolution="by_field_match",
+                match_field="_id",
+                impact_policy=ImpactPolicy(on_parent_edit="none"),
+            )
+        )
+
+        return manager
+
+    def test_get_cascade_targets_demote(self, manager_with_cascades):
+        """Get relationships that demote on parent edit."""
+        rels = manager_with_cascades.get_relationships_from_type("section_brief")
+        demote_rels = [r for r in rels if r.impact_policy.on_parent_edit == "demote"]
+        assert len(demote_rels) == 1
+        assert demote_rels[0].to_type == "section"
+
+    def test_get_cascade_targets_flag_stale(self, manager_with_cascades):
+        """Get relationships that flag stale on parent edit."""
+        rels = manager_with_cascades.get_relationships_from_type("canon_pack")
+        stale_rels = [r for r in rels if r.impact_policy.on_parent_edit == "flag_stale"]
+        assert len(stale_rels) == 1
+        assert stale_rels[0].to_type == "codex_entry"
+
+    def test_get_cascade_targets_none(self, manager_with_cascades):
+        """Relationships with none policy don't cascade."""
+        rels = manager_with_cascades.get_relationships_from_type("note")
+        none_rels = [r for r in rels if r.impact_policy.on_parent_edit == "none"]
+        assert len(none_rels) == 1

--- a/tests/runtime/tools/test_lifecycle_transition.py
+++ b/tests/runtime/tools/test_lifecycle_transition.py
@@ -939,6 +939,108 @@ class TestColdTransitionWithStoreMigration:
         assert "StoreManager not available" in result.error
 
 
+class TestTransitionWithTargetStore:
+    """Tests for transitions that specify target_store for automatic store migration."""
+
+    @pytest.fixture
+    def lifecycle_manager_with_store_migration(self):
+        """Create lifecycle manager with target_store on transitions."""
+        manager = LifecycleManager()
+
+        section_lifecycle = ArtifactLifecycle(
+            artifact_type_id="section",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "review": LifecycleState(id="review", name="Review"),
+                "approved": LifecycleState(id="approved", name="Approved"),
+            },
+            transitions=[
+                LifecycleTransition(from_state="draft", to_state="review"),
+                LifecycleTransition(
+                    from_state="review",
+                    to_state="approved",
+                    target_store="archive",  # Move to archive on approval
+                ),
+            ],
+            initial_state="draft",
+        )
+        manager.register_lifecycle(section_lifecycle)
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_transition_migrates_to_target_store(
+        self, mock_project, lifecycle_manager_with_store_migration
+    ):
+        """Transition with target_store updates both state and store."""
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=mock_project,
+            agent_id="scene_smith",
+            lifecycle_manager=lifecycle_manager_with_store_migration,
+        )
+        mock_project.artifacts["section_001"]["_lifecycle_state"] = "review"
+        mock_project.artifacts["section_001"]["_store"] = "workspace"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "approved",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["new_state"] == "approved"
+        assert result.data["new_store"] == "archive"
+        assert result.data["previous_store"] == "workspace"
+
+        # Verify artifact was updated
+        artifact = mock_project.artifacts["section_001"]
+        assert artifact["_lifecycle_state"] == "approved"
+        assert artifact["_store"] == "archive"
+
+    @pytest.mark.asyncio
+    async def test_transition_without_target_store_no_migration(
+        self, mock_project, lifecycle_manager_with_store_migration
+    ):
+        """Transition without target_store doesn't change store."""
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=mock_project,
+            agent_id="scene_smith",
+            lifecycle_manager=lifecycle_manager_with_store_migration,
+        )
+        mock_project.artifacts["section_001"]["_lifecycle_state"] = "draft"
+        mock_project.artifacts["section_001"]["_store"] = "workspace"
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "section_001",
+                "target_state": "review",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["new_state"] == "review"
+        # No store migration for this transition
+        assert "new_store" not in result.data
+
+        # Verify store unchanged
+        artifact = mock_project.artifacts["section_001"]
+        assert artifact["_store"] == "workspace"
+
+
 class TestDirectGatecheckToColdTransition:
     """Tests for direct gatecheck → cold transition (Phase 4)."""
 


### PR DESCRIPTION
## Summary

Implements runtime policy enforcement as specified in issue #253 (Epic 2). This enables the runtime to enforce lifecycle policies and artifact relationships.

**Key changes:**
- **LifecyclePolicy**: Added `edit_policy`, `demote_trigger_states`, `demote_target_state`, and `demote_target_store` to control how artifacts behave when edited in certain states
- **RelationshipManager**: New component to manage artifact relationships with cascade policies (on_parent_edit: none/flag_stale/demote)
- **EditPolicyGuard**: Enforces edit policies by checking artifact state and computing required demotions (including cascade demotions for related children)
- **UpdateArtifactTool integration**: Edit policy checks run before content updates
- **target_store on transitions**: Lifecycle transitions can now specify a target store for automatic store migration
- **Full runtime wiring**: RelationshipManager is initialized from domain and passed through to ToolContext

**Domain configuration:**
- `domain-v4/relationships/section_from_brief.json` - Section derives from brief
- `domain-v4/relationships/codex_from_canon.json` - Codex entry derives from canon pack

**Test coverage:**
- test_lifecycle.py: LifecyclePolicy, target_store on transitions
- test_relationship.py: Relationship, ImpactPolicy, RelationshipManager
- test_edit_policy.py: EditPolicyResult, EditPolicyGuard, cascade demotions
- test_lifecycle_transition.py: target_store migration tests

## Test plan
- [x] All 1018 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, markdownlint)
- [x] Verified runtime wiring (RelationshipManager flows from AgentRuntime → ToolRegistry → ToolContext)

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)