### PR TITLE
feat(runtime): Implement sandwich pattern for critical knowledge

### DIFF
--- a/meta/docs/prompt-engineering.md
+++ b/meta/docs/prompt-engineering.md
@@ -443,6 +443,72 @@ Before deploying prompts:
 
 ---
 
+## 12. Chain-of-Thought (CoT)
+
+For complex logical tasks, forcing the model to articulate its reasoning *before* acting significantly reduces hallucination and logic errors.
+
+### The Problem
+
+Zero-shot tool calling often fails on multi-step problems because the model commits to an action before fully processing the constraints.
+
+### Best Practice
+
+Require explicit reasoning steps in the output structure:
+
+- **Structure**: `<thought>Analysis of constraints...</thought>` followed by tool call.
+- **Tooling**: Add a mandatory `reasoning` parameter to critical tools.
+- **Benefits**:
+  - **Debuggability**: exposing the "why" behind an action.
+  - **Accuracy**: +40-50% improvement on complex reasoning benchmarks.
+
+---
+
+## 13. Dynamic Few-Shot Prompting
+
+Static lists of examples ("fixed few-shot") consume tokens and may not match the specific nuance of the current task.
+
+### Best Practice
+
+Use Retrieval-Augmented Generation (RAG) to inject context-aware examples.
+
+1. **Store** a library of high-quality examples (hooks, story beats, validation reports) as vectors.
+2. **Query** this library using the current task description.
+3. **Inject** the top 3-5 most relevant examples into the `Task Layer` of the prompt.
+
+**Standard**: Prefer dynamic injection over static "Must Know" lists for examples. This ensures the agent sees relevant patterns without context window bloat.
+
+---
+
+## 14. Reflection & Self-Correction
+
+Models perform significantly better when asked to critique their own work before finalizing it ("Reflexion").
+
+### Best Practice
+
+Implement a "Check-Act" loop for high-stakes actions (e.g., modifying Canon, finalizing a chapter).
+
+1. **Draft**: Agent generates a preliminary plan or content.
+2. **Critique**: Agent (or a separate "Critic" persona) evaluates the draft against `Constraints` and `Constitution`.
+3. **Refine**: Agent generates the final output based on the critique.
+
+**Implementation**: Use a `validate_plan` tool or an internal thought step to simulate this loop within a single turn for capable models.
+
+---
+
+## 15. Active Context Pruning
+
+Long-running sessions suffer from "Context Rot" where old, irrelevant details confuse the model, even within the token limit.
+
+### Best Practice
+
+Treat context as a garden that must be actively weeded, not just a log file.
+
+- **Semantic Chunking**: Group history by "Episodes" or "Tasks".
+- **Active Forgetting**: When a task is marked complete (e.g., `binding_run` finished), summarize that segment into a high-level outcome and **remove** the raw turns from the active prompt.
+- **State-over-History**: Prefer providing the current *State* (artifacts, flags) over the *History* of how that state was reached.
+
+---
+
 ## Summary Checklist
 
 - [ ] Critical instructions at start AND end (sandwich pattern)
@@ -457,3 +523,7 @@ Before deploying prompts:
 - [ ] Menu + consult pattern for reference material
 - [ ] `injection_priority: "critical"` on must-follow rules
 - [ ] Tested with smallest target model
+- [ ] **CoT/Reasoning enabled for complex tasks**
+- [ ] **Dynamic few-shot used for examples (vs static)**
+- [ ] **Self-correction/Reflection loops implemented**
+- [ ] **Active context pruning strategy defined**

--- a/src/questfoundry/runtime/agent/context.py
+++ b/src/questfoundry/runtime/agent/context.py
@@ -320,7 +320,8 @@ class ContextBuilder:
             use_concise: If True, use concise_description for small models
 
         Returns:
-            Dict with id, name, content or None if entry should be excluded
+            Dict with id, name, content, injection_priority, concise_summary
+            or None if entry should be excluded
         """
         if use_concise:
             # Check for concise_description (small model optimization)
@@ -339,6 +340,8 @@ class ContextBuilder:
             "id": entry.id,
             "name": entry.name or entry.id,
             "content": content,
+            "injection_priority": entry.injection_priority,
+            "concise_summary": entry.concise_summary or entry.summary or "",
         }
 
     def _format_entry_for_menu(

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -178,6 +178,13 @@ class PromptBuilder:
             menu = self._build_knowledge_menu(role_specific_menu)
             self.add_section("knowledge_menu", menu, priority=45)
 
+        # 13. Critical Reminder (sandwich pattern - LOWEST priority = appears LAST)
+        # Repeats critical knowledge at end to combat "Lost in the Middle" effect
+        if must_know_entries:
+            reminder = self._build_critical_reminder_section(must_know_entries)
+            if reminder:
+                self.add_section("critical_reminder", reminder, priority=0)
+
         return self._assemble()
 
     def _build_identity_section(self, agent: Agent) -> str:
@@ -209,6 +216,36 @@ class PromptBuilder:
             lines.append(f"### {name}\n")
             lines.append(content)
             lines.append("")
+
+        return "\n".join(lines)
+
+    def _build_critical_reminder_section(self, entries: list[dict[str, str]]) -> str | None:
+        """Build the critical reminder section (sandwich pattern).
+
+        Extracts entries with injection_priority="critical" and repeats
+        them at the END of the prompt in condensed form. This combats
+        the "Lost in the Middle" effect where models forget instructions
+        that appear in the middle of long prompts.
+
+        Args:
+            entries: List of must_know entries with injection_priority and concise_summary
+
+        Returns:
+            Formatted reminder section, or None if no critical entries
+        """
+        critical_entries = [e for e in entries if e.get("injection_priority") == "critical"]
+
+        if not critical_entries:
+            return None
+
+        lines = ["## REMEMBER (Critical Rules)"]
+        lines.append("")
+
+        for entry in critical_entries:
+            # Use concise_summary for the reminder (not full content)
+            summary = entry.get("concise_summary", "")
+            if summary:
+                lines.append(f"**{entry.get('name', entry.get('id'))}**: {summary}")
 
         return "\n".join(lines)
 

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -231,22 +231,21 @@ class PromptBuilder:
             entries: List of must_know entries with injection_priority and concise_summary
 
         Returns:
-            Formatted reminder section, or None if no critical entries
+            Formatted reminder section, or None if no critical entries with summaries
         """
-        critical_entries = [e for e in entries if e.get("injection_priority") == "critical"]
+        # Collect reminder lines first, then check if any exist
+        reminder_lines = []
+        for entry in entries:
+            if entry.get("injection_priority") == "critical":
+                summary = entry.get("concise_summary", "")
+                if summary:
+                    reminder_lines.append(f"**{entry.get('name', entry.get('id'))}**: {summary}")
 
-        if not critical_entries:
+        if not reminder_lines:
             return None
 
-        lines = ["## REMEMBER (Critical Rules)"]
-        lines.append("")
-
-        for entry in critical_entries:
-            # Use concise_summary for the reminder (not full content)
-            summary = entry.get("concise_summary", "")
-            if summary:
-                lines.append(f"**{entry.get('name', entry.get('id'))}**: {summary}")
-
+        lines = ["## REMEMBER (Critical Rules)", ""]
+        lines.extend(reminder_lines)
         return "\n".join(lines)
 
     def _build_constraints_section(self, agent: Agent) -> str:

--- a/tests/runtime/agent/test_prompt.py
+++ b/tests/runtime/agent/test_prompt.py
@@ -365,7 +365,7 @@ class TestSandwichPattern:
         assert reminder_section.priority == 0  # Lowest priority = appears last
 
     def test_empty_concise_summary_skipped(self, basic_agent: Agent) -> None:
-        """Entries with empty concise_summary are skipped in reminder."""
+        """No REMEMBER section when only critical entry has empty summary."""
         builder = PromptBuilder()
         must_know = [
             {
@@ -379,8 +379,5 @@ class TestSandwichPattern:
 
         result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
 
-        # Reminder section may exist but without this entry's name
-        # (since its summary is empty, it won't be added to the reminder)
-        if "REMEMBER" in result.text:
-            reminder_section = result.text.split("REMEMBER")[-1]
-            assert "No Summary Entry" not in reminder_section
+        # The REMEMBER section should not be generated at all if it would be empty
+        assert "REMEMBER" not in result.text

--- a/tests/runtime/agent/test_prompt.py
+++ b/tests/runtime/agent/test_prompt.py
@@ -227,3 +227,160 @@ class TestBuildPromptConvenience:
         assert isinstance(result, BuiltPrompt)
         assert "Test Agent" in result.text
         assert "Test constitution" in result.text
+
+
+class TestSandwichPattern:
+    """Tests for the sandwich pattern (critical reminder at end)."""
+
+    def test_critical_reminder_appears_at_end(self, basic_agent: Agent) -> None:
+        """Critical entries are repeated at the end of the prompt."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "critical_rules",
+                "name": "Critical Rules",
+                "content": "Full content of critical rules here.",
+                "injection_priority": "critical",
+                "concise_summary": "Tools only. Never write prose.",
+            },
+        ]
+
+        result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
+
+        # Check that reminder section exists
+        assert "REMEMBER (Critical Rules)" in result.text
+
+        # Check the condensed summary is used
+        assert "Tools only. Never write prose." in result.text
+
+        # Verify reminder appears AFTER the main must_know section
+        must_know_pos = result.text.find("Critical Knowledge")
+        reminder_pos = result.text.find("REMEMBER (Critical Rules)")
+        assert reminder_pos > must_know_pos
+
+    def test_no_reminder_for_non_critical_entries(self, basic_agent: Agent) -> None:
+        """No reminder section when no critical entries exist."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "normal_knowledge",
+                "name": "Normal Knowledge",
+                "content": "Some normal knowledge.",
+                "injection_priority": "normal",
+                "concise_summary": "Just normal stuff.",
+            },
+        ]
+
+        result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
+
+        # No reminder section
+        assert "REMEMBER" not in result.text
+
+    def test_reminder_uses_concise_summary_not_full_content(self, basic_agent: Agent) -> None:
+        """Reminder uses concise_summary to avoid repeating full content."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "verbose_entry",
+                "name": "Verbose Entry",
+                "content": "This is a very long full content that should not appear twice.",
+                "injection_priority": "critical",
+                "concise_summary": "Short reminder.",
+            },
+        ]
+
+        result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
+
+        # Full content appears once (in must_know section)
+        assert result.text.count("very long full content") == 1
+
+        # Concise summary appears in reminder
+        assert "Short reminder." in result.text
+
+    def test_multiple_critical_entries_in_reminder(self, basic_agent: Agent) -> None:
+        """Multiple critical entries all appear in the reminder."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "rule1",
+                "name": "Rule One",
+                "content": "Full rule one.",
+                "injection_priority": "critical",
+                "concise_summary": "Summary one.",
+            },
+            {
+                "id": "rule2",
+                "name": "Rule Two",
+                "content": "Full rule two.",
+                "injection_priority": "critical",
+                "concise_summary": "Summary two.",
+            },
+            {
+                "id": "optional",
+                "name": "Optional Info",
+                "content": "Not critical.",
+                "injection_priority": "low",
+                "concise_summary": "Low priority.",
+            },
+        ]
+
+        result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
+
+        # Both critical summaries appear
+        assert "Summary one." in result.text
+        assert "Summary two." in result.text
+
+        # Low priority entry NOT in reminder
+        # Check that "Low priority." only appears in the must_know section, not in REMEMBER
+        reminder_section = result.text.split("REMEMBER")[-1] if "REMEMBER" in result.text else ""
+        assert "Low priority." not in reminder_section
+
+    def test_reminder_section_has_lowest_priority(self, basic_agent: Agent) -> None:
+        """Critical reminder section has priority=0 (appears last)."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "critical_rules",
+                "name": "Critical Rules",
+                "content": "Critical content.",
+                "injection_priority": "critical",
+                "concise_summary": "Remember this.",
+            },
+        ]
+
+        result = builder.build_for_agent(
+            basic_agent,
+            must_know_entries=must_know,
+            role_specific_menu=[{"id": "menu1", "name": "Menu Item", "summary": "Menu summary"}],
+        )
+
+        # Find the critical_reminder section
+        reminder_section = None
+        for section in result.sections:
+            if section.name == "critical_reminder":
+                reminder_section = section
+                break
+
+        assert reminder_section is not None
+        assert reminder_section.priority == 0  # Lowest priority = appears last
+
+    def test_empty_concise_summary_skipped(self, basic_agent: Agent) -> None:
+        """Entries with empty concise_summary are skipped in reminder."""
+        builder = PromptBuilder()
+        must_know = [
+            {
+                "id": "no_summary",
+                "name": "No Summary Entry",
+                "content": "Has content but no summary.",
+                "injection_priority": "critical",
+                "concise_summary": "",
+            },
+        ]
+
+        result = builder.build_for_agent(basic_agent, must_know_entries=must_know)
+
+        # Reminder section may exist but without this entry's name
+        # (since its summary is empty, it won't be added to the reminder)
+        if "REMEMBER" in result.text:
+            reminder_section = result.text.split("REMEMBER")[-1]
+            assert "No Summary Entry" not in reminder_section


### PR DESCRIPTION
## Summary

Addresses Phase 1 of #297. Implements the "Lost in the Middle" mitigation by repeating critical knowledge entries at the END of the prompt in condensed form.

- **context.py**: `_format_entry_for_injection()` now includes `injection_priority` and `concise_summary` fields in the returned dict
- **prompt.py**: Add `_build_critical_reminder_section()` that extracts entries with `injection_priority="critical"` and formats them using `concise_summary` (not full content) in a "REMEMBER" section
- **prompt.py**: Wire up reminder section with `priority=0` (lowest, so it appears last in the assembled prompt)

The sandwich pattern combats the known issue where models forget instructions that appear in the middle of long prompts. Critical rules now appear both in the full knowledge section AND as a condensed reminder at the very end.

### Example Output

The Showrunner prompt now ends with:
```markdown
## REMEMBER (Critical Rules)

**Runtime Guidelines (Core)**: Tools only. Never write prose.
```

## Test plan

- [x] All 1019 existing tests pass
- [x] 6 new sandwich pattern tests added covering:
  - Critical reminder appears at end of prompt
  - No reminder for non-critical entries
  - Reminder uses concise_summary (not full content)
  - Multiple critical entries all appear
  - Reminder section has lowest priority (0)
  - Empty concise_summary entries are skipped
- [x] Verified with CLI: `uv run qf agent prompt -f showrunner` shows REMEMBER section at end

🤖 Generated with [Claude Code](https://claude.com/claude-code)