### PR TITLE
fix(domain): Improve tool descriptions and add artifact model knowledge (#272, #273)

### DIFF
--- a/domain-v4/agents/art_director.json
+++ b/domain-v4/agents/art_director.json
@@ -147,7 +147,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene"],
+    "must_know": ["spoiler_hygiene", "artifact_model"],
     "should_know": ["quality_bars_overview", "sources_of_truth"],
     "role_specific": ["art_director_heuristics_core"],
     "can_lookup": ["accessibility_guidelines"]

--- a/domain-v4/agents/audio_director.json
+++ b/domain-v4/agents/audio_director.json
@@ -130,7 +130,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene"],
+    "must_know": ["spoiler_hygiene", "artifact_model"],
     "should_know": ["quality_bars_overview", "sources_of_truth"],
     "role_specific": ["audio_director_heuristics_core"],
     "can_lookup": ["accessibility_guidelines"]

--- a/domain-v4/agents/book_binder.json
+++ b/domain-v4/agents/book_binder.json
@@ -131,7 +131,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["sources_of_truth", "spoiler_hygiene"],
+    "must_know": ["sources_of_truth", "spoiler_hygiene", "artifact_model"],
     "should_know": ["quality_bars_overview"],
     "role_specific": ["book_binder_procedures", "export_patterns"],
     "can_lookup": ["accessibility_guidelines"]

--- a/domain-v4/agents/codex_curator.json
+++ b/domain-v4/agents/codex_curator.json
@@ -114,7 +114,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene"],
+    "must_know": ["spoiler_hygiene", "artifact_model"],
     "should_know": ["sources_of_truth", "quality_bars_overview"],
     "role_specific": ["codex_curator_guidelines"],
     "can_lookup": ["accessibility_guidelines"]

--- a/domain-v4/agents/gatekeeper.json
+++ b/domain-v4/agents/gatekeeper.json
@@ -148,7 +148,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["quality_bars_overview", "spoiler_hygiene"],
+    "must_know": ["quality_bars_overview", "spoiler_hygiene", "artifact_model"],
     "should_know": ["sources_of_truth"],
     "role_specific": ["gatekeeper_heuristics"]
   }

--- a/domain-v4/agents/lore_weaver.json
+++ b/domain-v4/agents/lore_weaver.json
@@ -114,7 +114,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene"],
+    "must_know": ["spoiler_hygiene", "artifact_model"],
     "should_know": ["quality_bars_overview", "sources_of_truth"],
     "role_specific": ["lore_weaver_procedures"]
   }

--- a/domain-v4/agents/player_narrator.json
+++ b/domain-v4/agents/player_narrator.json
@@ -126,7 +126,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["diegetic_gates", "spoiler_hygiene"],
+    "must_know": ["diegetic_gates", "spoiler_hygiene", "artifact_model"],
     "should_know": ["sources_of_truth"],
     "role_specific": ["player_narrator_heuristics_core"]
   }

--- a/domain-v4/agents/plotwright.json
+++ b/domain-v4/agents/plotwright.json
@@ -121,7 +121,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["choice_integrity"],
+    "must_know": ["choice_integrity", "artifact_model"],
     "should_know": ["diegetic_gates", "topology_patterns", "quality_bars_overview", "sources_of_truth"],
     "role_specific": ["plotwright_heuristics"]
   }

--- a/domain-v4/agents/researcher.json
+++ b/domain-v4/agents/researcher.json
@@ -115,7 +115,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["sources_of_truth", "spoiler_hygiene"],
+    "must_know": ["sources_of_truth", "spoiler_hygiene", "artifact_model"],
     "should_know": ["quality_bars_overview"],
     "role_specific": ["researcher_heuristics", "posture_definitions"]
   }

--- a/domain-v4/agents/scene_smith.json
+++ b/domain-v4/agents/scene_smith.json
@@ -137,7 +137,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene"],
+    "must_know": ["spoiler_hygiene", "artifact_model"],
     "should_know": ["choice_integrity", "diegetic_gates", "quality_bars_overview", "sources_of_truth"],
     "role_specific": ["scene_smith_heuristics", "prose_patterns"]
   }

--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -140,7 +140,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["runtime_guidelines_core", "story_building_workflow", "delegation_protocol"],
+    "must_know": ["runtime_guidelines_core", "story_building_workflow", "delegation_protocol", "artifact_model"],
     "should_know": ["spoiler_hygiene", "sources_of_truth", "quality_bars_overview", "showrunner_operating_principles", "runtime_guidelines"],
     "role_specific": []
   },

--- a/domain-v4/agents/style_lead.json
+++ b/domain-v4/agents/style_lead.json
@@ -154,7 +154,7 @@
 
   "knowledge_requirements": {
     "constitution": true,
-    "must_know": ["spoiler_hygiene", "choice_integrity"],
+    "must_know": ["spoiler_hygiene", "choice_integrity", "artifact_model"],
     "should_know": ["sources_of_truth", "quality_bars_overview"],
     "role_specific": ["style_lead_heuristics"],
     "can_lookup": ["accessibility_guidelines"]

--- a/domain-v4/knowledge/must_know/artifact_model.json
+++ b/domain-v4/knowledge/must_know/artifact_model.json
@@ -49,6 +49,16 @@
             "Stable across lifecycle transitions",
             "Must be included in return_to_orchestrator calls"
           ]
+        },
+        {
+          "term": "approved",
+          "meaning": "Lifecycle state indicating an artifact has passed quality gates and is ready for canon commitment.",
+          "distinguishing_features": [
+            "Reached via: draft → review → approved",
+            "Gatekeeper validates before this transition",
+            "Next transition is to 'cold' (canon commitment)",
+            "Can still be edited if issues found before cold"
+          ]
         }
       ],
       "rules": [

--- a/domain-v4/knowledge/must_know/artifact_model.json
+++ b/domain-v4/knowledge/must_know/artifact_model.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "artifact_model",
+  "name": "Artifact Model",
+  "layer": "must_know",
+
+  "summary": "What artifacts are and how they flow through the studio",
+
+  "keywords": ["artifact", "artifact type", "stores", "lifecycle", "versioning", "artifact ID"],
+
+  "triggers": [
+    "what is an artifact",
+    "how to create artifacts",
+    "artifact IDs",
+    "passing work between agents",
+    "artifact lifecycle"
+  ],
+
+  "content": {
+    "type": "structured",
+    "format": "json",
+    "schema_ref": "knowledge/structured-content.schema.json#/$defs/structured_entry",
+    "data": {
+      "definitions": [
+        {
+          "term": "artifact",
+          "meaning": "A versioned JSON object representing work product. Each artifact has an ID, type, lifecycle state, and content fields.",
+          "distinguishing_features": [
+            "Created by agents, stored in stores (workspace, canon)",
+            "Has lifecycle: draft → review → approved → cold",
+            "Referenced by ID (e.g., 'section_abc123')",
+            "Validated against its artifact type schema"
+          ]
+        },
+        {
+          "term": "artifact_type",
+          "meaning": "A schema defining what fields an artifact contains and how it behaves.",
+          "distinguishing_features": [
+            "Defines required and optional fields",
+            "Specifies lifecycle states and transitions",
+            "Examples: section, hook_card, research_memo, codex_entry"
+          ]
+        },
+        {
+          "term": "artifact_id",
+          "meaning": "Unique identifier for an artifact instance. Format: {type}_{random_suffix}",
+          "distinguishing_features": [
+            "Used to fetch, reference, and pass artifacts between agents",
+            "Stable across lifecycle transitions",
+            "Must be included in return_to_orchestrator calls"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "statement": "Always include artifact IDs when returning to orchestrator",
+          "enforcement": "llm",
+          "severity": "critical",
+          "reasoning": "The orchestrator needs IDs to pass your work to the next agent. Without IDs, workflow breaks."
+        },
+        {
+          "statement": "Use search_workspace to find artifacts, get_artifact to fetch by ID",
+          "enforcement": "llm",
+          "severity": "warning",
+          "reasoning": "Search for discovery, fetch for retrieval. Don't guess IDs."
+        }
+      ],
+      "procedures": [
+        {
+          "goal": "Pass work between agents via delegation",
+          "steps": [
+            "Create artifacts in workspace",
+            "Note artifact IDs from creation responses",
+            "Include IDs in return_to_orchestrator call",
+            "Orchestrator passes IDs to next delegated agent"
+          ]
+        }
+      ],
+      "warnings": [
+        {
+          "failure_mode": "Referring to artifacts by description instead of ID",
+          "consequence": "Next agent cannot find your work",
+          "prevention": "Always capture and pass artifact IDs"
+        }
+      ]
+    }
+  },
+
+  "applicable_to": {
+    "archetypes": ["orchestrator", "creator", "validator", "researcher", "curator"]
+  },
+
+  "related_entries": ["lifecycle_contract", "delegation_protocol", "sources_of_truth"],
+
+  "tags": ["runtime", "artifacts", "core-concept"]
+}

--- a/domain-v4/tools/communicate.json
+++ b/domain-v4/tools/communicate.json
@@ -3,7 +3,7 @@
   "id": "communicate",
   "name": "Communicate with Customer",
   "summary": "Send messages to customer or ask questions",
-  "description": "Send a message to the human customer.\n\nMessage types:\n- status: Brief progress update (non-blocking)\n- question: Need input from customer (blocks until answered)\n- notification: Deliverable ready or milestone reached (non-blocking)\n- error: Something failed or needs attention (may block depending on severity)",
+  "description": "Communicate with the human customer - send updates, ask questions, or report errors.\n\nMessage types and behavior:\n- status: Non-blocking progress update - you continue working\n- notification: Non-blocking milestone or event announcement\n- question: BLOCKING - you wait for customer response before proceeding\n- error: Report problems - may require customer decision\n\nUse this when you need to report progress, request input, or escalate decisions.",
 
   "terminates_turn": true,
   "summarization_policy": "preserve",

--- a/domain-v4/tools/communicate.json
+++ b/domain-v4/tools/communicate.json
@@ -3,7 +3,7 @@
   "id": "communicate",
   "name": "Communicate with Customer",
   "summary": "Send messages to customer or ask questions",
-  "description": "Communicate with the human customer - send updates, ask questions, or report errors.\n\nMessage types and behavior:\n- status: Non-blocking progress update - you continue working\n- notification: Non-blocking milestone or event announcement\n- question: BLOCKING - you wait for customer response before proceeding\n- error: Report problems - may require customer decision\n\nUse this when you need to report progress, request input, or escalate decisions.",
+  "description": "Communicate with the human customer - send updates, ask questions, or report errors.\n\nALL message types terminate your turn. The difference is whether the runtime waits for a response:\n- status: Progress update - runtime continues immediately\n- notification: Milestone announcement - runtime continues immediately\n- question: Waits for customer response before resuming\n- error: May wait for customer decision depending on severity\n\nUse this when you need to report progress, request input, or escalate decisions.",
 
   "terminates_turn": true,
   "summarization_policy": "preserve",

--- a/domain-v4/tools/delegate.json
+++ b/domain-v4/tools/delegate.json
@@ -3,7 +3,7 @@
   "id": "delegate",
   "name": "Delegate Work",
   "summary": "Assign work to another agent",
-  "description": "Assign work to another agent. Creates a delegation request with context, expected outputs, and quality criteria. The receiving agent will be notified and can accept, request clarification, or report completion.\n\nSee: delegation.schema.json for the full delegation protocol.",
+  "description": "Delegate work to another agent. This hands off control until the agent completes the task.\n\nProvide:\n- task: Clear description of what needs to be done\n- context: Relevant artifact IDs and background\n- expected_outputs: What artifacts should be produced\n- quality_criteria: How to judge completion quality\n\nThe receiving agent executes the work and returns control via return_to_orchestrator with artifact IDs and assessment.\n\nThis tool TERMINATES YOUR TURN - you yield control and resume when the agent returns.",
 
   "terminates_turn": true,
   "summarization_policy": "ultra_concise",

--- a/domain-v4/tools/get_artifact.json
+++ b/domain-v4/tools/get_artifact.json
@@ -3,7 +3,7 @@
   "id": "get_artifact",
   "name": "Get Artifact",
   "summary": "Retrieve an artifact by ID",
-  "description": "Retrieve artifacts by ID. Use this to fetch specific artifacts when you know their IDs. Accepts a single ID or list of IDs.\n\nUse search_workspace instead if you need to find artifacts by criteria (type, lifecycle state, text search).",
+  "description": "Retrieve one or more artifacts by ID. Returns the current version from workspace or canon stores.\n\nAccepts a single ID or list of IDs. Use search_workspace instead to find artifacts by criteria (type, lifecycle state, content search).",
 
   "summarization_policy": "concise",
   "summary_template": "Retrieved {count} artifact(s)",

--- a/domain-v4/tools/request_lifecycle_transition.json
+++ b/domain-v4/tools/request_lifecycle_transition.json
@@ -3,7 +3,7 @@
   "id": "request_lifecycle_transition",
   "name": "Request Lifecycle Transition",
   "summary": "Request a lifecycle state change for an artifact",
-  "description": "Request a lifecycle state transition for an artifact (draft→review→approved→cold). Uses the validate-with-feedback pattern: strict schema validation and clear, actionable error messages when a request is invalid or a transition is not allowed.",
+  "description": "Request a lifecycle state transition for an artifact. Transitions follow the path: draft → review → approved → cold.\n\nNot all agents can request all transitions - the runtime validates permissions and artifact state. Transitions to 'cold' (canon commitment) require Lorekeeper approval.\n\nReturns success or actionable error messages explaining what's required.",
 
   "summarization_policy": "preserve",
 

--- a/domain-v4/tools/request_lifecycle_transition.json
+++ b/domain-v4/tools/request_lifecycle_transition.json
@@ -3,7 +3,7 @@
   "id": "request_lifecycle_transition",
   "name": "Request Lifecycle Transition",
   "summary": "Request a lifecycle state change for an artifact",
-  "description": "Request a lifecycle state transition for an artifact. Transitions follow the path: draft → review → approved → cold.\n\nNot all agents can request all transitions - the runtime validates permissions and artifact state. Transitions to 'cold' (canon commitment) require Lorekeeper approval.\n\nReturns success or actionable error messages explaining what's required.",
+  "description": "Request a lifecycle state transition for an artifact. Transitions follow the path: draft → review → approved → cold.\n\nNot all agents can request all transitions - the runtime validates permissions and artifact state. Transitions to 'cold' (canon commitment) require Gatekeeper approval.\n\nReturns success or actionable error messages explaining what's required.",
 
   "summarization_policy": "preserve",
 

--- a/domain-v4/tools/return_to_orchestrator.json
+++ b/domain-v4/tools/return_to_orchestrator.json
@@ -3,7 +3,7 @@
   "id": "return_to_orchestrator",
   "name": "Return to Orchestrator",
   "summary": "Signal task completion and return control",
-  "description": "Signal task completion and return control to the orchestrator. Use this when your delegated work is complete, blocked, or needs orchestrator decision.\n\nProvide a summary, quality assessment, and recommended next action. The orchestrator will receive this information and decide next steps.",
+  "description": "Signal that your delegated task is complete and return control to the orchestrator.\n\nYou MUST include:\n- summary: What you accomplished\n- result_assessment: pass/partial/fail/skip/info\n- recommendation: proceed/rework/escalate/hold\n- artifacts_produced: List of artifact IDs you created (CRITICAL for workflow continuity)\n\nWithout artifact IDs, the orchestrator cannot pass your work to the next agent.",
 
   "terminates_turn": true,
   "summarization_policy": "ultra_concise",

--- a/domain-v4/tools/return_to_orchestrator.json
+++ b/domain-v4/tools/return_to_orchestrator.json
@@ -3,7 +3,7 @@
   "id": "return_to_orchestrator",
   "name": "Return to Orchestrator",
   "summary": "Signal task completion and return control",
-  "description": "Signal that your delegated task is complete and return control to the orchestrator.\n\nYou MUST include:\n- summary: What you accomplished\n- result_assessment: pass/partial/fail/skip/info\n- recommendation: proceed/rework/escalate/hold\n- artifacts_produced: List of artifact IDs you created (CRITICAL for workflow continuity)\n\nWithout artifact IDs, the orchestrator cannot pass your work to the next agent.",
+  "description": "Signal that your delegated task is complete and return control to the orchestrator.\n\nRequired fields:\n- summary: What you accomplished\n- result_assessment: pass/partial/fail/skip/info\n- recommendation: proceed/rework/escalate/hold\n\nIf you created or updated artifacts, include artifacts_produced with their IDs. This is CRITICAL for workflow continuity - without IDs, the orchestrator cannot pass your work to the next agent.",
 
   "terminates_turn": true,
   "summarization_policy": "ultra_concise",


### PR DESCRIPTION
## Summary

- **#272**: Improved tool descriptions for semantic clarity
  - Removed internal implementation details ("validate-with-feedback pattern")
  - Clarified actors (who grants transitions, who approves)
  - Distinguished blocking vs non-blocking behavior
  - Explained hand-off semantics (terminates turn)
  - Emphasized CRITICAL artifact ID handoff

- **#273**: Added artifact model knowledge entry
  - Created `artifact_model.json` explaining what artifacts are and how they flow
  - Added to all 12 agents' `must_know`

## Files Changed

**#272 - Tool Descriptions:**
- `domain-v4/tools/request_lifecycle_transition.json`
- `domain-v4/tools/communicate.json`
- `domain-v4/tools/delegate.json`
- `domain-v4/tools/get_artifact.json`
- `domain-v4/tools/return_to_orchestrator.json`

**#273 - Artifact Model:**
- `domain-v4/knowledge/must_know/artifact_model.json` (new)
- All 12 agent files (added artifact_model to must_know)

## Test plan

- [x] Pre-commit checks pass
- [x] All 1018 tests pass
- [ ] `uv run qf agent prompt -f showrunner` shows improved tool descriptions
- [ ] Artifact model appears in agent prompts

Closes #272
Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)