### PR TITLE
feat(domain,runtime): Add few-shot examples for archetypes (#275)

### DIFF
--- a/domain-v4/knowledge/must_know/creator_examples.json
+++ b/domain-v4/knowledge/must_know/creator_examples.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "creator_examples",
+  "name": "Creator Few-Shot Examples",
+  "layer": "must_know",
+
+  "summary": "Complete creation cycle examples for creator agents",
+
+  "keywords": ["create", "save", "artifact", "return", "prose", "content"],
+
+  "triggers": [
+    "how to create artifacts",
+    "creation example",
+    "save artifact",
+    "return to orchestrator"
+  ],
+
+  "content": {
+    "type": "structured",
+    "format": "json",
+    "schema_ref": "knowledge/structured-content.schema.json#/$defs/structured_entry",
+    "data": {
+      "procedures": [
+        {
+          "goal": "Complete a creation cycle",
+          "steps": [
+            "Step 1 - Fetch input artifact: get_artifact('SB-001')",
+            "Step 2 - Read the brief to understand requirements (beats, tone, constraints)",
+            "Step 3 - Create content following the brief",
+            "Step 4 - Save artifact: save_artifact(artifact_type='section', data={'title': 'The Arrival', 'content': '...prose...', 'brief_ref': 'SB-001'})",
+            "Step 5 - Note artifact ID from response: {\"artifact_id\": \"section-001\", \"status\": \"created\"}",
+            "Step 6 - Return to orchestrator: return_to_orchestrator(summary='Created section from brief SB-001', result_assessment='pass', recommendation='proceed', artifacts_produced=['section-001'])"
+          ],
+          "preconditions": [
+            "Received delegation with artifact_refs containing input brief"
+          ],
+          "postconditions": [
+            "Artifact saved to workspace",
+            "Artifact ID returned to orchestrator"
+          ]
+        }
+      ],
+      "heuristics": [
+        {
+          "context": "When creating content",
+          "guidance": "Always reference the input artifact that guided your creation",
+          "examples": [
+            "Section references its section_brief via brief_ref field",
+            "Codex entry references source sections via source_refs field"
+          ]
+        },
+        {
+          "context": "When returning to orchestrator",
+          "guidance": "Include ALL artifact IDs you created, not just the main one",
+          "examples": [
+            "Created 3 sections -> artifacts_produced=['section-001', 'section-002', 'section-003']",
+            "Created section and fixed another -> artifacts_produced=['section-004', 'section-001']"
+          ]
+        }
+      ],
+      "warnings": [
+        {
+          "failure_mode": "Returning without artifact IDs",
+          "consequence": "Orchestrator cannot pass your work to next agent",
+          "prevention": "Always capture artifact_id from save_artifact response and include in return_to_orchestrator"
+        },
+        {
+          "failure_mode": "Returning with description instead of ID",
+          "consequence": "Next agent cannot find artifact by description",
+          "prevention": "Use exact artifact IDs like 'section-001', not descriptions like 'the opening scene'"
+        }
+      ]
+    }
+  },
+
+  "applicable_to": {
+    "archetypes": ["creator"]
+  },
+
+  "related_entries": ["artifact_model", "delegation_protocol"],
+
+  "tags": ["examples", "few-shot", "creation", "artifacts"]
+}

--- a/domain-v4/knowledge/must_know/orchestrator_examples.json
+++ b/domain-v4/knowledge/must_know/orchestrator_examples.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "orchestrator_examples",
+  "name": "Orchestrator Few-Shot Examples",
+  "layer": "must_know",
+
+  "summary": "Complete delegation cycle examples for orchestrator agents",
+
+  "keywords": ["delegation", "delegate", "workflow", "chain", "orchestration"],
+
+  "triggers": [
+    "how to delegate",
+    "delegation example",
+    "workflow pattern",
+    "passing artifacts"
+  ],
+
+  "content": {
+    "type": "structured",
+    "format": "json",
+    "schema_ref": "knowledge/structured-content.schema.json#/$defs/structured_entry",
+    "data": {
+      "procedures": [
+        {
+          "goal": "Complete a delegation cycle",
+          "steps": [
+            "Step 1 - Delegate to specialist: delegate(to_agent='plotwright', task='Create section brief for opening scene', context={'artifact_refs': [], 'notes': 'Mystery genre, noir tone'}, expected_outputs=[{'artifact_type': 'section_brief'}])",
+            "Step 2 - Agent returns with artifact IDs: {\"summary\": \"Created section brief\", \"result_assessment\": \"pass\", \"recommendation\": \"proceed\", \"artifacts_produced\": [\"SB-001\"]}",
+            "Step 3 - Continue chain with artifact ID: delegate(to_agent='scene_smith', task='Write prose for section brief SB-001', context={'artifact_refs': ['SB-001']}, expected_outputs=[{'artifact_type': 'section'}])",
+            "Step 4 - Scene Smith returns: {\"summary\": \"Wrote prose\", \"result_assessment\": \"pass\", \"artifacts_produced\": [\"section-001\"]}",
+            "Step 5 - Send to validation: delegate(to_agent='gatekeeper', task='Validate section-001 against quality bars', context={'artifact_refs': ['section-001']}, expected_outputs=[{'artifact_type': 'gatecheck_report'}])"
+          ],
+          "preconditions": [
+            "User goal is clear and specific",
+            "Appropriate playbook selected"
+          ],
+          "postconditions": [
+            "Each delegation includes artifact IDs from previous agent",
+            "Chain continues until workflow complete"
+          ]
+        }
+      ],
+      "heuristics": [
+        {
+          "context": "When delegating work",
+          "guidance": "Always pass artifact IDs from previous agent to next agent in context.artifact_refs",
+          "examples": [
+            "Plotwright returns SB-001 -> pass 'SB-001' to Scene Smith",
+            "Scene Smith returns section-001 -> pass 'section-001' to Gatekeeper"
+          ]
+        },
+        {
+          "context": "When agent returns with issues",
+          "guidance": "Check result_assessment and recommendation to decide next action",
+          "examples": [
+            "result_assessment='pass' + recommendation='proceed' -> delegate to next agent",
+            "result_assessment='partial' + recommendation='rework' -> delegate back to same agent with fixes",
+            "result_assessment='fail' + recommendation='escalate' -> communicate(type='error') to customer"
+          ]
+        }
+      ],
+      "warnings": [
+        {
+          "failure_mode": "Delegating without passing artifact IDs",
+          "consequence": "Next agent cannot find previous work, workflow breaks",
+          "prevention": "Always include artifacts_produced IDs in next delegation's context.artifact_refs"
+        }
+      ]
+    }
+  },
+
+  "applicable_to": {
+    "archetypes": ["orchestrator"]
+  },
+
+  "related_entries": ["delegation_protocol", "artifact_model", "orchestrator_onboarding"],
+
+  "tags": ["examples", "few-shot", "orchestration", "delegation"]
+}

--- a/domain-v4/knowledge/must_know/researcher_examples.json
+++ b/domain-v4/knowledge/must_know/researcher_examples.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "researcher_examples",
+  "name": "Researcher Few-Shot Examples",
+  "layer": "must_know",
+
+  "summary": "Complete research and fact-checking cycle examples for researcher agents",
+
+  "keywords": ["research", "fact-check", "verify", "plausibility", "sources"],
+
+  "triggers": [
+    "how to research",
+    "research example",
+    "fact-checking",
+    "verify information"
+  ],
+
+  "content": {
+    "type": "structured",
+    "format": "json",
+    "schema_ref": "knowledge/structured-content.schema.json#/$defs/structured_entry",
+    "data": {
+      "procedures": [
+        {
+          "goal": "Complete a research and verification cycle",
+          "steps": [
+            "Step 1 - Fetch artifact to verify: get_artifact('section-001')",
+            "Step 2 - Identify claims requiring verification (dates, facts, technical details)",
+            "Step 3 - Research each claim using available knowledge sources",
+            "Step 4 - Document findings: save_artifact(artifact_type='research_memo', data={'target_artifact': 'section-001', 'verified_claims': [...], 'issues_found': [...], 'recommendations': [...]})",
+            "Step 5 - Note memo ID: {\"artifact_id\": \"RM-001\", \"status\": \"created\"}",
+            "Step 6 - Return with assessment: return_to_orchestrator(summary='Researched section-001 - 3 claims verified, 1 issue found', result_assessment='partial', recommendation='rework', artifacts_produced=['RM-001'])"
+          ],
+          "preconditions": [
+            "Received delegation with artifact_refs containing content to verify"
+          ],
+          "postconditions": [
+            "Research memo saved with findings",
+            "Clear assessment of factual accuracy"
+          ]
+        }
+      ],
+      "heuristics": [
+        {
+          "context": "When verifying claims",
+          "guidance": "Focus on objective facts that can be wrong, not subjective style choices",
+          "examples": [
+            "Verify: 'The mansion was built in 1892' - check if date is consistent with other canon",
+            "Skip: 'The moonlight cast eerie shadows' - this is style, not fact"
+          ]
+        },
+        {
+          "context": "When issues are found",
+          "guidance": "Provide specific corrections in the research memo",
+          "examples": [
+            "Issue: 'Character age inconsistent' -> Correction: 'Sarah is 32 in chapter 1 but mentioned as 35 here'",
+            "Issue: 'Timeline impossible' -> Correction: 'Train journey from London to Edinburgh took 10 hours in 1890, not 2'"
+          ]
+        }
+      ],
+      "warnings": [
+        {
+          "failure_mode": "Approving without checking cross-references",
+          "consequence": "Inconsistencies with existing canon slip through",
+          "prevention": "Always search_workspace for related artifacts and verify consistency"
+        }
+      ]
+    }
+  },
+
+  "applicable_to": {
+    "archetypes": ["researcher"]
+  },
+
+  "related_entries": ["artifact_model"],
+
+  "tags": ["examples", "few-shot", "research", "verification"]
+}

--- a/domain-v4/knowledge/must_know/validator_examples.json
+++ b/domain-v4/knowledge/must_know/validator_examples.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "../../../meta/schemas/knowledge/knowledge-entry.schema.json",
+  "id": "validator_examples",
+  "name": "Validator Few-Shot Examples",
+  "layer": "must_know",
+
+  "summary": "Complete validation cycle examples for validator agents",
+
+  "keywords": ["validate", "gatekeeper", "quality", "check", "review", "approve"],
+
+  "triggers": [
+    "how to validate",
+    "validation example",
+    "gatecheck",
+    "quality review"
+  ],
+
+  "content": {
+    "type": "structured",
+    "format": "json",
+    "schema_ref": "knowledge/structured-content.schema.json#/$defs/structured_entry",
+    "data": {
+      "procedures": [
+        {
+          "goal": "Complete a validation cycle",
+          "steps": [
+            "Step 1 - Fetch artifact to validate: get_artifact('section-001')",
+            "Step 2 - Check each quality bar (canon consistency, prose quality, format compliance)",
+            "Step 3 - Document findings in structured report",
+            "Step 4 - Save report: save_artifact(artifact_type='gatecheck_report', data={'target_artifact': 'section-001', 'findings': [...], 'verdict': 'pass'})",
+            "Step 5 - Note report ID: {\"artifact_id\": \"GC-001\", \"status\": \"created\"}",
+            "Step 6 - Return with assessment: return_to_orchestrator(summary='Validated section-001 against quality bars', result_assessment='pass', recommendation='proceed', artifacts_produced=['GC-001'])"
+          ],
+          "preconditions": [
+            "Received delegation with artifact_refs containing artifact to validate"
+          ],
+          "postconditions": [
+            "Gatecheck report saved with findings",
+            "Clear pass/fail verdict returned"
+          ]
+        }
+      ],
+      "heuristics": [
+        {
+          "context": "When artifacts fail validation",
+          "guidance": "Provide actionable feedback in report findings",
+          "examples": [
+            "Issue: 'Character name inconsistent' -> Action: 'Change \"John\" to \"Jonathan\" in paragraph 3'",
+            "Issue: 'Missing scene transition' -> Action: 'Add transition beat between scenes 2 and 3'"
+          ]
+        },
+        {
+          "context": "Choosing result_assessment and recommendation",
+          "guidance": "Match assessment to severity of issues found",
+          "examples": [
+            "No issues -> result_assessment='pass', recommendation='proceed'",
+            "Minor issues, fixable -> result_assessment='partial', recommendation='rework'",
+            "Critical issues, needs major revision -> result_assessment='fail', recommendation='rework'",
+            "Blocking issue, needs customer input -> result_assessment='fail', recommendation='escalate'"
+          ]
+        }
+      ],
+      "warnings": [
+        {
+          "failure_mode": "Approving without reading artifact",
+          "consequence": "Quality issues slip through to canon",
+          "prevention": "Always call get_artifact to read the full content before validating"
+        },
+        {
+          "failure_mode": "Vague findings",
+          "consequence": "Creator cannot fix issues without specific guidance",
+          "prevention": "Include exact location (paragraph, sentence) and specific fix in each finding"
+        }
+      ]
+    }
+  },
+
+  "applicable_to": {
+    "archetypes": ["validator"]
+  },
+
+  "related_entries": ["artifact_model", "quality_bars_overview"],
+
+  "tags": ["examples", "few-shot", "validation", "quality"]
+}

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -119,11 +119,21 @@ class ContextBuilder:
                 context.constitution_text = constitution_text
                 context.constitution_tokens = len(constitution_text) // self.CHARS_PER_TOKEN
 
-        # 2. Must-know entries
+        # 2. Must-know entries (explicit from agent's knowledge_requirements)
         for entry_id in reqs.must_know:
             entry = self._find_knowledge_entry(entry_id, studio)
             if entry:
                 entry_dict = self._format_entry_for_injection(entry)
+                context.must_know_entries.append(entry_dict)
+                context.must_know_tokens += (
+                    len(entry_dict.get("content", "")) // self.CHARS_PER_TOKEN
+                )
+
+        # 2b. Must-know entries matching agent's archetypes (auto-injected)
+        archetype_entries = self._load_archetype_knowledge(agent)
+        for entry_dict in archetype_entries:
+            # Avoid duplicates if already in explicit must_know
+            if not any(e.get("id") == entry_dict.get("id") for e in context.must_know_entries):
                 context.must_know_entries.append(entry_dict)
                 context.must_know_tokens += (
                     len(entry_dict.get("content", "")) // self.CHARS_PER_TOKEN
@@ -300,6 +310,49 @@ class ContextBuilder:
             if arch_str == "orchestrator":
                 return True
         return False
+
+    def _load_archetype_knowledge(self, agent: Agent) -> list[dict[str, str]]:
+        """Load must_know entries that apply to agent's archetypes.
+
+        Scans knowledge entries with applicable_to.archetypes and includes
+        those matching any of the agent's archetypes. This enables domain-driven
+        archetype-specific knowledge without hardcoding in the prompt builder.
+
+        Args:
+            agent: The agent to load knowledge for
+
+        Returns:
+            List of formatted knowledge entries for prompt injection
+        """
+        if not self._domain_path or not agent.archetypes:
+            return []
+
+        import json
+
+        # Get agent archetype strings
+        agent_archetypes = {a.value if hasattr(a, "value") else str(a) for a in agent.archetypes}
+
+        entries: list[dict[str, str]] = []
+        must_know_dir = self._domain_path / "knowledge" / "must_know"
+
+        if must_know_dir.exists():
+            for file_path in must_know_dir.glob("*.json"):
+                try:
+                    data = json.loads(file_path.read_text())
+                    applicable_to = data.get("applicable_to", {})
+                    entry_archetypes = set(applicable_to.get("archetypes", []))
+
+                    # Include if any archetype matches
+                    if agent_archetypes & entry_archetypes:
+                        from questfoundry.runtime.models.base import KnowledgeEntry
+
+                        entry = KnowledgeEntry(**data)
+                        entries.append(self._format_entry_for_injection(entry))
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    # Skip malformed entries
+                    continue
+
+        return entries
 
     def _format_playbook_for_menu(self, playbook: Playbook) -> dict[str, Any]:
         """Format a playbook for the playbooks menu.

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -7,11 +7,14 @@ knowledge injection and conversation history.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.runtime.agent.content_utils import extract_knowledge_content
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, KnowledgeEntry, Playbook, Studio
@@ -131,9 +134,10 @@ class ContextBuilder:
 
         # 2b. Must-know entries matching agent's archetypes (auto-injected)
         archetype_entries = self._load_archetype_knowledge(agent)
+        existing_entry_ids = {e.get("id") for e in context.must_know_entries}
         for entry_dict in archetype_entries:
             # Avoid duplicates if already in explicit must_know
-            if not any(e.get("id") == entry_dict.get("id") for e in context.must_know_entries):
+            if entry_dict.get("id") not in existing_entry_ids:
                 context.must_know_entries.append(entry_dict)
                 context.must_know_tokens += (
                     len(entry_dict.get("content", "")) // self.CHARS_PER_TOKEN
@@ -300,16 +304,24 @@ class ContextBuilder:
             "summary": entry.summary or "",
         }
 
+    def _get_agent_archetypes(self, agent: Agent) -> set[str]:
+        """Extract archetype strings from an agent.
+
+        Handles both string and Archetype enum values.
+
+        Args:
+            agent: The agent to get archetypes from
+
+        Returns:
+            Set of archetype strings (lowercase)
+        """
+        if not agent.archetypes:
+            return set()
+        return {a.value if hasattr(a, "value") else str(a) for a in agent.archetypes}
+
     def _is_orchestrator(self, agent: Agent) -> bool:
         """Check if agent has orchestrator archetype."""
-        if not agent.archetypes:
-            return False
-        # Handle both string and Archetype enum values
-        for a in agent.archetypes:
-            arch_str = a.value if hasattr(a, "value") else str(a)
-            if arch_str == "orchestrator":
-                return True
-        return False
+        return "orchestrator" in self._get_agent_archetypes(agent)
 
     def _load_archetype_knowledge(self, agent: Agent) -> list[dict[str, str]]:
         """Load must_know entries that apply to agent's archetypes.
@@ -324,13 +336,11 @@ class ContextBuilder:
         Returns:
             List of formatted knowledge entries for prompt injection
         """
-        if not self._domain_path or not agent.archetypes:
+        agent_archetypes = self._get_agent_archetypes(agent)
+        if not self._domain_path or not agent_archetypes:
             return []
 
         import json
-
-        # Get agent archetype strings
-        agent_archetypes = {a.value if hasattr(a, "value") else str(a) for a in agent.archetypes}
 
         entries: list[dict[str, str]] = []
         must_know_dir = self._domain_path / "knowledge" / "must_know"
@@ -348,8 +358,12 @@ class ContextBuilder:
 
                         entry = KnowledgeEntry(**data)
                         entries.append(self._format_entry_for_injection(entry))
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    # Skip malformed entries
+                except (json.JSONDecodeError, KeyError, TypeError) as e:
+                    logger.warning(
+                        "Skipping malformed knowledge entry %s: %s",
+                        file_path,
+                        e,
+                    )
                     continue
 
         return entries


### PR DESCRIPTION
## Summary
- Add complete few-shot examples for each archetype as domain-driven knowledge entries
- Auto-inject examples based on agent archetypes via `_load_archetype_knowledge()`
- Preserves separation of concerns: examples in domain layer, runtime handles lookup

## Changes

### Domain Layer (`domain-v4/knowledge/must_know/`)
- `orchestrator_examples.json` - Complete delegation cycle with artifact handoff
- `creator_examples.json` - Artifact creation cycle with save_artifact and return
- `validator_examples.json` - Validation cycle with gatecheck reports
- `researcher_examples.json` - Research/verification cycle with fact-checking

### Runtime Layer (`src/questfoundry/runtime/agent/context.py`)
- Add `_load_archetype_knowledge()` method
- Scan must_know entries for `applicable_to.archetypes` matching agent
- Auto-inject without explicit must_know references in agent definitions

## Example Output

Showrunner prompt now includes:
```
### Orchestrator Few-Shot Examples

## Procedures

### Complete a delegation cycle

**Steps:**
1. Step 1 - Delegate to specialist: delegate(to_agent='plotwright', ...)
2. Step 2 - Agent returns with artifact IDs: {"summary": "...", "artifacts_produced": ["SB-001"]}
3. Step 3 - Continue chain with artifact ID: delegate(to_agent='scene_smith', context={'artifact_refs': ['SB-001']}, ...)
```

## Test plan
- [x] Pre-commit passes
- [x] All 1018 tests pass
- [x] Verified orchestrator examples in showrunner prompt
- [x] Verified creator examples in scene_smith prompt
- [x] Verified validator examples in gatekeeper prompt
- [x] Verified researcher examples in researcher prompt

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)