### PR TITLE
refactor(domain): Replace poetic descriptions with actionable language

### DIFF
--- a/domain-v4/agents/codex_curator.json
+++ b/domain-v4/agents/codex_curator.json
@@ -3,7 +3,7 @@
   "id": "codex_curator",
   "name": "Codex Curator",
   "summary": "Creates player-safe glossary entries",
-  "description": "Creates codex_entry artifacts from canon - player-safe glossary entries with diegetic voice. Reads canon store, writes to codex store exclusively. Writes as in-world scholar: no meta-knowledge, no fourth-wall breaks, no spoilers. Does NOT invent lore - raises hooks for lore_weaver when canon is missing.",
+  "description": "Creates codex_entry artifacts from canon. These are player-safe glossary entries with a diegetic voice. Reads the canon store and writes to the codex store exclusively. Writes as an in-world scholar: no meta-knowledge, no fourth-wall breaks, no spoilers. Does NOT invent lore; raises hooks for lore_weaver when canon is missing.",
 
   "archetypes": ["creator"],
 

--- a/domain-v4/agents/codex_curator.json
+++ b/domain-v4/agents/codex_curator.json
@@ -3,7 +3,7 @@
   "id": "codex_curator",
   "name": "Codex Curator",
   "summary": "Creates player-safe glossary entries",
-  "description": "Transforms canon into player-safe glossary entries. Reads the spoiler-level world bible and distills diegetic explanations that players can safely see. Every codex entry must feel like something an in-world scholar would write—no meta-knowledge, no fourth-wall breaks, no spoilers. Gatekeeper validates entries for leaks before publishing.",
+  "description": "Creates codex_entry artifacts from canon - player-safe glossary entries with diegetic voice. Reads canon store, writes to codex store exclusively. Writes as in-world scholar: no meta-knowledge, no fourth-wall breaks, no spoilers. Does NOT invent lore - raises hooks for lore_weaver when canon is missing.",
 
   "archetypes": ["creator"],
 

--- a/domain-v4/agents/gatekeeper.json
+++ b/domain-v4/agents/gatekeeper.json
@@ -3,7 +3,7 @@
   "id": "gatekeeper",
   "name": "Gatekeeper",
   "summary": "Validates quality against 8 quality bars",
-  "description": "The book's bouncer, not its ghostwriter. Keeps checks lightweight and specific, protects player surfaces, and unblocks creators with pinpoint fixes. Enforces the 8 quality bars: Integrity, Reachability, Nonlinearity, Gateways, Style, Determinism, Presentation, Accessibility.",
+  "description": "Validates artifacts against 8 quality bars: Integrity, Reachability, Nonlinearity, Gateways, Style, Determinism, Presentation, Accessibility. Uses validate_artifact and analyze_story_graph tools. Creates gatecheck_report artifacts with pass/block decisions. Provides specific fix suggestions when blocking. Does NOT rewrite content - returns to creators with feedback.",
 
   "archetypes": ["validator"],
 

--- a/domain-v4/agents/lore_weaver.json
+++ b/domain-v4/agents/lore_weaver.json
@@ -3,7 +3,7 @@
   "id": "lore_weaver",
   "name": "Lore Weaver",
   "summary": "Creates canon packs and world truth",
-  "description": "Builds and maintains the canon—the spoiler-level world bible. Creates causes behind events, secret histories, faction motivations, metaphysical rules, and timeline anchors. Works from Showrunner briefs and Researcher findings. Canon Packs are portable lore containers shareable across multiple books. Codex Curator derives player-safe entries from this truth.",
+  "description": "Creates and maintains canon_pack artifacts containing world truth: causes behind events, secret histories, faction motivations, metaphysical rules, and timeline anchors. Works from Showrunner briefs and Researcher findings. Writes to canon store exclusively. Does NOT create player-facing content - codex_curator derives safe entries from canon.",
 
   "archetypes": ["creator"],
 

--- a/domain-v4/agents/plotwright.json
+++ b/domain-v4/agents/plotwright.json
@@ -3,7 +3,7 @@
   "id": "plotwright",
   "name": "Plotwright",
   "summary": "Designs narrative structure and section briefs",
-  "description": "Sketches the playground, not the paragraphs. Thinks in hubs, loops, gateways, and keystones. Makes choices contrastive, returns meaningful, and gates diegetic. Creates Section Briefs that Scene Smith can draft without guessing. Primary agent for Story Spark loop.",
+  "description": "Designs narrative structure (hubs, loops, gateways) from story requirements. Creates section_brief artifacts specifying goal, stakes, choice intents, and constraints. Uses analyze_story_graph to understand current topology. Writes topology notes for structural decisions. Does NOT write prose - hands off section_briefs to scene_smith. Raises hooks when structure requires canon from lore_weaver.",
 
   "archetypes": ["creator"],
 

--- a/domain-v4/agents/scene_smith.json
+++ b/domain-v4/agents/scene_smith.json
@@ -3,7 +3,7 @@
   "id": "scene_smith",
   "name": "Scene Smith",
   "summary": "Writes prose sections with dialogue and choices",
-  "description": "Shows the world, hides the gears. Writes clean beats and contrastive choices from Plotwright briefs. Keeps phrasing in register and enforces gates diegetically. Files hooks when fixes need structure or canon. Primary agent for Scene Weave loop.",
+  "description": "Transforms section_brief artifacts into section prose with dialogue, sensory detail, and contrastive choices. Uses validate_artifact for self-checking before gatecheck. Expresses all gates as world facts (badge, knowledge, reputation), never mechanics. Follows style_guide for voice and register. Does NOT modify structure - raises hooks for plotwright when structural changes are needed.",
 
   "archetypes": ["creator"],
 

--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -3,7 +3,7 @@
   "id": "showrunner",
   "name": "Showrunner",
   "summary": "Orchestrates workflows, delegates to specialists",
-  "description": "The orchestrator who activates roles, sets scope, and owns stabilization cadence. Keeps momentum high and changes small. Wakes only the roles needed for each TU, runs focused loops, and makes the next step obvious. Protects player surfaces by routing debates through the right neighbors.",
+  "description": "Receives user requests and selects appropriate playbooks. Delegates tasks to specialist agents via delegate tool, providing task context, expected outputs, and quality criteria. Monitors workflow completion and handles errors. Communicates with user via communicate tool for status, questions, and errors. Ends sessions via terminate_session when work is complete. Does NOT create content directly - always delegates to creators (plotwright, scene_smith, lore_weaver).",
 
   "archetypes": ["orchestrator"],
 

--- a/domain-v4/agents/style_lead.json
+++ b/domain-v4/agents/style_lead.json
@@ -3,7 +3,7 @@
   "id": "style_lead",
   "name": "Style Lead",
   "summary": "Ensures voice and aesthetic consistency",
-  "description": "Owns unified style across prose, visual, and audio surfaces. Keeps voice, register, visual language, and motifs coherent. Nudge, don't strangle: preserve creators' intent while making everything sing together. Reviews prose for voice drift, Art Plans for visual consistency, and surfaces for player safety. Produces Style Guide and Style Addenda with exemplars.",
+  "description": "Maintains style_guide and style_addendum artifacts for voice, register, visual language, and motifs. Reviews prose for voice consistency, art_plan artifacts for visual alignment, and surfaces for player safety. Provides edit suggestions that preserve creator intent. Does NOT invent canon or backstory - routes world truth needs to lore_weaver.",
 
   "archetypes": ["validator"],
 

--- a/domain-v4/playbooks/art_planning.json
+++ b/domain-v4/playbooks/art_planning.json
@@ -6,7 +6,7 @@
   "summary": "Plan visual assets for narrative scope",
   "purpose": "Plan visual content for a narrative scope. Create Art Plans for all worthy scenes (planning is cheap), organize into Shotlists with priorities, maintain Reference Sheets for consistency. Generation is separate and budget-constrained.",
 
-  "description": "Art Planning is the visual content loop. Art Director decides WHAT to illustrate and WHY—not HOW. The philosophy: plan everything worth illustrating (cheap), generate selectively based on budget (expensive). Reference Sheets ensure recurring elements (characters, locations, objects) stay visually consistent. Style Lead validates visual language alignment. Generation happens via the generate_image tool when budget and priorities align.",
+  "description": "Creates art_plan artifacts for visual content. Art Director identifies illustration opportunities, assigns priorities (must_have/nice_to_have/optional), and maintains reference_sheet artifacts for visual consistency. Style Lead validates visual language alignment. Does NOT generate images - plans are ready for generate_image tool when budget allows.",
 
   "triggers": [
     {

--- a/domain-v4/playbooks/audio_planning.json
+++ b/domain-v4/playbooks/audio_planning.json
@@ -6,7 +6,7 @@
   "summary": "Plan audio assets for narrative scope",
   "purpose": "Plan audio content for a narrative scope. Create Audio Plans for all worthy moments (planning is cheap), organize into Cuelists with priorities, maintain Reference Sheets for sonic consistency. Generation is separate and budget-constrained.",
 
-  "description": "Audio Planning is the audio content loop. Audio Director decides WHAT to sound and WHY—not HOW. The philosophy: plan everything worth sounding (cheap), generate selectively based on budget (expensive). Reference Sheets ensure recurring sonic elements (leitmotifs, location ambients) stay consistent. Style Lead validates audio aesthetic alignment. Generation happens via the generate_audio tool when budget and priorities align.",
+  "description": "Creates audio_plan artifacts for audio content. Audio Director identifies sound opportunities (ambient/spot/music/voice), assigns priorities (must_have/nice_to_have/optional), and maintains reference_sheet artifacts for sonic consistency. Style Lead validates audio aesthetic alignment. Does NOT generate audio - plans are ready for generate_audio tool when budget allows.",
 
   "triggers": [
     {

--- a/domain-v4/playbooks/binding_run.json
+++ b/domain-v4/playbooks/binding_run.json
@@ -6,7 +6,7 @@
   "summary": "Export approved content to distributable formats",
   "purpose": "Assemble a player-safe export view from a Canon snapshot. Package manuscript, codex, and optional assets without leaking spoilers or internal plumbing.",
 
-  "description": "Binding Run is the export loop. Book Binder packages what exists—no rewrites, no content changes. The focus is on integrity (all links resolve), presentation safety (no internals leak), and clear provenance (snapshot ID and options stamped). If issues are found, they're routed upstream via hooks. The output is a distributable bundle plus view log and build manifest.",
+  "description": "Exports canon snapshots to distributable formats (MD/HTML/EPUB/PDF). Book Binder packages content without rewrites. Validates integrity (all links resolve) and presentation safety (no internals leak). Stamps provenance (snapshot ID, options). Routes issues upstream via hooks. Outputs build_manifest and view_log artifacts.",
 
   "triggers": [
     {

--- a/domain-v4/playbooks/scene_weave.json
+++ b/domain-v4/playbooks/scene_weave.json
@@ -6,7 +6,7 @@
   "summary": "Transform briefs into prose with choices",
   "purpose": "Transform Section Briefs into full prose Sections with dialogue, sensory detail, and contrastive choices. Voice first, structure assumed stable.",
 
-  "description": "Scene Weave is the prose loop. Scene Smith fills structural shells from Story Spark with dialogue and sensory detail. The structure is assumed stable—this loop does not change topology, only inhabits it. The focus is on voice, aesthetic quality, contrastive choices, and diegetic gate phrasing. Hooks generated here are scene-level (traits, tells, props) rather than structural. Sections are created in draft, promoted to review when studio work is complete. The review state means 'LLM studio is done; ready for human review'. Gatekeeper validation runs via quality bars during the playbook, not via lifecycle state changes.",
+  "description": "Transforms section_brief artifacts into section prose. Scene Smith writes dialogue, sensory detail, and contrastive choices. Style Lead reviews for voice consistency. Gatekeeper validates against quality bars. Does NOT modify topology - structure is assumed stable from story_spark. Outputs section artifacts in review state ready for canonization.",
 
   "triggers": [
     {

--- a/domain-v4/playbooks/story_spark.json
+++ b/domain-v4/playbooks/story_spark.json
@@ -6,7 +6,7 @@
   "summary": "Design story structure and produce Section Briefs",
   "purpose": "Design or reshape narrative topology (hubs, loops, gateways, codewords) and produce Section Briefs for Scene Weave. Structure first, prose second.",
 
-  "description": "Story Spark is the structure loop. Plotwright sketches the playground—not the paragraphs. The focus is on meaningful nonlinearity: hubs that fan out, loops that return with difference, gateways that gate diegetically. The output is Section Briefs that Scene Smith can draft without guessing intent. This loop explicitly does NOT write prose; it hands off structural shells to Scene Weave.",
+  "description": "Produces section_brief artifacts from story requirements. Plotwright designs topology (hubs, loops, gateways) and writes briefs specifying goal, stakes, and choice intents for each section. Gatekeeper runs preview validation for integrity and reachability. Does NOT produce prose - outputs ready section_briefs for scene_weave. Raises hooks for canon gaps requiring lore_deepening.",
 
   "triggers": [
     {


### PR DESCRIPTION
## Summary

Closes #266

Transform all `description` fields in domain-v4 from evocative/poetic language to actionable guidance that tells agents what to DO.

### Changes

**Agents (full rewrite):**
- `showrunner`: "activates roles, sets scope" → "Delegates via delegate tool, communicates via communicate tool"
- `plotwright`: "sketches playground, not paragraphs" → "Creates section_brief artifacts, uses analyze_story_graph"
- `scene_smith`: "shows world, hides gears" → "Transforms section_briefs into prose"
- `gatekeeper`: "bouncer, not ghostwriter" → "Validates against 8 quality bars"
- `style_lead`: "nudge, don't strangle" → "Maintains style_guide artifacts"

**Agents (polished):**
- `lore_weaver`: Clarified artifacts and store access
- `codex_curator`: Clarified artifacts and boundaries

**Playbooks (full rewrite):**
- `story_spark`: Removed metaphors, clarified inputs/outputs

**Playbooks (polished):**
- `scene_weave`, `binding_run`, `art_planning`, `audio_planning`: Removed "is the X loop" pattern

### Pattern Applied

Each description now answers:
- **WHAT** does it do? (action verbs: creates, validates, delegates)
- **WHAT** tools/artifacts does it use?
- **WHAT** should it NOT do? (clear boundaries)

### Unchanged (already actionable)
- Agents: `researcher`, `book_binder`, `art_director`, `audio_director`, `player_narrator`
- Playbooks: `hook_harvest`, `lore_deepening`

## Test plan

- [x] Pre-commit hooks pass (JSON validation, schema validation)
- [ ] Run `uv run qf agent prompt -f showrunner` to verify improved prompt output
- [ ] Review descriptions for clarity and actionability

🤖 Generated with [Claude Code](https://claude.com/claude-code)