### PR TITLE
feat(265): Prompt quick wins - tool summaries, agent roles, delegation protocol

### DIFF
--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -140,7 +140,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["runtime_guidelines_core", "story_building_workflow"],
+    "must_know": ["runtime_guidelines_core", "story_building_workflow", "delegation_protocol"],
     "should_know": ["spoiler_hygiene", "sources_of_truth", "quality_bars_overview", "showrunner_operating_principles", "runtime_guidelines"],
     "role_specific": []
   },

--- a/domain-v4/knowledge/must_know/delegation_protocol.json
+++ b/domain-v4/knowledge/must_know/delegation_protocol.json
@@ -152,7 +152,7 @@
   },
 
   "applicable_to": {
-    "archetypes": ["creator", "validator", "researcher", "performer"]
+    "archetypes": ["orchestrator", "creator", "validator", "researcher", "performer"]
   },
 
   "tags": ["runtime", "delegation", "handoff", "protocol"]

--- a/domain-v4/tools/analyze_story_graph.json
+++ b/domain-v4/tools/analyze_story_graph.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "analyze_story_graph",
   "name": "Analyze Story Graph",
+  "summary": "Analyze narrative structure topology",
   "description": "Programmatically analyzes story topology to check reachability, dead ends, orphans, missing targets, and lifecycle status. Provides concrete data for structural analysis without requiring LLM reasoning about graph structure.\n\nChecks:\n1. Reachability - Can all nodes be reached from entry?\n2. Dead ends - Nodes with no outgoing connections\n3. Orphans - Nodes with no incoming connections (except entry)\n4. Missing targets - References to non-existent nodes\n5. Lifecycle status - What state are the paths in?\n\nReturns structured analysis with actionable recommendations.",
 
   "summarization_policy": "preserve",

--- a/domain-v4/tools/assemble_export.json
+++ b/domain-v4/tools/assemble_export.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "assemble_export",
   "name": "Assemble Export",
+  "summary": "Build export bundle from canon snapshot",
   "description": "Assemble a player-safe export bundle from a Canon snapshot. Compiles manuscript, codex, and optional assets into distributable formats (MD/HTML/EPUB/PDF). Validates link integrity, generates navigation, and stamps front matter.\n\nThis tool does NOT edit content - it packages what exists. If integrity issues are found, they're reported for upstream fixes.",
 
   "summarization_policy": "preserve",

--- a/domain-v4/tools/communicate.json
+++ b/domain-v4/tools/communicate.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "communicate",
   "name": "Communicate with Customer",
+  "summary": "Send messages to customer or ask questions",
   "description": "Send a message to the human customer.\n\nMessage types:\n- status: Brief progress update (non-blocking)\n- question: Need input from customer (blocks until answered)\n- notification: Deliverable ready or milestone reached (non-blocking)\n- error: Something failed or needs attention (may block depending on severity)",
 
   "terminates_turn": true,

--- a/domain-v4/tools/consult_corpus.json
+++ b/domain-v4/tools/consult_corpus.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "consult_corpus",
   "name": "Consult Corpus",
+  "summary": "Search craft guidance in the corpus",
   "description": "Access the craft corpus for writing guidance and genre conventions. Supports multiple modes:\n\n- **toc**: Get table of contents listing all corpus files\n- **file**: Retrieve full content of a specific file\n- **cluster**: Browse files in a cluster (genre-conventions, prose-and-language, etc.)\n- **search**: Search for relevant excerpts (default mode)\n\nUse this for prose techniques, choice architecture, genre conventions, and craft guidance.",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/consult_knowledge.json
+++ b/domain-v4/tools/consult_knowledge.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "consult_knowledge",
   "name": "Consult Knowledge",
+  "summary": "Retrieve full content of a knowledge entry",
   "description": "Retrieve detailed guidance from the studio knowledge base. Use this when you need full content for entries shown in your Knowledge Menu.\n\nThe Knowledge Menu in your system prompt shows summaries of available knowledge. Use this tool to get the complete content when you need detailed guidance, examples, or procedures.\n\nCommon uses:\n- Get detailed examples when summary is insufficient\n- Retrieve full procedures or checklists\n- Access domain-specific guidance for specialized tasks",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/consult_playbook.json
+++ b/domain-v4/tools/consult_playbook.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "consult_playbook",
   "name": "Consult Playbook",
+  "summary": "Get full details of a playbook",
   "description": "Retrieve full details for a playbook/workflow. Returns the sequence of phases and steps, which agents handle each step, input/output artifacts, completion criteria, and quality checkpoints. Use this to understand how a workflow should be orchestrated.",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/consult_schema.json
+++ b/domain-v4/tools/consult_schema.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "consult_schema",
   "name": "Consult Schema",
+  "summary": "Get the JSON schema for an artifact type",
   "description": "Retrieve the schema definition for an artifact type. Returns the field definitions, validation rules, and lifecycle states for the specified artifact type. Use this to understand the structure of artifacts before creating or validating them.\n\nPattern: consult-schema - agent asks for schema, gets both structure and documentation.",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/delegate.json
+++ b/domain-v4/tools/delegate.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "delegate",
   "name": "Delegate Work",
+  "summary": "Assign work to another agent",
   "description": "Assign work to another agent. Creates a delegation request with context, expected outputs, and quality criteria. The receiving agent will be notified and can accept, request clarification, or report completion.\n\nSee: delegation.schema.json for the full delegation protocol.",
 
   "terminates_turn": true,

--- a/domain-v4/tools/generate_audio.json
+++ b/domain-v4/tools/generate_audio.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "generate_audio",
   "name": "Generate Audio",
+  "summary": "Generate audio from a plan",
   "description": "Generate an audio asset from an Audio Plan. Consults Style Guide for sonic aesthetic. Returns an audio asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Audio Plans should exist for ALL worthy moments, but generation is selective based on priority.\n\nRuntime provides implementation (TTS, music generation, sound library, commission queue, etc.).",
 
   "cost_tier": "high",

--- a/domain-v4/tools/generate_image.json
+++ b/domain-v4/tools/generate_image.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "generate_image",
   "name": "Generate Image",
+  "summary": "Generate an image from a plan",
   "description": "Generate an illustration from an Art Plan. Consults Reference Sheets for visual consistency of recurring elements (characters, locations, objects). Returns an image asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Art Plans should exist for ALL worthy scenes, but generation is selective based on priority.\n\nRuntime provides implementation (DALL-E, Stable Diffusion, commission queue, etc.).",
 
   "cost_tier": "high",

--- a/domain-v4/tools/get_artifact.json
+++ b/domain-v4/tools/get_artifact.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "get_artifact",
   "name": "Get Artifact",
+  "summary": "Retrieve an artifact by ID",
   "description": "Retrieve artifacts by ID. Use this to fetch specific artifacts when you know their IDs. Accepts a single ID or list of IDs.\n\nUse search_workspace instead if you need to find artifacts by criteria (type, lifecycle state, text search).",
 
   "summarization_policy": "concise",

--- a/domain-v4/tools/list_agents.json
+++ b/domain-v4/tools/list_agents.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "list_agents",
   "name": "List Agents",
+  "summary": "List available agents and their capabilities",
   "description": "List all agents available for delegation. Use this to discover what specialist agents exist and their archetypes before delegating work. Returns a compact list with id, name, archetypes, and brief description.",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/list_artifact_types.json
+++ b/domain-v4/tools/list_artifact_types.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "list_artifact_types",
   "name": "List Artifact Types",
+  "summary": "List available artifact types",
   "description": "List all available artifact types with brief descriptions. Use this to discover what artifact types exist before consulting their full schemas. Returns a compact list with id, name, category, and brief description for each type.",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/list_stores.json
+++ b/domain-v4/tools/list_stores.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "list_stores",
   "name": "List Stores",
+  "summary": "List available stores and access levels",
   "description": "List all available stores with their semantics and descriptions. Use this to discover what stores exist and understand their access patterns (hot, cold, versioned, ephemeral).",
 
   "summarization_policy": "drop",

--- a/domain-v4/tools/request_lifecycle_transition.json
+++ b/domain-v4/tools/request_lifecycle_transition.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "request_lifecycle_transition",
   "name": "Request Lifecycle Transition",
+  "summary": "Request a lifecycle state change for an artifact",
   "description": "Request a lifecycle state transition for an artifact (draft→review→approved→cold). Uses the validate-with-feedback pattern: strict schema validation and clear, actionable error messages when a request is invalid or a transition is not allowed.",
 
   "summarization_policy": "preserve",

--- a/domain-v4/tools/return_to_orchestrator.json
+++ b/domain-v4/tools/return_to_orchestrator.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "return_to_orchestrator",
   "name": "Return to Orchestrator",
+  "summary": "Signal task completion and return control",
   "description": "Signal task completion and return control to the orchestrator. Use this when your delegated work is complete, blocked, or needs orchestrator decision.\n\nProvide a summary, quality assessment, and recommended next action. The orchestrator will receive this information and decide next steps.",
 
   "terminates_turn": true,

--- a/domain-v4/tools/search_workspace.json
+++ b/domain-v4/tools/search_workspace.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "search_workspace",
   "name": "Search Workspace",
+  "summary": "Search for artifacts in the workspace",
   "description": "Search for artifacts in the Hot SoT (workspace store). Supports filtering by artifact type, lifecycle state, and text search within fields. Returns matching artifacts with their current state.\n\nUse this to find:\n- Drafts in progress\n- Section briefs ready for implementation\n- Hooks awaiting triage\n- Related artifacts for context",
 
   "summarization_policy": "concise",

--- a/domain-v4/tools/terminate_session.json
+++ b/domain-v4/tools/terminate_session.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "terminate_session",
   "name": "Terminate Session",
+  "summary": "End the session when all work is complete",
   "description": "End the current session. Use when:\n- All requested work is complete\n- User explicitly requests session end\n- Unrecoverable error prevents further progress\n\nUnlike communicate and delegate which yield control temporarily, this tool ends the session permanently.",
   "terminates_turn": true,
   "terminates_session": true,

--- a/domain-v4/tools/validate_artifact.json
+++ b/domain-v4/tools/validate_artifact.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "validate_artifact",
   "name": "Validate Artifact",
+  "summary": "Check an artifact against quality criteria",
   "description": "Validate an artifact against its type schema and the 8 quality bars. Returns validation results with specific errors and suggested fixes.\n\nQuality Bars checked:\n1. Integrity - No contradictions or dead links\n2. Reachability - Critical content accessible\n3. Nonlinearity - Branches matter\n4. Gateways - Conditions enforceable\n5. Style - Voice consistent\n6. Determinism - Reproducible where promised\n7. Presentation - Spoiler-safe\n8. Accessibility - Navigation clear\n\nPattern: validate-with-feedback - strict validation, clear rejection messages with remediation guidance.",
 
   "summarization_policy": "preserve",

--- a/domain-v4/tools/web_fetch.json
+++ b/domain-v4/tools/web_fetch.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "web_fetch",
   "name": "Web Fetch",
+  "summary": "Fetch content from a URL",
   "description": "Fetch and extract content from a specific URL. Returns cleaned text content from the page, suitable for reading and analysis. Handles HTML cleanup, removes navigation/ads, and extracts main content.\n\nBest for: deep-diving a specific source, reading full articles, extracting detailed information.\nFor discovering sources, use web_search first.",
 
   "summarization_policy": "concise",

--- a/domain-v4/tools/web_search.json
+++ b/domain-v4/tools/web_search.json
@@ -2,6 +2,7 @@
   "$schema": "../../meta/schemas/core/tool-definition.schema.json",
   "id": "web_search",
   "name": "Web Search",
+  "summary": "Search the web for information",
   "description": "Search the web for factual information. Returns a list of relevant results with titles, snippets, and URLs. Use this to find sources for verification, corroborate claims, or discover current information.\n\nBest for: broad queries, finding multiple sources, discovering what exists.\nFor deep-diving a specific page, use web_fetch instead.",
 
   "summarization_policy": "concise",

--- a/meta/schemas/core/tool-definition.schema.json
+++ b/meta/schemas/core/tool-definition.schema.json
@@ -23,6 +23,11 @@
       "description": "What this tool does - included in LLM context to help it decide when to use the tool"
     },
 
+    "summary": {
+      "$ref": "_definitions.schema.json#/$defs/summary",
+      "description": "Concise one-liner for prompt injection. Use description for full explanation."
+    },
+
     "cost_tier": {
       "type": "string",
       "enum": ["low", "medium", "high", "external"],

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -518,6 +518,7 @@ class ContextBuilder:
                 {
                     "id": target_agent.id,
                     "name": target_agent.name,
+                    "summary": target_agent.summary or "",
                     "description": target_agent.description or "",
                     "archetypes": archetypes,
                     "specialties": specialties,

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -251,7 +251,11 @@ class PromptBuilder:
             if category not in by_category:
                 by_category[category] = []
 
-            desc = cap.description or cap.name
+            # Include tool_ref when available so agent knows which tool to call
+            if cap.tool_ref:
+                desc = f"{cap.description or cap.name} (`{cap.tool_ref}`)"
+            else:
+                desc = cap.description or cap.name
             by_category[category].append(desc)
 
         for category, caps in by_category.items():

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -304,26 +304,26 @@ class PromptBuilder:
         Details available via list_agents() or consulting agent charters.
 
         Args:
-            agents: List of agent menu items with id, name, description, archetypes, specialties
+            agents: List of agent menu items with id, name, summary, description, archetypes, specialties
 
         Returns:
             Compact formatted agents section for the prompt
         """
         lines = ["## Available Agents for Delegation\n"]
-        lines.append("| Agent | Archetype | Specialty |")
-        lines.append("|-------|-----------|-----------|")
+        lines.append("| Agent | Archetype | Role |")
+        lines.append("|-------|-----------|------|")
 
         for ag in agents:
             name = ag.get("name", ag.get("id", "Unknown"))
             archetypes = ag.get("archetypes", [])
             archetypes_str = ", ".join(archetypes[:2]) if archetypes else "general"
-            # Use summary (preferred) or fall back to first specialty
-            specialties = ag.get("specialties", [])
-            spec = ag.get("summary") or (specialties[0] if specialties else "")
-            lines.append(f"| {name} | {archetypes_str} | {spec} |")
+            # Use summary for role description
+            role = ag.get("summary", "")
+            lines.append(f"| {name} | {archetypes_str} | {role} |")
 
         lines.append("")
         lines.append("Use `delegate(to_agent, task, expected_outputs)` to assign work.")
+        lines.append("Use `list_agents()` for full agent details.")
 
         return "\n".join(lines)
 

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -348,9 +348,9 @@ class PromptBuilder:
 
         for tool in tool_schemas:
             name = tool.get("name", "unknown")
-            # Use summary if available, otherwise first sentence of description
+            # Use summary if available, otherwise first line of description
             raw_desc = tool.get("description", "") or ""
-            desc = tool.get("summary") or (raw_desc.split(".")[0] + "." if raw_desc else "")
+            desc = tool.get("summary") or raw_desc.split("\n")[0]
             lines.append(f"- **{name}**: {desc}")
 
         return "\n".join(lines)

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -344,8 +344,9 @@ class PromptBuilder:
 
         for tool in tool_schemas:
             name = tool.get("name", "unknown")
-            # Use first line of description (no truncation - keep domain data short instead)
-            desc = (tool.get("description", "") or "").split("\n")[0]
+            # Use summary if available, otherwise first sentence of description
+            raw_desc = tool.get("description", "") or ""
+            desc = tool.get("summary") or (raw_desc.split(".")[0] + "." if raw_desc else "")
             lines.append(f"- **{name}**: {desc}")
 
         return "\n".join(lines)

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -192,6 +192,7 @@ class Agent(BaseModel):
 
     id: str
     name: str
+    summary: str | None = None
     description: str | None = None
     # Archetypes are flexible strings - domains can extend beyond base archetypes
     # Base archetypes: orchestrator, creator, validator, researcher, curator


### PR DESCRIPTION
## Summary
Implements 4 quick-win issues from #265 to improve prompt clarity:

- **#268** - Add `summary` field to tools for clean prompt injection (no more mid-sentence truncation)
- **#269** - Agents table shows role summaries instead of tool names
- **#270** - Add `delegation_protocol` to Showrunner's must_know knowledge
- **#271** - Capabilities display shows `tool_ref` so agents know which tool to call

## Changes

### Commit 1: Tool summaries (#268)
- Added `summary` field to tool schema
- Updated prompt builder to use summary instead of truncating description
- Added concise summaries to all 21 tools

### Commit 2: Agent role summaries (#269)
- Added `summary` field to Agent model (matches schema)
- Context builder now passes agent summary to delegation menu
- Table header changed from "Specialty" to "Role"
- Added hint about `list_agents()` for details

### Commit 3: Delegation protocol (#270)
- Added `delegation_protocol` to Showrunner's must_know
- Added `orchestrator` to delegation_protocol applicable archetypes

### Commit 4: Tool ref in capabilities (#271)
- Capabilities with tool_ref now show tool name in backticks

## Before/After

**Tools (before):** `Terminate Session: End the current session. Use when:`
**Tools (after):** `Terminate Session: End the session when all work is complete`

**Agents (before):** `| Gatekeeper | validator | Validate Artifact Tool |`
**Agents (after):** `| Gatekeeper | validator | Enforces quality gates on all artifacts |`

**Capabilities (before):** `- Search Workspace`
**Capabilities (after):** `- Search Workspace (\`search_workspace\`)`

## Test plan
- [x] All 1018 tests pass
- [x] Pre-commit checks pass
- [x] JSON schemas validate
- [ ] Manual: `uv run qf agent prompt -f showrunner` shows cleaner output

Closes #268, #269, #270, #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)