### PR TITLE
feat(domain): Mark critical knowledge entries for sandwich pattern

### DIFF
--- a/domain-v4/knowledge/must_know/artifact_model.json
+++ b/domain-v4/knowledge/must_know/artifact_model.json
@@ -10,6 +10,8 @@
 
   "concise_description": "",
 
+  "injection_priority": "critical",
+
   "keywords": ["artifact", "artifact type", "stores", "lifecycle", "versioning", "artifact ID"],
 
   "triggers": [

--- a/domain-v4/knowledge/must_know/choice_integrity.json
+++ b/domain-v4/knowledge/must_know/choice_integrity.json
@@ -6,6 +6,10 @@
 
   "summary": "Choices must be contrastive (differ in intent and outcome). Two clear options beat five near-synonyms. Convergence must be acknowledged.",
 
+  "concise_summary": "Choices must differ in intent AND outcome. No near-synonyms.",
+
+  "injection_priority": "critical",
+
   "keywords": ["choices", "contrastive", "convergence", "fake agency", "meaningful choices"],
 
   "triggers": [

--- a/domain-v4/knowledge/must_know/spoiler_hygiene.json
+++ b/domain-v4/knowledge/must_know/spoiler_hygiene.json
@@ -6,6 +6,10 @@
 
   "summary": "Player-facing surfaces must never reveal twists, secrets, or backstory that the narrative intends to reveal through play. Keep canon separate from codex.",
 
+  "concise_summary": "Never reveal twists, secrets, or mechanics on player surfaces.",
+
+  "injection_priority": "critical",
+
   "keywords": ["spoilers", "player-safe", "canon", "codex", "secrets", "twists", "player surfaces"],
 
   "triggers": [


### PR DESCRIPTION
## Summary

Phase 5 of #297. Adds `injection_priority="critical"` to key knowledge entries so they appear in the REMEMBER section at the end of prompts.

- **spoiler_hygiene**: Player-facing content rules (+ added `concise_summary`)
- **choice_integrity**: Contrastive choices rule (+ added `concise_summary`)
- **artifact_model**: Always pass artifact IDs (already had `concise_summary`)

These entries are now repeated at the end of agent prompts to combat the "Lost in the Middle" effect.

### Showrunner REMEMBER Section
```
## REMEMBER (Critical Rules)

**Runtime Guidelines (Core)**: Tools only. Never write prose.
**Artifact Model**: Artifacts are versioned work products. Always pass artifact IDs.
**Spoiler Hygiene**: Never reveal twists, secrets, or mechanics on player surfaces.
```

### Scene Smith REMEMBER Section
```
## REMEMBER (Critical Rules)

**Spoiler Hygiene**: Never reveal twists, secrets, or mechanics on player surfaces.
**Artifact Model**: Artifacts are versioned work products. Always pass artifact IDs.
**Choice Integrity**: Choices must differ in intent AND outcome. No near-synonyms.
```

Note: Entries only appear for agents they're applicable to (via `applicable_to.archetypes`).

## Test plan

- [x] All 1019 tests pass
- [x] Verified `uv run qf agent prompt -f showrunner` shows 3 critical entries
- [x] Verified `uv run qf agent prompt -f scene_smith` shows 3 entries (including choice_integrity)
- [x] JSON schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)