### PR TITLE
feat(meta): Add transition preconditions for artifact dependencies

### DIFF
--- a/domain-v4/artifact-types/passage_brief.json
+++ b/domain-v4/artifact-types/passage_brief.json
@@ -204,7 +204,27 @@
     ],
     "initial_state": "draft",
     "transitions": [
-      { "from": "draft", "to": "ready" },
+      {
+        "from": "draft",
+        "to": "ready",
+        "description": "Brief is complete and ready for Scene Smith. Requires topology to exist.",
+        "preconditions": [
+          {
+            "requires_artifact": {
+              "artifact_type": "topology",
+              "match_field": "ifid"
+            }
+          },
+          {
+            "field_references": {
+              "source_field": "target",
+              "target_artifact_type": "topology",
+              "target_path": "passages[].pid",
+              "match_field": "ifid"
+            }
+          }
+        ]
+      },
       { "from": "ready", "to": "in_use" },
       { "from": "in_use", "to": "ready" },
       { "from": "in_use", "to": "archived" }

--- a/meta/schemas/core/artifact-type.schema.json
+++ b/meta/schemas/core/artifact-type.schema.json
@@ -143,6 +143,11 @@
                 "items": { "type": "string" },
                 "description": "IDs of quality criteria that must pass for this transition"
               },
+              "preconditions": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/transition_precondition" },
+                "description": "Artifact dependency preconditions that must be satisfied before this transition. Runtime validates these and blocks transition with actionable error if unmet."
+              },
               "target_store": {
                 "$ref": "_definitions.schema.json#/$defs/store_ref",
                 "description": "Store to migrate artifact to on this transition. Generalizes cold migration - any transition can trigger store migration. Runtime updates both _lifecycle_state and _store atomically."
@@ -226,6 +231,67 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "transition_precondition": {
+      "type": "object",
+      "description": "Precondition that must be satisfied before a lifecycle transition. Used to enforce artifact dependencies at transition time rather than save time, allowing flexible creation order.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["requires_artifact"],
+          "properties": {
+            "requires_artifact": {
+              "type": "object",
+              "required": ["artifact_type"],
+              "properties": {
+                "artifact_type": {
+                  "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
+                  "description": "Type of artifact that must exist"
+                },
+                "match_field": {
+                  "type": "string",
+                  "description": "Field in both artifacts that must match (e.g., 'ifid'). If omitted, just checks existence."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Requires an artifact of specified type to exist, optionally with matching field value"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["field_references"],
+          "properties": {
+            "field_references": {
+              "type": "object",
+              "required": ["source_field", "target_artifact_type", "target_path"],
+              "properties": {
+                "source_field": {
+                  "type": "string",
+                  "description": "Field in this artifact containing the reference value"
+                },
+                "target_artifact_type": {
+                  "$ref": "_definitions.schema.json#/$defs/artifact_type_ref",
+                  "description": "Type of artifact to check"
+                },
+                "target_path": {
+                  "type": "string",
+                  "description": "JSONPath-like expression to array of valid values (e.g., 'passages[].pid')"
+                },
+                "match_field": {
+                  "type": "string",
+                  "description": "Field to match when finding the target artifact (e.g., 'ifid')"
+                }
+              },
+              "additionalProperties": false,
+              "description": "Validates that source_field value exists in target artifact's array"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -109,6 +109,29 @@ class LifecycleState(BaseModel):
     terminal: bool = False
 
 
+class RequiresArtifact(BaseModel):
+    """Precondition requiring an artifact of a specific type to exist."""
+
+    artifact_type: str
+    match_field: str | None = None
+
+
+class FieldReferences(BaseModel):
+    """Precondition validating a field value exists in another artifact."""
+
+    source_field: str
+    target_artifact_type: str
+    target_path: str
+    match_field: str | None = None
+
+
+class TransitionPrecondition(BaseModel):
+    """Precondition that must be satisfied before a lifecycle transition."""
+
+    requires_artifact: RequiresArtifact | None = None
+    field_references: FieldReferences | None = None
+
+
 class LifecycleTransition(BaseModel):
     """Lifecycle state transition."""
 
@@ -116,6 +139,9 @@ class LifecycleTransition(BaseModel):
     to_state: str = Field(alias="to")
     allowed_agents: list[str] = Field(default_factory=list)
     requires_validation: list[str] = Field(default_factory=list)
+    preconditions: list[TransitionPrecondition] = Field(default_factory=list)
+    target_store: str | None = None
+    description: str | None = None
 
     model_config = {"populate_by_name": True}
 

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from questfoundry.runtime.models.enums import (
     AssetCategory,
@@ -110,14 +110,31 @@ class LifecycleState(BaseModel):
 
 
 class RequiresArtifact(BaseModel):
-    """Precondition requiring an artifact of a specific type to exist."""
+    """Precondition requiring an artifact of a specific type to exist.
+
+    The optional ``match_field`` can be used to further restrict which artifacts
+    satisfy this precondition. When set, the required artifact must have the
+    same value for this field as the source artifact (e.g., both artifacts
+    sharing the same ``ifid`` identifier).
+    """
 
     artifact_type: str
     match_field: str | None = None
 
 
 class FieldReferences(BaseModel):
-    """Precondition validating a field value exists in another artifact."""
+    """Precondition validating a field value exists in another artifact's array.
+
+    Validates that the value of ``source_field`` exists somewhere in the array
+    at ``target_path`` within an artifact of type ``target_artifact_type``.
+
+    Example: If source_field='target' has value 'PID-001', and target_path is
+    'passages[].pid', this checks that 'PID-001' appears in the passages array
+    of the target artifact.
+
+    The optional ``match_field`` filters which target artifacts to check
+    (e.g., only check topology artifacts with matching ifid).
+    """
 
     source_field: str
     target_artifact_type: str
@@ -126,10 +143,25 @@ class FieldReferences(BaseModel):
 
 
 class TransitionPrecondition(BaseModel):
-    """Precondition that must be satisfied before a lifecycle transition."""
+    """Precondition that must be satisfied before a lifecycle transition.
+
+    Exactly one of ``requires_artifact`` or ``field_references`` must be set.
+    This matches the oneOf constraint in the JSON schema.
+    """
 
     requires_artifact: RequiresArtifact | None = None
     field_references: FieldReferences | None = None
+
+    @model_validator(mode="after")
+    def check_exactly_one(self) -> TransitionPrecondition:
+        """Enforce that exactly one precondition type is specified."""
+        has_requires = self.requires_artifact is not None
+        has_references = self.field_references is not None
+        if has_requires == has_references:  # Both True or both False
+            raise ValueError(
+                "Exactly one of 'requires_artifact' or 'field_references' must be provided"
+            )
+        return self
 
 
 class LifecycleTransition(BaseModel):

--- a/src/questfoundry/runtime/storage/lifecycle.py
+++ b/src/questfoundry/runtime/storage/lifecycle.py
@@ -74,6 +74,66 @@ class LifecycleState:
 
 
 @dataclass
+class RequiresArtifactPrecondition:
+    """Precondition requiring an artifact of a specific type to exist."""
+
+    artifact_type: str
+    match_field: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RequiresArtifactPrecondition:
+        """Create from dictionary."""
+        return cls(
+            artifact_type=data["artifact_type"],
+            match_field=data.get("match_field"),
+        )
+
+
+@dataclass
+class FieldReferencesPrecondition:
+    """Precondition validating a field value exists in another artifact."""
+
+    source_field: str
+    target_artifact_type: str
+    target_path: str
+    match_field: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FieldReferencesPrecondition:
+        """Create from dictionary."""
+        return cls(
+            source_field=data["source_field"],
+            target_artifact_type=data["target_artifact_type"],
+            target_path=data["target_path"],
+            match_field=data.get("match_field"),
+        )
+
+
+@dataclass
+class TransitionPrecondition:
+    """Precondition that must be satisfied before a lifecycle transition."""
+
+    requires_artifact: RequiresArtifactPrecondition | None = None
+    field_references: FieldReferencesPrecondition | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TransitionPrecondition:
+        """Create from dictionary."""
+        requires_artifact = None
+        field_references = None
+
+        if "requires_artifact" in data:
+            requires_artifact = RequiresArtifactPrecondition.from_dict(data["requires_artifact"])
+        if "field_references" in data:
+            field_references = FieldReferencesPrecondition.from_dict(data["field_references"])
+
+        return cls(
+            requires_artifact=requires_artifact,
+            field_references=field_references,
+        )
+
+
+@dataclass
 class LifecycleTransition:
     """A transition between lifecycle states."""
 
@@ -81,16 +141,26 @@ class LifecycleTransition:
     to_state: str
     allowed_agents: list[str] = field(default_factory=list)
     requires_validation: list[str] = field(default_factory=list)
+    preconditions: list[TransitionPrecondition] = field(default_factory=list)
     target_store: str | None = None  # Store migration on transition
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> LifecycleTransition:
         """Create from dictionary."""
+        preconditions = []
+        for pc_data in data.get("preconditions", []):
+            if isinstance(pc_data, dict):
+                preconditions.append(TransitionPrecondition.from_dict(pc_data))
+            else:
+                # Already a TransitionPrecondition object
+                preconditions.append(pc_data)
+
         return cls(
             from_state=data["from"],
             to_state=data["to"],
             allowed_agents=data.get("allowed_agents", []),
             requires_validation=data.get("requires_validation", []),
+            preconditions=preconditions,
             target_store=data.get("target_store"),
         )
 
@@ -409,6 +479,30 @@ class LifecycleManager:
             return []
 
         return transition.requires_validation
+
+    def get_preconditions(
+        self, artifact_type_id: str, from_state: str, to_state: str
+    ) -> list[TransitionPrecondition]:
+        """
+        Get preconditions for a transition.
+
+        Args:
+            artifact_type_id: Artifact type
+            from_state: Current state
+            to_state: Target state
+
+        Returns:
+            List of preconditions that must be satisfied
+        """
+        lifecycle = self._lifecycles.get(artifact_type_id)
+        if lifecycle is None:
+            return []
+
+        transition = lifecycle.get_transition(from_state, to_state)
+        if transition is None:
+            return []
+
+        return transition.preconditions
 
     @classmethod
     def from_artifact_types(cls, artifact_types: list[Any]) -> LifecycleManager:

--- a/src/questfoundry/runtime/storage/project.py
+++ b/src/questfoundry/runtime/storage/project.py
@@ -572,6 +572,25 @@ class Project:
 
         return results
 
+    def list_artifacts(
+        self,
+        artifact_type: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """
+        List artifacts, optionally filtered by type.
+
+        This is a convenience method that wraps query_artifacts for simpler use cases.
+
+        Args:
+            artifact_type: Filter by artifact type (e.g., "topology")
+            limit: Maximum results (default 100)
+
+        Returns:
+            List of matching artifacts
+        """
+        return self.query_artifacts(artifact_type=artifact_type, limit=limit)
+
     def get_children_by_relationship(
         self,
         parent_artifact: dict[str, Any],

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -116,6 +116,29 @@ class RequestLifecycleTransitionTool(BaseTool):
                     error=f"Transition not allowed: {reason}",
                 )
 
+            # Check preconditions (artifact dependencies)
+            preconditions = lifecycle_manager.get_preconditions(
+                artifact_type, current_state, target_state
+            )
+
+            if preconditions:
+                precondition_result = self._validate_preconditions(
+                    artifact=artifact,
+                    preconditions=preconditions,
+                )
+
+                if not precondition_result["satisfied"]:
+                    return ToolResult(
+                        success=False,
+                        data={
+                            "artifact_id": artifact_id,
+                            "current_state": current_state,
+                            "target_state": target_state,
+                            "precondition_failures": precondition_result["failures"],
+                        },
+                        error=f"Preconditions not met: {precondition_result['summary']}",
+                    )
+
             # Check for required validations
             required_validations = lifecycle_manager.get_required_validations(
                 artifact_type, current_state, target_state
@@ -233,6 +256,214 @@ class RequestLifecycleTransitionTool(BaseTool):
     def _get_store_manager(self) -> StoreManager | None:
         """Get store manager from context."""
         return getattr(self._context, "store_manager", None)
+
+    def _validate_preconditions(
+        self,
+        artifact: dict[str, Any],
+        preconditions: list[Any],
+    ) -> dict[str, Any]:
+        """
+        Validate transition preconditions against current project state.
+
+        Args:
+            artifact: The artifact being transitioned
+            preconditions: List of TransitionPrecondition objects
+
+        Returns:
+            Dict with:
+                satisfied: bool - True if all preconditions are met
+                failures: list - Details of failed preconditions
+                summary: str - Human-readable summary of failures
+        """
+        if not self._context.project:
+            return {
+                "satisfied": False,
+                "failures": [{"type": "no_project", "message": "No project available"}],
+                "summary": "No project available to check preconditions",
+            }
+
+        failures: list[dict[str, Any]] = []
+        project = self._context.project
+
+        for precondition in preconditions:
+            # Handle requires_artifact precondition
+            if precondition.requires_artifact:
+                req = precondition.requires_artifact
+                target_type = req.artifact_type
+                match_field = req.match_field
+
+                # Find artifacts of the required type
+                matching_artifacts = project.list_artifacts(artifact_type=target_type)
+
+                if not matching_artifacts:
+                    failures.append(
+                        {
+                            "type": "requires_artifact",
+                            "artifact_type": target_type,
+                            "message": f"No '{target_type}' artifact exists",
+                            "fix": f"Create a '{target_type}' artifact before this transition",
+                        }
+                    )
+                    continue
+
+                # If match_field specified, check for matching value
+                if match_field:
+                    source_value = artifact.get(match_field)
+                    found_match = False
+                    for candidate in matching_artifacts:
+                        if candidate.get(match_field) == source_value:
+                            found_match = True
+                            break
+
+                    if not found_match:
+                        failures.append(
+                            {
+                                "type": "requires_artifact",
+                                "artifact_type": target_type,
+                                "match_field": match_field,
+                                "expected_value": source_value,
+                                "message": (
+                                    f"No '{target_type}' artifact with "
+                                    f"{match_field}='{source_value}'"
+                                ),
+                                "fix": (
+                                    f"Create a '{target_type}' artifact with "
+                                    f"{match_field}='{source_value}'"
+                                ),
+                            }
+                        )
+
+            # Handle field_references precondition
+            if precondition.field_references:
+                ref = precondition.field_references
+                source_field = ref.source_field
+                target_type = ref.target_artifact_type
+                target_path = ref.target_path
+                match_field = ref.match_field
+
+                # Get source value from artifact
+                source_value = artifact.get(source_field)
+                if source_value is None:
+                    failures.append(
+                        {
+                            "type": "field_references",
+                            "source_field": source_field,
+                            "message": f"Source field '{source_field}' is not set",
+                            "fix": f"Set the '{source_field}' field before this transition",
+                        }
+                    )
+                    continue
+
+                # Find target artifact
+                target_artifacts = project.list_artifacts(artifact_type=target_type)
+
+                # Filter by match_field if specified
+                if match_field:
+                    match_value = artifact.get(match_field)
+                    target_artifacts = [
+                        a for a in target_artifacts if a.get(match_field) == match_value
+                    ]
+
+                if not target_artifacts:
+                    failures.append(
+                        {
+                            "type": "field_references",
+                            "target_artifact_type": target_type,
+                            "message": f"No '{target_type}' artifact exists",
+                            "fix": f"Create a '{target_type}' artifact first",
+                        }
+                    )
+                    continue
+
+                # Check if source_value exists in target_path
+                # Parse target_path like "passages[].pid"
+                found_in_any = False
+                for target_artifact in target_artifacts:
+                    if self._check_value_in_path(target_artifact, target_path, source_value):
+                        found_in_any = True
+                        break
+
+                if not found_in_any:
+                    failures.append(
+                        {
+                            "type": "field_references",
+                            "source_field": source_field,
+                            "source_value": source_value,
+                            "target_artifact_type": target_type,
+                            "target_path": target_path,
+                            "message": (
+                                f"Value '{source_value}' from '{source_field}' not found "
+                                f"in {target_type}.{target_path}"
+                            ),
+                            "fix": (
+                                f"Ensure '{source_value}' exists in the "
+                                f"'{target_type}' artifact's {target_path}"
+                            ),
+                        }
+                    )
+
+        if failures:
+            summary_parts = [f["message"] for f in failures]
+            return {
+                "satisfied": False,
+                "failures": failures,
+                "summary": "; ".join(summary_parts),
+            }
+
+        return {
+            "satisfied": True,
+            "failures": [],
+            "summary": "",
+        }
+
+    def _check_value_in_path(
+        self,
+        artifact: dict[str, Any],
+        path: str,
+        value: Any,
+    ) -> bool:
+        """
+        Check if a value exists at a JSONPath-like path in an artifact.
+
+        Supports paths like:
+        - "passages[].pid" - check pid field in each item of passages array
+        - "name" - check top-level field
+
+        Args:
+            artifact: The artifact to search
+            path: JSONPath-like expression
+            value: Value to find
+
+        Returns:
+            True if value found at path
+        """
+        # Parse path like "passages[].pid"
+        if "[]." in path:
+            array_field, item_field = path.split("[].", 1)
+            array_data = artifact.get(array_field, [])
+            if not isinstance(array_data, list):
+                return False
+
+            for item in array_data:
+                if isinstance(item, dict):
+                    # Handle nested path like "pid"
+                    if "." in item_field:
+                        # Recursively check nested path
+                        if self._check_value_in_path(item, item_field, value):
+                            return True
+                    elif item.get(item_field) == value:
+                        return True
+            return False
+
+        # Simple field lookup
+        if "." in path:
+            parts = path.split(".", 1)
+            nested = artifact.get(parts[0])
+            if isinstance(nested, dict):
+                return self._check_value_in_path(nested, parts[1], value)
+            return False
+
+        return bool(artifact.get(path) == value)
 
     def _handle_cold_transition(
         self,

--- a/src/questfoundry/runtime/tools/lifecycle_transition.py
+++ b/src/questfoundry/runtime/tools/lifecycle_transition.py
@@ -18,7 +18,10 @@ from questfoundry.runtime.tools.base import BaseTool, ToolResult
 from questfoundry.runtime.tools.registry import TOOL_IMPLEMENTATIONS, register_tool
 
 if TYPE_CHECKING:
-    from questfoundry.runtime.storage.lifecycle import LifecycleManager
+    from questfoundry.runtime.storage.lifecycle import (
+        LifecycleManager,
+        TransitionPrecondition,
+    )
     from questfoundry.runtime.storage.store_manager import StoreManager
 
 logger = logging.getLogger(__name__)
@@ -260,7 +263,7 @@ class RequestLifecycleTransitionTool(BaseTool):
     def _validate_preconditions(
         self,
         artifact: dict[str, Any],
-        preconditions: list[Any],
+        preconditions: list[TransitionPrecondition],
     ) -> dict[str, Any]:
         """
         Validate transition preconditions against current project state.
@@ -309,6 +312,22 @@ class RequestLifecycleTransitionTool(BaseTool):
                 # If match_field specified, check for matching value
                 if match_field:
                     source_value = artifact.get(match_field)
+                    # Check if source artifact has the match_field
+                    if source_value is None:
+                        failures.append(
+                            {
+                                "type": "requires_artifact",
+                                "artifact_type": target_type,
+                                "match_field": match_field,
+                                "message": (
+                                    f"Source artifact missing '{match_field}' field "
+                                    f"required for matching"
+                                ),
+                                "fix": (f"Set the '{match_field}' field on the source artifact"),
+                            }
+                        )
+                        continue
+
                     found_match = False
                     for candidate in matching_artifacts:
                         if candidate.get(match_field) == source_value:
@@ -360,6 +379,20 @@ class RequestLifecycleTransitionTool(BaseTool):
                 # Filter by match_field if specified
                 if match_field:
                     match_value = artifact.get(match_field)
+                    # Check if source artifact has the match_field
+                    if match_value is None:
+                        failures.append(
+                            {
+                                "type": "field_references",
+                                "match_field": match_field,
+                                "message": (
+                                    f"Source artifact missing '{match_field}' field "
+                                    f"required for filtering target artifacts"
+                                ),
+                                "fix": (f"Set the '{match_field}' field on the source artifact"),
+                            }
+                        )
+                        continue
                     target_artifacts = [
                         a for a in target_artifacts if a.get(match_field) == match_value
                     ]

--- a/tests/runtime/tools/test_lifecycle_transition.py
+++ b/tests/runtime/tools/test_lifecycle_transition.py
@@ -1502,3 +1502,47 @@ class TestTransitionPreconditions:
         result = await tool.execute({"artifact_id": "brief_001", "target_state": "ready"})
         assert result.success is True
         assert result.data["transitioned"] is True
+
+    @pytest.mark.asyncio
+    async def test_precondition_blocks_when_match_field_missing_on_source(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition blocked when match_field is specified but source artifact lacks it."""
+        # Add topology with ifid
+        precondition_project.artifacts["topology_001"] = {
+            "_id": "topology_001",
+            "_type": "topology",
+            "ifid": "story-123",
+            "passages": [{"pid": "passage-1", "name": "Passage 1"}],
+        }
+
+        # Remove ifid from the source brief - match_field won't find a value
+        del precondition_project.artifacts["brief_001"]["ifid"]
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is False
+        assert "Preconditions not met" in result.error
+        failures = result.data["precondition_failures"]
+        # Should complain about missing match_field on source artifact
+        assert any(
+            "missing" in f.get("message", "").lower() and "ifid" in f.get("message", "")
+            for f in failures
+        )

--- a/tests/runtime/tools/test_lifecycle_transition.py
+++ b/tests/runtime/tools/test_lifecycle_transition.py
@@ -5,9 +5,12 @@ import pytest
 from questfoundry.runtime.models.enums import StoreSemantics
 from questfoundry.runtime.storage.lifecycle import (
     ArtifactLifecycle,
+    FieldReferencesPrecondition,
     LifecycleManager,
     LifecycleState,
     LifecycleTransition,
+    RequiresArtifactPrecondition,
+    TransitionPrecondition,
 )
 from questfoundry.runtime.storage.store_manager import (
     StoreDefinition,
@@ -42,6 +45,14 @@ class MockProject:
             return None
         self.artifacts[artifact_id].update(data)
         return self.artifacts[artifact_id]
+
+    def list_artifacts(self, artifact_type: str | None = None) -> list[dict]:
+        """List artifacts, optionally filtering by type."""
+        results = []
+        for artifact in self.artifacts.values():
+            if artifact_type is None or artifact.get("_type") == artifact_type:
+                results.append(artifact)
+        return results
 
 
 class MockToolDefinition:
@@ -1167,3 +1178,327 @@ class TestDirectGatecheckToColdTransition:
 
         assert result.success is False
         assert "not allowed" in result.error.lower()
+
+
+class TestTransitionPreconditions:
+    """Tests for transition precondition validation."""
+
+    @pytest.fixture
+    def lifecycle_manager_with_preconditions(self):
+        """Create lifecycle manager with preconditions on transitions."""
+        manager = LifecycleManager()
+
+        passage_brief_lifecycle = ArtifactLifecycle(
+            artifact_type_id="passage_brief",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "ready": LifecycleState(id="ready", name="Ready"),
+            },
+            transitions=[
+                LifecycleTransition(
+                    from_state="draft",
+                    to_state="ready",
+                    preconditions=[
+                        TransitionPrecondition(
+                            requires_artifact=RequiresArtifactPrecondition(
+                                artifact_type="topology",
+                                match_field="ifid",
+                            )
+                        ),
+                        TransitionPrecondition(
+                            field_references=FieldReferencesPrecondition(
+                                source_field="target",
+                                target_artifact_type="topology",
+                                target_path="passages[].pid",
+                                match_field="ifid",
+                            )
+                        ),
+                    ],
+                ),
+            ],
+            initial_state="draft",
+        )
+        manager.register_lifecycle(passage_brief_lifecycle)
+        return manager
+
+    @pytest.fixture
+    def precondition_project(self):
+        """Create project with passage_brief and topology artifacts."""
+        project = MockProject()
+        project.artifacts = {
+            "brief_001": {
+                "_id": "brief_001",
+                "_type": "passage_brief",
+                "_lifecycle_state": "draft",
+                "ifid": "story-123",
+                "target": "passage-1",
+                "title": "Test Brief",
+            },
+        }
+        return project
+
+    @pytest.mark.asyncio
+    async def test_precondition_blocks_when_required_artifact_missing(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition blocked when required artifact type doesn't exist."""
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        # No topology exists - should fail
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is False
+        assert "Preconditions not met" in result.error
+        assert "topology" in result.error.lower()
+        assert result.data.get("precondition_failures")
+        failures = result.data["precondition_failures"]
+        assert any(f["type"] == "requires_artifact" for f in failures)
+
+    @pytest.mark.asyncio
+    async def test_precondition_blocks_when_match_field_differs(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition blocked when artifact exists but match_field doesn't match."""
+        # Add topology with different ifid
+        precondition_project.artifacts["topology_001"] = {
+            "_id": "topology_001",
+            "_type": "topology",
+            "ifid": "different-story",  # Different ifid
+            "passages": [{"pid": "passage-1", "name": "Passage 1"}],
+        }
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is False
+        assert "Preconditions not met" in result.error
+        # Should complain about match_field mismatch
+        failures = result.data["precondition_failures"]
+        assert any(
+            f["type"] == "requires_artifact" and f.get("match_field") == "ifid" for f in failures
+        )
+
+    @pytest.mark.asyncio
+    async def test_precondition_blocks_when_field_reference_missing(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition blocked when field value doesn't exist in target artifact."""
+        # Add topology with matching ifid but missing passage
+        precondition_project.artifacts["topology_001"] = {
+            "_id": "topology_001",
+            "_type": "topology",
+            "ifid": "story-123",  # Matching ifid
+            "passages": [
+                {"pid": "other-passage", "name": "Other Passage"}  # Different pid
+            ],
+        }
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is False
+        assert "Preconditions not met" in result.error
+        failures = result.data["precondition_failures"]
+        assert any(f["type"] == "field_references" for f in failures)
+        # Should mention the missing passage-1
+        assert any("passage-1" in f.get("source_value", "") for f in failures)
+
+    @pytest.mark.asyncio
+    async def test_precondition_succeeds_when_all_met(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition succeeds when all preconditions are satisfied."""
+        # Add topology with matching ifid and passage
+        precondition_project.artifacts["topology_001"] = {
+            "_id": "topology_001",
+            "_type": "topology",
+            "ifid": "story-123",  # Matching ifid
+            "passages": [
+                {"pid": "passage-1", "name": "Passage 1"},  # Matching pid
+                {"pid": "passage-2", "name": "Passage 2"},
+            ],
+        }
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["transitioned"] is True
+        assert result.data["new_state"] == "ready"
+        # Verify artifact was updated
+        artifact = precondition_project.artifacts["brief_001"]
+        assert artifact["_lifecycle_state"] == "ready"
+
+    @pytest.mark.asyncio
+    async def test_precondition_blocks_when_source_field_missing(
+        self, precondition_project, lifecycle_manager_with_preconditions
+    ):
+        """Transition blocked when source field for field_references is not set."""
+        # Add topology with matching ifid
+        precondition_project.artifacts["topology_001"] = {
+            "_id": "topology_001",
+            "_type": "topology",
+            "ifid": "story-123",
+            "passages": [{"pid": "passage-1", "name": "Passage 1"}],
+        }
+
+        # Remove target field from brief
+        del precondition_project.artifacts["brief_001"]["target"]
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=precondition_project,
+            agent_id="plotwright",
+            lifecycle_manager=lifecycle_manager_with_preconditions,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        result = await tool.execute(
+            {
+                "artifact_id": "brief_001",
+                "target_state": "ready",
+            }
+        )
+
+        assert result.success is False
+        assert "Preconditions not met" in result.error
+        failures = result.data["precondition_failures"]
+        assert any(
+            f["type"] == "field_references" and "target" in f.get("source_field", "")
+            for f in failures
+        )
+
+    @pytest.mark.asyncio
+    async def test_precondition_requires_artifact_without_match_field(self):
+        """Test requires_artifact precondition without match_field (just type check)."""
+        manager = LifecycleManager()
+
+        # Simpler precondition - just requires artifact type to exist
+        simple_lifecycle = ArtifactLifecycle(
+            artifact_type_id="brief",
+            states={
+                "draft": LifecycleState(id="draft", name="Draft"),
+                "ready": LifecycleState(id="ready", name="Ready"),
+            },
+            transitions=[
+                LifecycleTransition(
+                    from_state="draft",
+                    to_state="ready",
+                    preconditions=[
+                        TransitionPrecondition(
+                            requires_artifact=RequiresArtifactPrecondition(
+                                artifact_type="story",  # Just needs a story to exist
+                                match_field=None,
+                            )
+                        ),
+                    ],
+                ),
+            ],
+            initial_state="draft",
+        )
+        manager.register_lifecycle(simple_lifecycle)
+
+        project = MockProject()
+        project.artifacts = {
+            "brief_001": {
+                "_id": "brief_001",
+                "_type": "brief",
+                "_lifecycle_state": "draft",
+                "title": "Test Brief",
+            },
+        }
+
+        ctx = ToolContext(
+            studio=MockStudio(),
+            project=project,
+            agent_id="plotwright",
+            lifecycle_manager=manager,
+        )
+
+        tool = RequestLifecycleTransitionTool(
+            MockToolDefinition("request_lifecycle_transition"),
+            ctx,
+        )
+
+        # No story exists - should fail
+        result = await tool.execute({"artifact_id": "brief_001", "target_state": "ready"})
+        assert result.success is False
+        assert "story" in result.error.lower()
+
+        # Add any story - should succeed
+        project.artifacts["story_001"] = {
+            "_id": "story_001",
+            "_type": "story",
+            "name": "Test Story",
+        }
+
+        result = await tool.execute({"artifact_id": "brief_001", "target_state": "ready"})
+        assert result.success is True
+        assert result.data["transitioned"] is True


### PR DESCRIPTION
## Summary

Adds a new `preconditions` field to lifecycle transitions that enables runtime enforcement of artifact dependencies at transition time rather than save time. This allows flexible artifact creation order while still ensuring dependencies exist before critical state changes.

**Key insight:** Topology artifact MUST exist, but creation order doesn't matter. Briefs can be created first, topology second - as long as topology exists before briefs are promoted to `ready` state.

## Changes

### Schema (meta/schemas/core/artifact-type.schema.json)
- Added `transition_precondition` definition with two types:
  - `requires_artifact` - artifact type existence check with optional field matching
  - `field_references` - validates field value exists in another artifact's array

### Domain (domain-v4/artifact-types/passage_brief.json)
- Added preconditions to `draft -> ready` transition:
  - Requires `topology` artifact with matching `ifid`
  - Validates `target` field exists in `topology.passages[].pid`

### Runtime
- **src/questfoundry/runtime/models/base.py** - Pydantic models: `RequiresArtifact`, `FieldReferences`, `TransitionPrecondition`
- **src/questfoundry/runtime/storage/lifecycle.py** - Dataclass models + `get_preconditions()` method
- **src/questfoundry/runtime/tools/lifecycle_transition.py** - `_validate_preconditions()` and `_check_value_in_path()` methods
- **src/questfoundry/runtime/storage/project.py** - Added `list_artifacts()` convenience method

### Tests
- Added 6 new test cases covering all precondition scenarios:
  - Blocks when required artifact type missing
  - Blocks when match_field doesn't match
  - Blocks when field reference not found in target
  - Blocks when source field not set
  - Succeeds when all preconditions met
  - Works with simpler requires_artifact (no match_field)

## Design Decision

See [issue #289 comment](https://github.com/pvliesdonk/questfoundry/issues/289#issuecomment-3692950413) for full design discussion comparing options:

| Approach | When Enforced | Order Matters? |
|----------|---------------|----------------|
| **A. Save-time validation** | On save | ✅ Yes |
| **B. Lifecycle transition (chosen)** | On promotion | ❌ No |
| **C. Gatecheck** | Before handoff | ❌ No |

## Test plan
- [x] All 1024 tests pass
- [x] Domain loads with preconditions correctly
- [x] JSON schema validation passes
- [x] Runtime enforcement implemented and tested

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)