### PR TITLE
feat(runtime): Add small_model_tools for token optimization (#293)

### DIFF
--- a/domain-v4/agents/showrunner.json
+++ b/domain-v4/agents/showrunner.json
@@ -9,6 +9,8 @@
 
   "is_entry_agent": true,
 
+  "small_model_tools": ["delegate", "communicate", "terminate_session", "consult"],
+
   "capabilities": [
     {
       "id": "delegate_all",

--- a/domain-v4/studio.json
+++ b/domain-v4/studio.json
@@ -74,6 +74,7 @@
   ],
 
   "tools": [
+    "tools/consult.json",
     "tools/consult_schema.json",
     "tools/consult_playbook.json",
     "tools/validate_artifact.json",

--- a/domain-v4/tools/consult.json
+++ b/domain-v4/tools/consult.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../meta/schemas/core/tool-definition.schema.json",
+  "id": "consult",
+  "name": "Consult Reference",
+  "summary": "Look up playbooks, knowledge, or schemas",
+  "description": "Unified lookup tool for reference material. Use this to retrieve detailed guidance, workflow definitions, or artifact schemas.\n\nLookup types:\n- playbook: Get workflow phases, steps, agents, and completion criteria\n- knowledge: Get full content of knowledge entries from your Knowledge Menu\n- schema: Get artifact type definitions with fields and validation rules",
+  "concise_description": "Look up reference material by type and ID.",
+
+  "summarization_policy": "drop",
+  "summary_template": "Retrieved {lookup_type}: {id}",
+
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "lookup_type": {
+        "type": "string",
+        "enum": ["playbook", "knowledge", "schema"],
+        "description": "Type of reference to look up"
+      },
+      "id": {
+        "type": "string",
+        "description": "ID of the playbook, knowledge entry, or artifact type to retrieve"
+      },
+      "section": {
+        "type": "string",
+        "description": "For knowledge lookups: optional section heading to retrieve"
+      },
+      "include_examples": {
+        "type": "boolean",
+        "default": true,
+        "description": "For schema lookups: include usage examples"
+      },
+      "include_validation_rules": {
+        "type": "boolean",
+        "default": true,
+        "description": "For schema lookups: include validation rules"
+      }
+    },
+    "required": ["lookup_type", "id"]
+  },
+
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "lookup_type": {
+        "type": "string",
+        "description": "The type of lookup that was performed"
+      },
+      "id": {
+        "type": "string",
+        "description": "The requested ID"
+      },
+      "content": {
+        "type": "object",
+        "description": "The retrieved content (structure varies by lookup_type)"
+      }
+    }
+  },
+
+  "examples": [
+    {
+      "description": "Get playbook details for Story Spark workflow",
+      "input": {
+        "lookup_type": "playbook",
+        "id": "story_spark"
+      }
+    },
+    {
+      "description": "Get knowledge entry for spoiler hygiene guidelines",
+      "input": {
+        "lookup_type": "knowledge",
+        "id": "spoiler_hygiene"
+      }
+    },
+    {
+      "description": "Get artifact schema for Passage Brief",
+      "input": {
+        "lookup_type": "schema",
+        "id": "passage_brief"
+      }
+    }
+  ]
+}

--- a/meta/schemas/core/agent.schema.json
+++ b/meta/schemas/core/agent.schema.json
@@ -54,6 +54,13 @@
       "description": "What this agent can do (tools, permissions, actions)"
     },
 
+    "small_model_tools": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Complete tool set for small models (8B and under). If defined and non-empty, this REPLACES the tools derived from capabilities. Can include different tools than capabilities (e.g., unified 'consult' instead of individual consult_* tools). Fallback: if empty or not defined, tools are derived from capabilities."
+    },
+
     "constraints": {
       "type": "array",
       "items": {

--- a/meta/schemas/core/tool-definition.schema.json
+++ b/meta/schemas/core/tool-definition.schema.json
@@ -28,6 +28,11 @@
       "description": "Concise one-liner for prompt injection. Use description for full explanation."
     },
 
+    "concise_description": {
+      "type": "string",
+      "description": "Simplified description for small models (8B and under). Drops nuances that small models cannot handle. If not specified, falls back to description. Use this to provide a shorter, more direct explanation suitable for limited context windows."
+    },
+
     "cost_tier": {
       "type": "string",
       "enum": ["low", "medium", "high", "external"],

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -10,17 +10,15 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from questfoundry.runtime.agent.content_utils import extract_knowledge_content
+from questfoundry.runtime.models.enums import ModelClass
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, KnowledgeEntry, Playbook, Studio
-
-# Model class type alias for prompt optimization
-ModelClass = Literal["small", "medium", "large"]
 
 
 @dataclass
@@ -101,7 +99,7 @@ class ContextBuilder:
         self._knowledge_cache: dict[str, dict[str, Any]] = {}
 
     def build(
-        self, agent: Agent, studio: Studio, model_class: ModelClass = "large"
+        self, agent: Agent, studio: Studio, model_class: ModelClass = ModelClass.LARGE
     ) -> AgentContext:
         """
         Build context for agent activation.
@@ -118,7 +116,7 @@ class ContextBuilder:
             AgentContext with all prepared knowledge
         """
         context = AgentContext()
-        use_concise = model_class == "small"
+        use_concise = model_class == ModelClass.SMALL
 
         if not agent.knowledge_requirements:
             return context
@@ -676,7 +674,7 @@ def build_context(
     agent: Agent,
     studio: Studio,
     domain_path: Path | None = None,
-    model_class: ModelClass = "large",
+    model_class: ModelClass = ModelClass.LARGE,
 ) -> AgentContext:
     """Build context for an agent.
 
@@ -685,9 +683,9 @@ def build_context(
         studio: The studio containing knowledge entries
         domain_path: Path to domain directory
         model_class: Model size class for prompt optimization
-            - "small": Use concise variants, minimal knowledge
-            - "medium": Normal content, some optimization
-            - "large": Full knowledge content (default)
+            - SMALL: Use concise variants, minimal knowledge
+            - MEDIUM: Normal content, some optimization
+            - LARGE: Full knowledge content (default)
 
     Returns:
         AgentContext with all prepared knowledge

--- a/src/questfoundry/runtime/agent/knowledge.py
+++ b/src/questfoundry/runtime/agent/knowledge.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from questfoundry.runtime.models import Agent, KnowledgeEntry, Studio
@@ -30,14 +30,12 @@ if TYPE_CHECKING:
 import logging
 
 from questfoundry.runtime.agent.content_utils import extract_knowledge_content
+from questfoundry.runtime.models.enums import ModelClass
 
 logger = logging.getLogger(__name__)
 
 # Valid knowledge layers for archetype-based inclusion
 VALID_LAYERS = frozenset({"must_know", "should_know", "role_specific"})
-
-# Model class type alias
-ModelClass = Literal["small", "medium", "large"]
 
 
 def _combine_entry_lists(explicit: list[str], archetype_matched: list[str]) -> list[str]:
@@ -121,7 +119,7 @@ class KnowledgeContextBuilder:
         self,
         agent: Agent,
         studio: Studio,
-        model_class: ModelClass = "large",
+        model_class: ModelClass = ModelClass.LARGE,
     ) -> KnowledgeContext:
         """
         Build knowledge context for an agent.
@@ -145,7 +143,7 @@ class KnowledgeContextBuilder:
         entries_inlined: list[str] = []
         entries_in_menu: list[str] = []
         used_tokens = 0
-        use_concise = model_class == "small"
+        use_concise = model_class == ModelClass.SMALL
 
         knowledge_req = agent.knowledge_requirements
 
@@ -467,7 +465,7 @@ def build_knowledge_context(
     studio: Studio,
     config: KnowledgeBudgetConfig | None = None,
     domain_path: Path | str | None = None,
-    model_class: ModelClass = "large",
+    model_class: ModelClass = ModelClass.LARGE,
 ) -> KnowledgeContext:
     """
     Convenience function to build knowledge context for an agent.
@@ -477,7 +475,7 @@ def build_knowledge_context(
         studio: Studio with knowledge entries
         config: Optional budget configuration
         domain_path: Path to domain directory for loading constitution
-        model_class: Model size class ("small", "medium", "large")
+        model_class: Model size class (ModelClass.SMALL, MEDIUM, LARGE)
 
     Returns:
         KnowledgeContext with formatted text

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -496,8 +496,9 @@ class AgentRuntime:
                 error="Tool registry not available",
             )
 
-        # Enforce capability
-        self.tool_registry.enforce_capability(agent, tool_id)
+        # Enforce capability (model_class determines which tools are allowed)
+        model_class = self._get_model_class()
+        self.tool_registry.enforce_capability(agent, tool_id, model_class)
 
         # Get and execute tool
         tool = self.tool_registry.get_tool(tool_id, agent.id, session_id)

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from questfoundry.runtime.agent.context import AgentContext, ContextBuilder, ModelClass
+from questfoundry.runtime.agent.context import AgentContext, ContextBuilder
 from questfoundry.runtime.agent.prompt import PromptBuilder, build_prompt
 from questfoundry.runtime.agent.turn_validator import (
     TurnValidationConfig,
@@ -51,6 +51,7 @@ from questfoundry.runtime.context import (
     render_cached_hit_message,
     summarize_messages,
 )
+from questfoundry.runtime.models.enums import ModelClass
 from questfoundry.runtime.observability import EventType
 from questfoundry.runtime.providers import (
     ContextOverflowError,
@@ -561,12 +562,12 @@ class AgentRuntime:
         """Determine model class from model name.
 
         Uses heuristics to classify models:
-        - "small": 8B parameters and under (e.g., qwen3:8b, llama3.2:3b)
-        - "medium": 9B-70B parameters (e.g., qwen3:32b, llama3.1:70b)
-        - "large": 70B+ or cloud models (e.g., gpt-4, claude)
+        - SMALL: 8B parameters and under (e.g., qwen3:8b, llama3.2:3b)
+        - MEDIUM: 9B-70B parameters (e.g., qwen3:32b, llama3.1:70b)
+        - LARGE: 70B+ or cloud models (e.g., gpt-4, claude)
 
         Returns:
-            Model class: "small", "medium", or "large"
+            ModelClass enum value
         """
         import re
 
@@ -577,22 +578,22 @@ class AgentRuntime:
 
         # Small model patterns (8B and under)
         if re.search(r"[:\-_]?8b\b", model):
-            return "small"
+            return ModelClass.SMALL
         if re.search(r"[:\-_]?7b\b", model):
-            return "small"
+            return ModelClass.SMALL
         if re.search(r"[:\-_]?[1-4]b\b", model):
-            return "small"
+            return ModelClass.SMALL
 
         # Medium model patterns (9B-70B)
         if re.search(r"[:\-_]?70b\b", model):
-            return "medium"
+            return ModelClass.MEDIUM
         if re.search(r"[:\-_]?32b\b", model):
-            return "medium"
+            return ModelClass.MEDIUM
         if re.search(r"[:\-_]?(14|22|27)b\b", model):
-            return "medium"
+            return ModelClass.MEDIUM
 
-        # Cloud models and large models default to "large"
-        return "large"
+        # Cloud models and large models default to LARGE
+        return ModelClass.LARGE
 
     def build_context(self, agent: Agent) -> AgentContext:
         """Build context for an agent."""
@@ -612,7 +613,8 @@ class AgentRuntime:
         """
         if not self.tool_registry:
             return []
-        return self.tool_registry.get_langchain_tools(agent, session_id)
+        model_class = self._get_model_class()
+        return self.tool_registry.get_langchain_tools(agent, session_id, model_class)
 
     def build_messages(
         self,

--- a/src/questfoundry/runtime/models/base.py
+++ b/src/questfoundry/runtime/models/base.py
@@ -260,6 +260,7 @@ class Agent(BaseModel):
     is_entry_agent: bool = False
 
     capabilities: list[Capability] = Field(default_factory=list)
+    small_model_tools: list[str] = Field(default_factory=list)
     constraints: list[Constraint] = Field(default_factory=list)
     exclusive_stores: list[str] = Field(default_factory=list)
     knowledge_requirements: KnowledgeRequirements | None = None
@@ -288,6 +289,7 @@ class Tool(BaseModel):
     id: str
     name: str
     description: str
+    concise_description: str | None = None  # Simplified description for small models
 
     input_schema: ToolInputSchema | None = None
     output_schema: dict[str, Any] | None = None

--- a/src/questfoundry/runtime/models/enums.py
+++ b/src/questfoundry/runtime/models/enums.py
@@ -113,3 +113,17 @@ class CompletionStatus(str, Enum):
     FAILED = "failed"
     BLOCKED = "blocked"
     CANCELLED = "cancelled"
+
+
+class ModelClass(str, Enum):
+    """Model size class for tool and knowledge filtering.
+
+    Used to optimize prompts for different model capacities:
+    - SMALL: 8B parameters and under (local models)
+    - MEDIUM: 9B-70B parameters
+    - LARGE: 70B+ or cloud models (GPT-4, Claude)
+    """
+
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"

--- a/src/questfoundry/runtime/tools/__init__.py
+++ b/src/questfoundry/runtime/tools/__init__.py
@@ -21,6 +21,7 @@ Usage:
 from questfoundry.runtime.tools import (
     analyze_story_graph,  # noqa: F401  # Programmatic graph topology analysis
     communicate,  # noqa: F401  # Phase 7: unified human communication
+    consult,  # noqa: F401  # Unified consult for small models
     consult_corpus,  # noqa: F401
     consult_knowledge,  # noqa: F401  # Phase 7: knowledge menu+consult pattern
     consult_playbook,  # noqa: F401

--- a/src/questfoundry/runtime/tools/base.py
+++ b/src/questfoundry/runtime/tools/base.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.runtime.models.enums import ModelClass
+
 if TYPE_CHECKING:
     from questfoundry.runtime.messaging.broker import AsyncMessageBroker
     from questfoundry.runtime.models import Studio, Tool
@@ -291,13 +293,21 @@ class BaseTool(ABC):
                 execution_time_ms=(time.time() - start_time) * 1000,
             )
 
-    def to_langchain_schema(self) -> dict[str, Any]:
+    def to_langchain_schema(self, model_class: ModelClass = ModelClass.LARGE) -> dict[str, Any]:
         """
         Convert tool to LangChain-compatible schema for bind_tools().
+
+        Args:
+            model_class: Model size class. Small models use concise_description if available.
 
         Returns:
             Dict with name, description, and parameters
         """
+        # Use concise_description for small models if available
+        description = self.description
+        if model_class == ModelClass.SMALL and self._definition.concise_description:
+            description = self._definition.concise_description
+
         parameters = {"type": "object", "properties": {}, "required": []}
 
         if self._definition.input_schema:
@@ -306,7 +316,7 @@ class BaseTool(ABC):
 
         return {
             "name": self.id,
-            "description": self.description,
+            "description": description,
             "parameters": parameters,
         }
 

--- a/src/questfoundry/runtime/tools/consult.py
+++ b/src/questfoundry/runtime/tools/consult.py
@@ -76,22 +76,9 @@ class ConsultTool(BaseTool):
 
     async def execute(self, args: dict[str, Any]) -> ToolResult:
         """Execute lookup by dispatching to the appropriate tool."""
-        lookup_type = args.get("lookup_type")
-        lookup_id = args.get("id")
-
-        if not lookup_type:
-            return ToolResult(
-                success=False,
-                data={},
-                error="lookup_type is required. Use 'playbook', 'knowledge', or 'schema'.",
-            )
-
-        if not lookup_id:
-            return ToolResult(
-                success=False,
-                data={},
-                error="id is required. Specify the ID of the playbook, knowledge entry, or artifact type.",
-            )
+        # Args are validated by validate_input() before execute() is called
+        lookup_type = args["lookup_type"]
+        lookup_id = args["id"]
 
         if lookup_type == "playbook":
             return await self._consult_playbook(lookup_id)
@@ -102,12 +89,9 @@ class ConsultTool(BaseTool):
             include_examples = args.get("include_examples", True)
             include_validation_rules = args.get("include_validation_rules", True)
             return await self._consult_schema(lookup_id, include_examples, include_validation_rules)
-        else:
-            return ToolResult(
-                success=False,
-                data={},
-                error=f"Unknown lookup_type: {lookup_type}. Use 'playbook', 'knowledge', or 'schema'.",
-            )
+
+        # This path should be unreachable if validation is correct
+        raise AssertionError(f"Invalid lookup_type '{lookup_type}' was not caught by validation.")
 
     async def _consult_playbook(self, playbook_id: str) -> ToolResult:
         """Delegate to consult_playbook."""
@@ -155,21 +139,12 @@ class ConsultTool(BaseTool):
 
     def validate_input(self, args: dict[str, Any]) -> None:
         """Validate input arguments."""
+        # Base class validates types and required fields from JSON schema
         super().validate_input(args)
 
+        # Additional validation: enum check for lookup_type
         lookup_type = args.get("lookup_type")
-        if lookup_type is not None:
-            if not isinstance(lookup_type, str):
-                raise ToolValidationError("lookup_type must be a string")
-            if lookup_type not in ("playbook", "knowledge", "schema"):
-                raise ToolValidationError(
-                    f"lookup_type must be 'playbook', 'knowledge', or 'schema', got '{lookup_type}'"
-                )
-
-        lookup_id = args.get("id")
-        if lookup_id is not None and not isinstance(lookup_id, str):
-            raise ToolValidationError("id must be a string")
-
-        section = args.get("section")
-        if section is not None and not isinstance(section, str):
-            raise ToolValidationError("section must be a string")
+        if lookup_type is not None and lookup_type not in ("playbook", "knowledge", "schema"):
+            raise ToolValidationError(
+                f"'lookup_type' must be 'playbook', 'knowledge', or 'schema', got '{lookup_type}'"
+            )

--- a/src/questfoundry/runtime/tools/consult.py
+++ b/src/questfoundry/runtime/tools/consult.py
@@ -1,0 +1,175 @@
+"""
+Unified Consult tool implementation.
+
+Dispatches to consult_playbook, consult_knowledge, or consult_schema
+based on the lookup_type parameter. Provides a single tool for small
+models to reduce schema token overhead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.runtime.models import Tool
+from questfoundry.runtime.tools.base import BaseTool, ToolResult, ToolValidationError
+from questfoundry.runtime.tools.consult_knowledge import ConsultKnowledgeTool
+from questfoundry.runtime.tools.consult_playbook import ConsultPlaybookTool
+from questfoundry.runtime.tools.consult_schema import ConsultSchemaTool
+from questfoundry.runtime.tools.registry import register_tool
+
+# Stub definitions for delegate tools (required for BaseTool constructor)
+_PLAYBOOK_TOOL_DEF = Tool(
+    id="consult_playbook",
+    name="Consult Playbook",
+    description="Get full details for a playbook/workflow.",
+)
+_KNOWLEDGE_TOOL_DEF = Tool(
+    id="consult_knowledge",
+    name="Consult Knowledge",
+    description="Retrieve full content for a knowledge entry.",
+)
+_SCHEMA_TOOL_DEF = Tool(
+    id="consult_schema",
+    name="Consult Schema",
+    description="Get artifact type definition with schema and validation rules.",
+)
+
+
+@register_tool("consult")
+class ConsultTool(BaseTool):
+    """
+    Unified lookup tool for reference material.
+
+    Dispatches to the appropriate specialized tool based on lookup_type:
+    - playbook: Get workflow phases, steps, agents, and completion criteria
+    - knowledge: Get full content of knowledge entries from Knowledge Menu
+    - schema: Get artifact type definitions with fields and validation rules
+
+    This tool is designed for small models to reduce schema token overhead.
+    Large models should use the specialized tools directly for better clarity.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Lazily initialize delegate tools
+        self._playbook_tool: ConsultPlaybookTool | None = None
+        self._knowledge_tool: ConsultKnowledgeTool | None = None
+        self._schema_tool: ConsultSchemaTool | None = None
+
+    def _get_playbook_tool(self) -> ConsultPlaybookTool:
+        """Get or create the playbook tool delegate."""
+        if self._playbook_tool is None:
+            self._playbook_tool = ConsultPlaybookTool(_PLAYBOOK_TOOL_DEF, self._context)
+        return self._playbook_tool
+
+    def _get_knowledge_tool(self) -> ConsultKnowledgeTool:
+        """Get or create the knowledge tool delegate."""
+        if self._knowledge_tool is None:
+            self._knowledge_tool = ConsultKnowledgeTool(_KNOWLEDGE_TOOL_DEF, self._context)
+        return self._knowledge_tool
+
+    def _get_schema_tool(self) -> ConsultSchemaTool:
+        """Get or create the schema tool delegate."""
+        if self._schema_tool is None:
+            self._schema_tool = ConsultSchemaTool(_SCHEMA_TOOL_DEF, self._context)
+        return self._schema_tool
+
+    async def execute(self, args: dict[str, Any]) -> ToolResult:
+        """Execute lookup by dispatching to the appropriate tool."""
+        lookup_type = args.get("lookup_type")
+        lookup_id = args.get("id")
+
+        if not lookup_type:
+            return ToolResult(
+                success=False,
+                data={},
+                error="lookup_type is required. Use 'playbook', 'knowledge', or 'schema'.",
+            )
+
+        if not lookup_id:
+            return ToolResult(
+                success=False,
+                data={},
+                error="id is required. Specify the ID of the playbook, knowledge entry, or artifact type.",
+            )
+
+        if lookup_type == "playbook":
+            return await self._consult_playbook(lookup_id)
+        elif lookup_type == "knowledge":
+            section = args.get("section")
+            return await self._consult_knowledge(lookup_id, section)
+        elif lookup_type == "schema":
+            include_examples = args.get("include_examples", True)
+            include_validation_rules = args.get("include_validation_rules", True)
+            return await self._consult_schema(lookup_id, include_examples, include_validation_rules)
+        else:
+            return ToolResult(
+                success=False,
+                data={},
+                error=f"Unknown lookup_type: {lookup_type}. Use 'playbook', 'knowledge', or 'schema'.",
+            )
+
+    async def _consult_playbook(self, playbook_id: str) -> ToolResult:
+        """Delegate to consult_playbook."""
+        tool = self._get_playbook_tool()
+        result = await tool.execute({"playbook_id": playbook_id})
+
+        # Wrap result to indicate unified tool was used
+        if result.success:
+            result.data["lookup_type"] = "playbook"
+        return result
+
+    async def _consult_knowledge(self, entry_id: str, section: str | None = None) -> ToolResult:
+        """Delegate to consult_knowledge."""
+        tool = self._get_knowledge_tool()
+        args: dict[str, Any] = {"entry_id": entry_id}
+        if section:
+            args["section"] = section
+        result = await tool.execute(args)
+
+        # Wrap result to indicate unified tool was used
+        if result.success:
+            result.data["lookup_type"] = "knowledge"
+        return result
+
+    async def _consult_schema(
+        self,
+        artifact_type_id: str,
+        include_examples: bool = True,
+        include_validation_rules: bool = True,
+    ) -> ToolResult:
+        """Delegate to consult_schema."""
+        tool = self._get_schema_tool()
+        result = await tool.execute(
+            {
+                "artifact_type_id": artifact_type_id,
+                "include_examples": include_examples,
+                "include_validation_rules": include_validation_rules,
+            }
+        )
+
+        # Wrap result to indicate unified tool was used
+        if result.success:
+            result.data["lookup_type"] = "schema"
+        return result
+
+    def validate_input(self, args: dict[str, Any]) -> None:
+        """Validate input arguments."""
+        super().validate_input(args)
+
+        lookup_type = args.get("lookup_type")
+        if lookup_type is not None:
+            if not isinstance(lookup_type, str):
+                raise ToolValidationError("lookup_type must be a string")
+            if lookup_type not in ("playbook", "knowledge", "schema"):
+                raise ToolValidationError(
+                    f"lookup_type must be 'playbook', 'knowledge', or 'schema', got '{lookup_type}'"
+                )
+
+        lookup_id = args.get("id")
+        if lookup_id is not None and not isinstance(lookup_id, str):
+            raise ToolValidationError("id must be a string")
+
+        section = args.get("section")
+        if section is not None and not isinstance(section, str):
+            raise ToolValidationError("section must be a string")

--- a/src/questfoundry/runtime/tools/registry.py
+++ b/src/questfoundry/runtime/tools/registry.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.runtime.models import Tool
+from questfoundry.runtime.models.enums import ModelClass
 from questfoundry.runtime.tools.base import (
     BaseTool,
     CapabilityViolationError,
@@ -220,6 +221,7 @@ class ToolRegistry:
         self,
         agent: Agent,
         session_id: str | None = None,
+        model_class: ModelClass = ModelClass.LARGE,
     ) -> list[BaseTool]:
         """
         Get all tools an agent has capability to use.
@@ -227,13 +229,22 @@ class ToolRegistry:
         Args:
             agent: Agent to get tools for
             session_id: Current session ID
+            model_class: Model size class (small, medium, large). Small models
+                        use the agent's small_model_tools if defined.
 
         Returns:
             List of instantiated tools the agent can use
         """
         tools = []
-        allowed_tool_ids = self._get_agent_tool_refs(agent)
-        allowed_tool_ids.update(self._get_implicit_tool_refs(agent))
+
+        # For small models with small_model_tools defined, use it as complete replacement
+        if model_class == ModelClass.SMALL and agent.small_model_tools:
+            allowed_tool_ids = set(agent.small_model_tools)
+            logger.debug(f"Using small_model_tools for agent '{agent.id}': {allowed_tool_ids}")
+        else:
+            # Normal path: derive from capabilities + implicit tools
+            allowed_tool_ids = self._get_agent_tool_refs(agent)
+            allowed_tool_ids.update(self._get_implicit_tool_refs(agent))
 
         for tool_id in allowed_tool_ids:
             # Skip interactive-only tools when not in interactive mode
@@ -325,6 +336,7 @@ class ToolRegistry:
         self,
         agent: Agent,
         session_id: str | None = None,
+        model_class: ModelClass = ModelClass.LARGE,
     ) -> list[dict[str, Any]]:
         """
         Get LangChain-compatible tool schemas for an agent.
@@ -334,12 +346,15 @@ class ToolRegistry:
         Args:
             agent: Agent to get tools for
             session_id: Current session ID
+            model_class: Model size class for tool filtering
 
         Returns:
             List of tool schemas for LangChain
         """
-        tools = self.get_agent_tools(agent, session_id)
-        return [tool.to_langchain_schema() for tool in tools if tool.check_availability()]
+        tools = self.get_agent_tools(agent, session_id, model_class)
+        return [
+            tool.to_langchain_schema(model_class) for tool in tools if tool.check_availability()
+        ]
 
     def list_all_tools(self) -> list[str]:
         """List all tool IDs defined in the studio."""

--- a/src/questfoundry/runtime/tools/registry.py
+++ b/src/questfoundry/runtime/tools/registry.py
@@ -299,34 +299,54 @@ class ToolRegistry:
 
         return False
 
-    def check_capability(self, agent: Agent, tool_id: str) -> bool:
+    def check_capability(
+        self,
+        agent: Agent,
+        tool_id: str,
+        model_class: ModelClass = ModelClass.LARGE,
+    ) -> bool:
         """
         Check if an agent has capability to use a tool.
+
+        For small models with small_model_tools defined, the check is against
+        that list instead of capabilities.
 
         Args:
             agent: Agent to check
             tool_id: Tool ID to check
+            model_class: Model class for capability resolution
 
         Returns:
             True if agent can use the tool
         """
+        # For small models with small_model_tools, check against that list
+        if model_class == ModelClass.SMALL and agent.small_model_tools:
+            return tool_id in agent.small_model_tools
+
+        # Standard capability check
         explicit_tools = self._get_agent_tool_refs(agent)
         implicit_tools = self._get_implicit_tool_refs(agent)
 
         return tool_id in explicit_tools or tool_id in implicit_tools
 
-    def enforce_capability(self, agent: Agent, tool_id: str) -> None:
+    def enforce_capability(
+        self,
+        agent: Agent,
+        tool_id: str,
+        model_class: ModelClass = ModelClass.LARGE,
+    ) -> None:
         """
         Enforce capability check, raising if violation.
 
         Args:
             agent: Agent attempting to use tool
             tool_id: Tool being used
+            model_class: Model class for capability resolution
 
         Raises:
             CapabilityViolationError: If agent lacks capability
         """
-        if not self.check_capability(agent, tool_id):
+        if not self.check_capability(agent, tool_id, model_class):
             logger.warning(
                 f"Capability violation: agent '{agent.id}' attempted to use tool '{tool_id}'"
             )

--- a/tests/runtime/tools/test_consult.py
+++ b/tests/runtime/tools/test_consult.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from questfoundry.runtime.tools.base import ToolContext, ToolResult
+from questfoundry.runtime.tools.base import ToolContext, ToolResult, ToolValidationError
 from questfoundry.runtime.tools.consult import ConsultTool
 
 
@@ -40,43 +40,23 @@ def mock_context():
 class TestConsultTool:
     """Tests for ConsultTool."""
 
-    def test_requires_lookup_type(self, mock_tool_definition, mock_context):
-        """lookup_type is required."""
+    def test_validate_input_rejects_invalid_lookup_type(self, mock_tool_definition, mock_context):
+        """validate_input rejects invalid lookup_type values."""
         tool = ConsultTool(mock_tool_definition, mock_context)
 
-        # Execute without lookup_type
-        import asyncio
+        with pytest.raises(
+            ToolValidationError, match="must be 'playbook', 'knowledge', or 'schema'"
+        ):
+            tool.validate_input({"lookup_type": "invalid", "id": "test"})
 
-        result = asyncio.get_event_loop().run_until_complete(tool.execute({"id": "some_id"}))
-
-        assert not result.success
-        assert "lookup_type is required" in result.error
-
-    def test_requires_id(self, mock_tool_definition, mock_context):
-        """id is required."""
+    def test_validate_input_accepts_valid_lookup_types(self, mock_tool_definition, mock_context):
+        """validate_input accepts valid lookup_type values."""
         tool = ConsultTool(mock_tool_definition, mock_context)
 
-        import asyncio
-
-        result = asyncio.get_event_loop().run_until_complete(
-            tool.execute({"lookup_type": "playbook"})
-        )
-
-        assert not result.success
-        assert "id is required" in result.error
-
-    def test_unknown_lookup_type(self, mock_tool_definition, mock_context):
-        """Unknown lookup_type returns error."""
-        tool = ConsultTool(mock_tool_definition, mock_context)
-
-        import asyncio
-
-        result = asyncio.get_event_loop().run_until_complete(
-            tool.execute({"lookup_type": "invalid", "id": "some_id"})
-        )
-
-        assert not result.success
-        assert "Unknown lookup_type" in result.error
+        # These should not raise
+        tool.validate_input({"lookup_type": "playbook", "id": "test"})
+        tool.validate_input({"lookup_type": "knowledge", "id": "test"})
+        tool.validate_input({"lookup_type": "schema", "id": "test"})
 
     @pytest.mark.asyncio
     async def test_dispatches_to_playbook(self, mock_tool_definition, mock_context):
@@ -172,31 +152,35 @@ class TestConsultTool:
             assert result.success
             assert result.data["lookup_type"] == "schema"
 
-    def test_validate_input_lookup_type_must_be_string(self, mock_tool_definition, mock_context):
-        """lookup_type must be a string."""
+    @pytest.mark.asyncio
+    async def test_dispatches_to_schema_with_options(self, mock_tool_definition, mock_context):
+        """lookup_type=schema respects include_examples and include_validation_rules."""
         tool = ConsultTool(mock_tool_definition, mock_context)
 
-        from questfoundry.runtime.tools.base import ToolValidationError
+        mock_result = ToolResult(
+            success=True,
+            data={"artifact_type": "passage"},
+        )
 
-        with pytest.raises(ToolValidationError, match="'lookup_type'.*must be a string"):
-            tool.validate_input({"lookup_type": 123, "id": "test"})
+        with patch.object(tool, "_get_schema_tool") as mock_get:
+            mock_schema_tool = AsyncMock()
+            mock_schema_tool.execute.return_value = mock_result
+            mock_get.return_value = mock_schema_tool
 
-    def test_validate_input_lookup_type_must_be_valid(self, mock_tool_definition, mock_context):
-        """lookup_type must be playbook, knowledge, or schema."""
-        tool = ConsultTool(mock_tool_definition, mock_context)
+            result = await tool.execute(
+                {
+                    "lookup_type": "schema",
+                    "id": "passage",
+                    "include_examples": False,
+                    "include_validation_rules": False,
+                }
+            )
 
-        from questfoundry.runtime.tools.base import ToolValidationError
-
-        with pytest.raises(
-            ToolValidationError, match="must be 'playbook', 'knowledge', or 'schema'"
-        ):
-            tool.validate_input({"lookup_type": "invalid", "id": "test"})
-
-    def test_validate_input_id_must_be_string(self, mock_tool_definition, mock_context):
-        """id must be a string."""
-        tool = ConsultTool(mock_tool_definition, mock_context)
-
-        from questfoundry.runtime.tools.base import ToolValidationError
-
-        with pytest.raises(ToolValidationError, match="'id'.*must be a string"):
-            tool.validate_input({"lookup_type": "playbook", "id": 123})
+            mock_schema_tool.execute.assert_called_once_with(
+                {
+                    "artifact_type_id": "passage",
+                    "include_examples": False,
+                    "include_validation_rules": False,
+                }
+            )
+            assert result.success

--- a/tests/runtime/tools/test_consult.py
+++ b/tests/runtime/tools/test_consult.py
@@ -1,0 +1,202 @@
+"""Tests for the unified consult tool."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from questfoundry.runtime.tools.base import ToolContext, ToolResult
+from questfoundry.runtime.tools.consult import ConsultTool
+
+
+@pytest.fixture
+def mock_tool_definition():
+    """Create a mock tool definition."""
+    definition = MagicMock()
+    definition.id = "consult"
+    definition.name = "Consult Reference"
+    definition.description = "Look up reference material"
+    definition.timeout_ms = 30000
+    definition.input_schema = MagicMock()
+    definition.input_schema.required = ["lookup_type", "id"]
+    definition.input_schema.properties = {
+        "lookup_type": {"type": "string"},
+        "id": {"type": "string"},
+    }
+    definition.concise_description = "Look up references"
+    return definition
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock tool context."""
+    studio = MagicMock()
+    studio.playbooks = []
+    context = ToolContext(studio=studio)
+    return context
+
+
+class TestConsultTool:
+    """Tests for ConsultTool."""
+
+    def test_requires_lookup_type(self, mock_tool_definition, mock_context):
+        """lookup_type is required."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        # Execute without lookup_type
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(tool.execute({"id": "some_id"}))
+
+        assert not result.success
+        assert "lookup_type is required" in result.error
+
+    def test_requires_id(self, mock_tool_definition, mock_context):
+        """id is required."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute({"lookup_type": "playbook"})
+        )
+
+        assert not result.success
+        assert "id is required" in result.error
+
+    def test_unknown_lookup_type(self, mock_tool_definition, mock_context):
+        """Unknown lookup_type returns error."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute({"lookup_type": "invalid", "id": "some_id"})
+        )
+
+        assert not result.success
+        assert "Unknown lookup_type" in result.error
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_playbook(self, mock_tool_definition, mock_context):
+        """lookup_type=playbook dispatches to ConsultPlaybookTool."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        # Mock the playbook tool
+        mock_result = ToolResult(
+            success=True,
+            data={"playbook_id": "story_spark", "phases": []},
+        )
+
+        with patch.object(tool, "_get_playbook_tool") as mock_get:
+            mock_playbook_tool = AsyncMock()
+            mock_playbook_tool.execute.return_value = mock_result
+            mock_get.return_value = mock_playbook_tool
+
+            result = await tool.execute({"lookup_type": "playbook", "id": "story_spark"})
+
+            mock_playbook_tool.execute.assert_called_once_with({"playbook_id": "story_spark"})
+            assert result.success
+            assert result.data["lookup_type"] == "playbook"
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_knowledge(self, mock_tool_definition, mock_context):
+        """lookup_type=knowledge dispatches to ConsultKnowledgeTool."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        mock_result = ToolResult(
+            success=True,
+            data={"entry_id": "runtime_guidelines", "content": "..."},
+        )
+
+        with patch.object(tool, "_get_knowledge_tool") as mock_get:
+            mock_knowledge_tool = AsyncMock()
+            mock_knowledge_tool.execute.return_value = mock_result
+            mock_get.return_value = mock_knowledge_tool
+
+            result = await tool.execute({"lookup_type": "knowledge", "id": "runtime_guidelines"})
+
+            mock_knowledge_tool.execute.assert_called_once_with({"entry_id": "runtime_guidelines"})
+            assert result.success
+            assert result.data["lookup_type"] == "knowledge"
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_knowledge_with_section(self, mock_tool_definition, mock_context):
+        """lookup_type=knowledge with section passes section to tool."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        mock_result = ToolResult(
+            success=True,
+            data={"entry_id": "runtime_guidelines", "section": "tools"},
+        )
+
+        with patch.object(tool, "_get_knowledge_tool") as mock_get:
+            mock_knowledge_tool = AsyncMock()
+            mock_knowledge_tool.execute.return_value = mock_result
+            mock_get.return_value = mock_knowledge_tool
+
+            result = await tool.execute(
+                {"lookup_type": "knowledge", "id": "runtime_guidelines", "section": "tools"}
+            )
+
+            mock_knowledge_tool.execute.assert_called_once_with(
+                {"entry_id": "runtime_guidelines", "section": "tools"}
+            )
+            assert result.success
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_schema(self, mock_tool_definition, mock_context):
+        """lookup_type=schema dispatches to ConsultSchemaTool."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        mock_result = ToolResult(
+            success=True,
+            data={"artifact_type": "passage", "fields": []},
+        )
+
+        with patch.object(tool, "_get_schema_tool") as mock_get:
+            mock_schema_tool = AsyncMock()
+            mock_schema_tool.execute.return_value = mock_result
+            mock_get.return_value = mock_schema_tool
+
+            result = await tool.execute({"lookup_type": "schema", "id": "passage"})
+
+            mock_schema_tool.execute.assert_called_once_with(
+                {
+                    "artifact_type_id": "passage",
+                    "include_examples": True,
+                    "include_validation_rules": True,
+                }
+            )
+            assert result.success
+            assert result.data["lookup_type"] == "schema"
+
+    def test_validate_input_lookup_type_must_be_string(self, mock_tool_definition, mock_context):
+        """lookup_type must be a string."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        from questfoundry.runtime.tools.base import ToolValidationError
+
+        with pytest.raises(ToolValidationError, match="'lookup_type'.*must be a string"):
+            tool.validate_input({"lookup_type": 123, "id": "test"})
+
+    def test_validate_input_lookup_type_must_be_valid(self, mock_tool_definition, mock_context):
+        """lookup_type must be playbook, knowledge, or schema."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        from questfoundry.runtime.tools.base import ToolValidationError
+
+        with pytest.raises(
+            ToolValidationError, match="must be 'playbook', 'knowledge', or 'schema'"
+        ):
+            tool.validate_input({"lookup_type": "invalid", "id": "test"})
+
+    def test_validate_input_id_must_be_string(self, mock_tool_definition, mock_context):
+        """id must be a string."""
+        tool = ConsultTool(mock_tool_definition, mock_context)
+
+        from questfoundry.runtime.tools.base import ToolValidationError
+
+        with pytest.raises(ToolValidationError, match="'id'.*must be a string"):
+            tool.validate_input({"lookup_type": "playbook", "id": 123})

--- a/tests/runtime/tools/test_registry.py
+++ b/tests/runtime/tools/test_registry.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from questfoundry.runtime.models.enums import ModelClass
 from questfoundry.runtime.tools.base import BaseTool, CapabilityViolationError, ToolResult
 from questfoundry.runtime.tools.registry import (
     TOOL_IMPLEMENTATIONS,
@@ -326,3 +327,155 @@ class TestToolRegistryInteractiveMode:
 
         for tool in tools:
             assert tool.context.interactive is False
+
+
+class TestSmallModelTools:
+    """Tests for small_model_tools feature (issue #293)."""
+
+    def test_small_model_tools_is_complete_replacement(self):
+        """small_model_tools replaces capability-derived tools entirely for small models."""
+        studio = MagicMock()
+
+        # Define tools
+        delegate = MagicMock()
+        delegate.id = "delegate"
+        delegate.name = "Delegate"
+        delegate.description = "Delegate work"
+        delegate.timeout_ms = 30000
+        delegate.input_schema = None
+        delegate.concise_description = None
+
+        consult = MagicMock()
+        consult.id = "consult"
+        consult.name = "Consult"
+        consult.description = "Unified consult tool"
+        consult.timeout_ms = 30000
+        consult.input_schema = None
+        consult.concise_description = None
+
+        consult_playbook = MagicMock()
+        consult_playbook.id = "consult_playbook"
+        consult_playbook.name = "Consult Playbook"
+        consult_playbook.description = "Get playbook details"
+        consult_playbook.timeout_ms = 30000
+        consult_playbook.input_schema = None
+        consult_playbook.concise_description = None
+
+        consult_schema = MagicMock()
+        consult_schema.id = "consult_schema"
+        consult_schema.name = "Consult Schema"
+        consult_schema.description = "Get schema info"
+        consult_schema.timeout_ms = 30000
+        consult_schema.input_schema = None
+        consult_schema.concise_description = None
+
+        studio.tools = [delegate, consult, consult_playbook, consult_schema]
+
+        # Create agent with capabilities for individual consult tools
+        # BUT small_model_tools specifies unified consult tool
+        agent = MagicMock()
+        agent.id = "test_agent"
+
+        cap1 = MagicMock()
+        cap1.tool_ref = "delegate"
+        cap1.category = "tool"
+        cap1.access_level = None
+
+        cap2 = MagicMock()
+        cap2.tool_ref = "consult_playbook"
+        cap2.category = "tool"
+        cap2.access_level = None
+
+        cap3 = MagicMock()
+        cap3.tool_ref = "consult_schema"
+        cap3.category = "tool"
+        cap3.access_level = None
+
+        agent.capabilities = [cap1, cap2, cap3]
+        agent.small_model_tools = ["delegate", "consult"]  # Different tool!
+
+        registry = ToolRegistry(studio)
+
+        # Large model: should get capability-derived tools
+        tools_large = registry.get_agent_tools(agent, model_class=ModelClass.LARGE)
+        tool_ids_large = {t.id for t in tools_large}
+        assert tool_ids_large == {"delegate", "consult_playbook", "consult_schema"}
+
+        # Small model: should get small_model_tools (complete replacement)
+        tools_small = registry.get_agent_tools(agent, model_class=ModelClass.SMALL)
+        tool_ids_small = {t.id for t in tools_small}
+        assert tool_ids_small == {"delegate", "consult"}
+
+    def test_small_model_tools_fallback_to_capabilities(self):
+        """Without small_model_tools, derive from capabilities for all model sizes."""
+        studio, agent = make_mock_studio_with_tools()
+
+        # Ensure no small_model_tools defined
+        agent.small_model_tools = []
+
+        registry = ToolRegistry(studio)
+
+        # Large model: from capabilities
+        tools_large = registry.get_agent_tools(agent, model_class=ModelClass.LARGE)
+        tool_ids_large = {t.id for t in tools_large}
+        assert "delegate" in tool_ids_large
+        assert "consult_schema" in tool_ids_large
+
+        # Small model: also from capabilities (fallback)
+        tools_small = registry.get_agent_tools(agent, model_class=ModelClass.SMALL)
+        tool_ids_small = {t.id for t in tools_small}
+        assert tool_ids_small == tool_ids_large
+
+    def test_small_model_tools_none_falls_back(self):
+        """When small_model_tools is None, derive from capabilities."""
+        studio, agent = make_mock_studio_with_tools()
+
+        # No small_model_tools attribute
+        agent.small_model_tools = None
+
+        registry = ToolRegistry(studio)
+
+        tools = registry.get_agent_tools(agent, model_class=ModelClass.SMALL)
+        tool_ids = {t.id for t in tools}
+        assert "delegate" in tool_ids
+        assert "consult_schema" in tool_ids
+
+    def test_medium_model_uses_capabilities_not_small_model_tools(self):
+        """Medium model should use capabilities, not small_model_tools."""
+        studio = MagicMock()
+
+        delegate = MagicMock()
+        delegate.id = "delegate"
+        delegate.name = "Delegate"
+        delegate.description = "Delegate work"
+        delegate.timeout_ms = 30000
+        delegate.input_schema = None
+        delegate.concise_description = None
+
+        consult = MagicMock()
+        consult.id = "consult"
+        consult.name = "Consult"
+        consult.description = "Unified consult"
+        consult.timeout_ms = 30000
+        consult.input_schema = None
+        consult.concise_description = None
+
+        studio.tools = [delegate, consult]
+
+        agent = MagicMock()
+        agent.id = "test_agent"
+
+        cap = MagicMock()
+        cap.tool_ref = "delegate"
+        cap.category = "tool"
+        cap.access_level = None
+
+        agent.capabilities = [cap]
+        agent.small_model_tools = ["delegate", "consult"]
+
+        registry = ToolRegistry(studio)
+
+        # Medium model should use capabilities, not small_model_tools
+        tools = registry.get_agent_tools(agent, model_class=ModelClass.MEDIUM)
+        tool_ids = {t.id for t in tools}
+        assert tool_ids == {"delegate"}

--- a/tests/runtime/tools/test_registry.py
+++ b/tests/runtime/tools/test_registry.py
@@ -479,3 +479,34 @@ class TestSmallModelTools:
         tools = registry.get_agent_tools(agent, model_class=ModelClass.MEDIUM)
         tool_ids = {t.id for t in tools}
         assert tool_ids == {"delegate"}
+
+    def test_check_capability_small_model_with_small_model_tools(self):
+        """Capability check uses small_model_tools for small models."""
+        studio, agent = make_mock_studio_with_tools()
+
+        # Agent has consult in small_model_tools but not in capabilities
+        agent.small_model_tools = ["delegate", "consult"]
+
+        registry = ToolRegistry(studio)
+
+        # For small model, consult should be allowed (via small_model_tools)
+        assert registry.check_capability(agent, "consult", model_class=ModelClass.SMALL)
+
+        # For large model, consult should NOT be allowed (not in capabilities)
+        assert not registry.check_capability(agent, "consult", model_class=ModelClass.LARGE)
+
+    def test_enforce_capability_small_model_with_small_model_tools(self):
+        """Capability enforcement uses small_model_tools for small models."""
+        studio, agent = make_mock_studio_with_tools()
+
+        # Agent has consult in small_model_tools but not in capabilities
+        agent.small_model_tools = ["delegate", "consult"]
+
+        registry = ToolRegistry(studio)
+
+        # For small model, consult should not raise
+        registry.enforce_capability(agent, "consult", model_class=ModelClass.SMALL)
+
+        # For large model, consult should raise
+        with pytest.raises(CapabilityViolationError):
+            registry.enforce_capability(agent, "consult", model_class=ModelClass.LARGE)


### PR DESCRIPTION
## Summary

- Add `small_model_tools` agent property - complete tool replacement for small models (8B and under)
- Add `concise_description` tool property - simplified descriptions for small models
- Create unified `consult` tool that dispatches to consult_playbook/knowledge/schema
- Update showrunner with `small_model_tools: ["delegate", "communicate", "terminate_session", "consult"]`

## Token Impact

| Metric | Before | After |
|--------|--------|-------|
| Showrunner tools (small) | 13 | 4 |
| Total tool tokens (small) | ~4,800 | ~1,400 |

## Key Design Decision

`small_model_tools` is a **complete replacement**, not a filter. When defined and non-empty, it completely replaces capability-derived tools. This allows agents to use different tools for small models (e.g., unified `consult` instead of individual `consult_*` tools).

## Test Plan

- [x] Run `pytest tests/runtime/tools/test_registry.py::TestSmallModelTools` - 4 tests pass
- [x] Run `pytest tests/runtime/tools/test_consult.py` - 10 tests pass
- [x] Run `pytest tests/runtime/` - 1029 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, json validation)

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)