### PR TITLE
feat(prompt-engineering): Add Chain-of-Thought reasoning to all tools (Phase 2)

### DIFF
--- a/domain-v4/tools/analyze_story_graph.json
+++ b/domain-v4/tools/analyze_story_graph.json
@@ -4,12 +4,14 @@
   "name": "Analyze Story Graph",
   "summary": "Analyze story topology for structural issues",
   "description": "Reads the authoritative topology artifact and validates story structure. Uses story.start as entry point and checks alignment with passage_brief and passage artifacts.\n\nAnalysis checks:\n1. Reachability - Can all passages be reached from start?\n2. Dead ends - Passages with no outgoing links (except endings)\n3. Orphans - Passages with no incoming links (except start)\n4. Missing targets - Links to non-existent passages\n5. Alignment - Do briefs/passages match topology?\n6. Lifecycle - What state are the artifacts in?\n\nReturns structured analysis with actionable recovery actions.",
-
   "summarization_policy": "preserve",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "include_drafts": {
         "type": "boolean",
         "default": true,
@@ -19,16 +21,22 @@
         "type": "string",
         "description": "Optional explicit entry point passage pid. If not provided, uses story.start."
       }
-    }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "description": "Structured analysis result with blocking issues, warnings, and recovery actions",
     "properties": {
       "analysis_outcome": {
         "type": "string",
-        "enum": ["passed", "warnings", "failed"],
+        "enum": [
+          "passed",
+          "warnings",
+          "failed"
+        ],
         "description": "Analysis outcome: passed (no issues), warnings (non-blocking concerns), failed (blocking issues)"
       },
       "blocking_issues": {
@@ -39,12 +47,31 @@
           "properties": {
             "issue_type": {
               "type": "string",
-              "enum": ["no_topology", "no_start_passage", "invalid_start_passage", "missing_targets"]
+              "enum": [
+                "no_topology",
+                "no_start_passage",
+                "invalid_start_passage",
+                "missing_targets"
+              ]
             },
-            "severity": { "type": "string", "enum": ["blocking"] },
-            "description": { "type": "string" },
-            "affected_nodes": { "type": "array", "items": { "type": "string" } },
-            "count": { "type": "integer" }
+            "severity": {
+              "type": "string",
+              "enum": [
+                "blocking"
+              ]
+            },
+            "description": {
+              "type": "string"
+            },
+            "affected_nodes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "count": {
+              "type": "integer"
+            }
           }
         }
       },
@@ -56,12 +83,39 @@
           "properties": {
             "issue_type": {
               "type": "string",
-              "enum": ["unreachable_passages", "dead_ends", "orphan_passages", "briefs_missing", "briefs_extra", "passages_missing", "passages_extra", "no_stable_passages", "no_endings", "ifid_mismatch", "multiple_entry_points", "duplicate_pids"]
+              "enum": [
+                "unreachable_passages",
+                "dead_ends",
+                "orphan_passages",
+                "briefs_missing",
+                "briefs_extra",
+                "passages_missing",
+                "passages_extra",
+                "no_stable_passages",
+                "no_endings",
+                "ifid_mismatch",
+                "multiple_entry_points",
+                "duplicate_pids"
+              ]
             },
-            "severity": { "type": "string", "enum": ["warning"] },
-            "description": { "type": "string" },
-            "affected_nodes": { "type": "array", "items": { "type": "string" } },
-            "count": { "type": "integer" }
+            "severity": {
+              "type": "string",
+              "enum": [
+                "warning"
+              ]
+            },
+            "description": {
+              "type": "string"
+            },
+            "affected_nodes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "count": {
+              "type": "integer"
+            }
           }
         }
       },
@@ -71,9 +125,23 @@
         "items": {
           "type": "object",
           "properties": {
-            "priority": { "type": "string", "enum": ["high", "medium", "low", "info"] },
-            "action": { "type": "string", "description": "What to do" },
-            "details": { "type": "string", "description": "Specific details" }
+            "priority": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low",
+                "info"
+              ]
+            },
+            "action": {
+              "type": "string",
+              "description": "What to do"
+            },
+            "details": {
+              "type": "string",
+              "description": "Specific details"
+            }
           }
         }
       },
@@ -85,44 +153,98 @@
             "type": "object",
             "description": "Story identity from story artifact",
             "properties": {
-              "ifid": { "type": "string", "description": "Story IFID" },
-              "name": { "type": "string", "description": "Story name" },
-              "start": { "type": "string", "description": "Start passage pid" }
+              "ifid": {
+                "type": "string",
+                "description": "Story IFID"
+              },
+              "name": {
+                "type": "string",
+                "description": "Story name"
+              },
+              "start": {
+                "type": "string",
+                "description": "Start passage pid"
+              }
             }
           },
           "summary": {
             "type": "object",
             "properties": {
-              "total_passages": { "type": "integer" },
-              "reachable_count": { "type": "integer" },
-              "unreachable_count": { "type": "integer" },
-              "dead_end_count": { "type": "integer" },
-              "ending_count": { "type": "integer" },
-              "orphan_count": { "type": "integer" },
-              "missing_target_count": { "type": "integer" },
-              "has_reachable_stable_passage": { "type": "boolean" }
+              "total_passages": {
+                "type": "integer"
+              },
+              "reachable_count": {
+                "type": "integer"
+              },
+              "unreachable_count": {
+                "type": "integer"
+              },
+              "dead_end_count": {
+                "type": "integer"
+              },
+              "ending_count": {
+                "type": "integer"
+              },
+              "orphan_count": {
+                "type": "integer"
+              },
+              "missing_target_count": {
+                "type": "integer"
+              },
+              "has_reachable_stable_passage": {
+                "type": "boolean"
+              }
             }
           },
           "reachability": {
             "type": "object",
             "properties": {
-              "reachable": { "type": "array", "items": { "type": "string" } },
-              "unreachable": { "type": "array", "items": { "type": "string" } }
+              "reachable": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "unreachable": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
           },
           "structural": {
             "type": "object",
             "properties": {
-              "dead_ends": { "type": "array", "items": { "type": "string" } },
-              "endings": { "type": "array", "items": { "type": "string" } },
-              "orphans": { "type": "array", "items": { "type": "string" } },
+              "dead_ends": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "endings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "orphans": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "missing_targets": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "from": { "type": "string" },
-                    "to": { "type": "string" }
+                    "from": {
+                      "type": "string"
+                    },
+                    "to": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -132,10 +254,30 @@
             "type": "object",
             "description": "Alignment between topology and passage artifacts",
             "properties": {
-              "briefs_missing": { "type": "array", "items": { "type": "string" } },
-              "passages_missing": { "type": "array", "items": { "type": "string" } },
-              "briefs_extra": { "type": "array", "items": { "type": "string" } },
-              "passages_extra": { "type": "array", "items": { "type": "string" } }
+              "briefs_missing": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "passages_missing": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "briefs_extra": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "passages_extra": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
           },
           "lifecycle": {
@@ -143,11 +285,21 @@
             "properties": {
               "by_brief": {
                 "type": "object",
-                "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "by_passage": {
                 "type": "object",
-                "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -157,17 +309,58 @@
             "additionalProperties": {
               "type": "object",
               "properties": {
-                "pid": { "type": "string" },
-                "name": { "type": "string" },
-                "topology_role": { "type": ["string", "null"], "enum": ["hub", "loop", "gateway", "linear", null] },
-                "is_ending": { "type": "boolean" },
-                "tags": { "type": "array", "items": { "type": "string" } },
-                "brief_artifact_id": { "type": "string" },
-                "brief_lifecycle": { "type": "string" },
-                "passage_artifact_id": { "type": "string" },
-                "passage_lifecycle": { "type": "string" },
-                "outgoing": { "type": "array", "items": { "type": "string" } },
-                "incoming": { "type": "array", "items": { "type": "string" } }
+                "pid": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "topology_role": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "enum": [
+                    "hub",
+                    "loop",
+                    "gateway",
+                    "linear",
+                    null
+                  ]
+                },
+                "is_ending": {
+                  "type": "boolean"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "brief_artifact_id": {
+                  "type": "string"
+                },
+                "brief_lifecycle": {
+                  "type": "string"
+                },
+                "passage_artifact_id": {
+                  "type": "string"
+                },
+                "passage_lifecycle": {
+                  "type": "string"
+                },
+                "outgoing": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "incoming": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -175,7 +368,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Full story graph validation",

--- a/domain-v4/tools/assemble_export.json
+++ b/domain-v4/tools/assemble_export.json
@@ -4,12 +4,14 @@
   "name": "Assemble Export",
   "summary": "Build export bundle from canon snapshot",
   "description": "Assemble a player-safe export bundle from a Canon snapshot. Compiles manuscript, codex, and optional assets into distributable formats (MD/HTML/EPUB/PDF). Validates link integrity, generates navigation, and stamps front matter.\n\nThis tool does NOT edit content - it packages what exists. If integrity issues are found, they're reported for upstream fixes.",
-
   "summarization_policy": "preserve",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "snapshot_id": {
         "type": "string",
         "description": "Canon snapshot ID to export from (e.g., 'canon@2025-12-13T10:00:00Z' or a tag name)"
@@ -18,9 +20,17 @@
         "type": "array",
         "items": {
           "type": "string",
-          "enum": ["markdown", "html", "epub", "pdf"]
+          "enum": [
+            "markdown",
+            "html",
+            "epub",
+            "pdf"
+          ]
         },
-        "default": ["markdown", "html"],
+        "default": [
+          "markdown",
+          "html"
+        ],
         "description": "Output formats to generate"
       },
       "options": {
@@ -48,8 +58,12 @@
           },
           "languages": {
             "type": "array",
-            "items": { "type": "string" },
-            "default": ["en"],
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "en"
+            ],
             "description": "Language codes to include"
           },
           "print_friendly": {
@@ -66,9 +80,11 @@
         "description": "If true, run integrity checks without generating output"
       }
     },
-    "required": ["snapshot_id"]
+    "required": [
+      "reasoning",
+      "snapshot_id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -84,49 +100,80 @@
         "items": {
           "type": "object",
           "properties": {
-            "format": { "type": "string" },
-            "path": { "type": "string" },
-            "size_bytes": { "type": "integer" }
+            "format": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "size_bytes": {
+              "type": "integer"
+            }
           }
         }
       },
       "integrity_report": {
         "type": "object",
         "properties": {
-          "total_anchors": { "type": "integer" },
-          "broken_links": { "type": "array", "items": { "type": "string" } },
-          "missing_alt_text": { "type": "array", "items": { "type": "string" } },
-          "orphan_pages": { "type": "array", "items": { "type": "string" } }
+          "total_anchors": {
+            "type": "integer"
+          },
+          "broken_links": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "missing_alt_text": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "orphan_pages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "coverage": {
         "type": "object",
         "description": "Coverage percentages by language",
-        "additionalProperties": { "type": "number" }
+        "additionalProperties": {
+          "type": "number"
+        }
       },
       "warnings": {
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
     }
   },
-
   "timeout_ms": 120000,
-
   "retry_policy": {
     "max_retries": 1,
     "initial_delay_ms": 5000,
-    "retryable_errors": ["timeout"]
+    "retryable_errors": [
+      "timeout"
+    ]
   },
-
   "examples": [
     {
       "description": "Export a chapter for playtest",
       "input": {
         "snapshot_id": "canon@2025-12-01",
-        "output_formats": ["markdown", "html"],
+        "output_formats": [
+          "markdown",
+          "html"
+        ],
         "options": {
-          "languages": ["en"],
+          "languages": [
+            "en"
+          ],
           "print_friendly": true
         }
       }
@@ -142,10 +189,19 @@
       "description": "Full export with art and translations",
       "input": {
         "snapshot_id": "release-v1.0",
-        "output_formats": ["markdown", "html", "epub", "pdf"],
+        "output_formats": [
+          "markdown",
+          "html",
+          "epub",
+          "pdf"
+        ],
         "options": {
           "include_art_renders": true,
-          "languages": ["en", "nl", "de"],
+          "languages": [
+            "en",
+            "nl",
+            "de"
+          ],
           "print_friendly": true
         }
       }

--- a/domain-v4/tools/communicate.json
+++ b/domain-v4/tools/communicate.json
@@ -4,16 +4,23 @@
   "name": "Communicate with Customer",
   "summary": "Send messages to customer or ask questions",
   "description": "Communicate with the human customer - send updates, ask questions, or report errors.\n\nALL message types terminate your turn. The difference is whether the runtime waits for a response:\n- status: Progress update - runtime continues immediately\n- notification: Milestone announcement - runtime continues immediately\n- question: Waits for customer response before resuming\n- error: May wait for customer decision depending on severity\n\nUse this when you need to report progress, request input, or escalate decisions.",
-
   "terminates_turn": true,
   "summarization_policy": "preserve",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "type": {
         "type": "string",
-        "enum": ["status", "question", "notification", "error"],
+        "enum": [
+          "status",
+          "question",
+          "notification",
+          "error"
+        ],
         "description": "Type of communication"
       },
       "message": {
@@ -42,7 +49,10 @@
               "description": "What choosing this option would lead to"
             }
           },
-          "required": ["id", "description"]
+          "required": [
+            "id",
+            "description"
+          ]
         },
         "description": "For questions: structured choices to present"
       },
@@ -59,14 +69,21 @@
       },
       "severity": {
         "type": "string",
-        "enum": ["info", "warning", "error"],
+        "enum": [
+          "info",
+          "warning",
+          "error"
+        ],
         "default": "info",
         "description": "For errors: severity level. 'error' severity may block for customer decision."
       }
     },
-    "required": ["type", "message"]
+    "required": [
+      "reasoning",
+      "type",
+      "message"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -90,7 +107,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Status update",
@@ -106,9 +122,21 @@
         "message": "What tone would you like for this story?",
         "context": "The tone will affect word choice, pacing, and themes throughout.",
         "options": [
-          { "id": "dark", "description": "Dark and serious", "implications": "Gothic atmosphere, moral ambiguity" },
-          { "id": "light", "description": "Light and adventurous", "implications": "Upbeat pacing, clear heroes/villains" },
-          { "id": "balanced", "description": "Balanced mix", "implications": "Varies by scene as appropriate" }
+          {
+            "id": "dark",
+            "description": "Dark and serious",
+            "implications": "Gothic atmosphere, moral ambiguity"
+          },
+          {
+            "id": "light",
+            "description": "Light and adventurous",
+            "implications": "Upbeat pacing, clear heroes/villains"
+          },
+          {
+            "id": "balanced",
+            "description": "Balanced mix",
+            "implications": "Varies by scene as appropriate"
+          }
         ],
         "default_option": "balanced"
       }
@@ -118,7 +146,9 @@
       "input": {
         "type": "notification",
         "message": "Chapter 1 draft is ready for your review.",
-        "artifacts": ["workspace:section:chapter_1_v1"]
+        "artifacts": [
+          "workspace:section:chapter_1_v1"
+        ]
       }
     },
     {

--- a/domain-v4/tools/consult.json
+++ b/domain-v4/tools/consult.json
@@ -5,16 +5,22 @@
   "summary": "Look up playbooks, knowledge, or schemas",
   "description": "Unified lookup tool for reference material. Use this to retrieve detailed guidance, workflow definitions, or artifact schemas.\n\nLookup types:\n- playbook: Get workflow phases, steps, agents, and completion criteria\n- knowledge: Get full content of knowledge entries from your Knowledge Menu\n- schema: Get artifact type definitions with fields and validation rules",
   "concise_description": "Look up reference material by type and ID.",
-
   "summarization_policy": "drop",
   "summary_template": "Retrieved {lookup_type}: {id}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "lookup_type": {
         "type": "string",
-        "enum": ["playbook", "knowledge", "schema"],
+        "enum": [
+          "playbook",
+          "knowledge",
+          "schema"
+        ],
         "description": "Type of reference to look up"
       },
       "id": {
@@ -36,9 +42,12 @@
         "description": "For schema lookups: include validation rules"
       }
     },
-    "required": ["lookup_type", "id"]
+    "required": [
+      "reasoning",
+      "lookup_type",
+      "id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -56,7 +65,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Get playbook details for Story Spark workflow",

--- a/domain-v4/tools/consult_corpus.json
+++ b/domain-v4/tools/consult_corpus.json
@@ -4,16 +4,23 @@
   "name": "Consult Corpus",
   "summary": "Search craft guidance in the corpus",
   "description": "Access the craft corpus for writing guidance and genre conventions. Supports multiple modes:\n\n- **toc**: Get table of contents listing all corpus files\n- **file**: Retrieve full content of a specific file\n- **cluster**: Browse files in a cluster (genre-conventions, prose-and-language, etc.)\n- **search**: Search for relevant excerpts (default mode)\n\nUse this for prose techniques, choice architecture, genre conventions, and craft guidance.",
-
   "summarization_policy": "drop",
   "summary_template": "Retrieved {excerpt_count} excerpts from corpus",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "mode": {
         "type": "string",
-        "enum": ["search", "toc", "file", "cluster"],
+        "enum": [
+          "search",
+          "toc",
+          "file",
+          "cluster"
+        ],
         "default": "search",
         "description": "Operation mode: 'search' for keyword/semantic search, 'toc' for table of contents, 'file' for direct file access, 'cluster' for browsing by cluster"
       },
@@ -45,9 +52,11 @@
         "maximum": 10,
         "description": "Maximum number of excerpts to return (mode=search only)"
       }
-    }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -98,10 +107,18 @@
         "items": {
           "type": "object",
           "properties": {
-            "title": { "type": "string" },
-            "summary": { "type": "string" },
-            "cluster": { "type": "string" },
-            "path": { "type": "string" }
+            "title": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "cluster": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
           }
         }
       },
@@ -109,17 +126,29 @@
         "type": "object",
         "description": "File content (mode=file)",
         "properties": {
-          "title": { "type": "string" },
-          "summary": { "type": "string" },
-          "cluster": { "type": "string" },
+          "title": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "string"
+          },
           "sections": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "heading": { "type": "string" },
-                "level": { "type": "integer" },
-                "content": { "type": "string" }
+                "heading": {
+                  "type": "string"
+                },
+                "level": {
+                  "type": "integer"
+                },
+                "content": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -131,15 +160,20 @@
         "items": {
           "type": "object",
           "properties": {
-            "title": { "type": "string" },
-            "summary": { "type": "string" },
-            "path": { "type": "string" }
+            "title": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
           }
         }
       }
     }
   },
-
   "examples": [
     {
       "description": "Get table of contents",

--- a/domain-v4/tools/consult_knowledge.json
+++ b/domain-v4/tools/consult_knowledge.json
@@ -4,13 +4,15 @@
   "name": "Consult Knowledge",
   "summary": "Retrieve full content of a knowledge entry",
   "description": "Retrieve detailed guidance from the studio knowledge base. Use this when you need full content for entries shown in your Knowledge Menu.\n\nThe Knowledge Menu in your system prompt shows summaries of available knowledge. Use this tool to get the complete content when you need detailed guidance, examples, or procedures.\n\nCommon uses:\n- Get detailed examples when summary is insufficient\n- Retrieve full procedures or checklists\n- Access domain-specific guidance for specialized tasks",
-
   "summarization_policy": "drop",
   "summary_template": "Retrieved knowledge: {name}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "entry_id": {
         "type": "string",
         "description": "The knowledge entry ID (e.g., 'spoiler_hygiene', 'runtime_guidelines', 'style_lead_heuristics')"
@@ -20,9 +22,11 @@
         "description": "Optional: specific section heading within the entry to retrieve. Use when you only need part of a large entry."
       }
     },
-    "required": ["entry_id"]
+    "required": [
+      "reasoning",
+      "entry_id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -36,7 +40,13 @@
       },
       "layer": {
         "type": "string",
-        "enum": ["constitution", "must_know", "should_know", "role_specific", "lookup"],
+        "enum": [
+          "constitution",
+          "must_know",
+          "should_know",
+          "role_specific",
+          "lookup"
+        ],
         "description": "Which knowledge layer this entry belongs to. See domain-v4/knowledge/layers.json for layer definitions."
       },
       "content": {
@@ -45,12 +55,13 @@
       },
       "related_entries": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "IDs of related knowledge entries you might also want to consult"
       }
     }
   },
-
   "examples": [
     {
       "description": "Get spoiler hygiene guidance",
@@ -62,7 +73,10 @@
         "name": "Spoiler Hygiene",
         "layer": "must_know",
         "content": "## Spoiler Hygiene\n\nNever reveal future plot points...",
-        "related_entries": ["sources_of_truth", "diegetic_gating"]
+        "related_entries": [
+          "sources_of_truth",
+          "diegetic_gating"
+        ]
       }
     },
     {

--- a/domain-v4/tools/consult_playbook.json
+++ b/domain-v4/tools/consult_playbook.json
@@ -4,21 +4,25 @@
   "name": "Consult Playbook",
   "summary": "Get full details of a playbook",
   "description": "Retrieve full details for a playbook/workflow. Returns the sequence of phases and steps, which agents handle each step, input/output artifacts, completion criteria, and quality checkpoints. Use this to understand how a workflow should be orchestrated.",
-
   "summarization_policy": "drop",
   "summary_template": "Retrieved playbook: {name}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "playbook_id": {
         "type": "string",
         "description": "The ID of the playbook to retrieve (e.g., 'story_spark', 'scene_weave'). See prompt for available playbook IDs."
       }
     },
-    "required": ["playbook_id"]
+    "required": [
+      "reasoning",
+      "playbook_id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -56,7 +60,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Get full details for the Story Spark workflow",

--- a/domain-v4/tools/consult_schema.json
+++ b/domain-v4/tools/consult_schema.json
@@ -4,13 +4,15 @@
   "name": "Consult Schema",
   "summary": "Get the JSON schema for an artifact type",
   "description": "Retrieve the schema definition for an artifact type. Returns the field definitions, validation rules, and lifecycle states for the specified artifact type. Use this to understand the structure of artifacts before creating or validating them.\n\nPattern: consult-schema - agent asks for schema, gets both structure and documentation.",
-
   "summarization_policy": "drop",
   "summary_template": "Schema for {artifact_type_id} retrieved",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "artifact_type_id": {
         "type": "string",
         "description": "The ID of the artifact type to retrieve (e.g., 'passage', 'hook_card', 'passage_brief')"
@@ -26,9 +28,11 @@
         "description": "Whether to include validation rules in the response"
       }
     },
-    "required": ["artifact_type_id"]
+    "required": [
+      "reasoning",
+      "artifact_type_id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -46,7 +50,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Get the Passage Brief schema before creating one",

--- a/domain-v4/tools/delegate.json
+++ b/domain-v4/tools/delegate.json
@@ -4,21 +4,29 @@
   "name": "Delegate Work",
   "summary": "Assign work to another agent",
   "description": "Delegate work to another agent. This hands off control until the agent completes the task.\n\nProvide:\n- task: Clear description of what needs to be done\n- context: Relevant artifact IDs and background\n- expected_outputs: What artifacts should be produced\n- quality_criteria: How to judge completion quality\n\nThe receiving agent executes the work and returns control via return_to_orchestrator with artifact IDs and assessment.\n\nThis tool TERMINATES YOUR TURN - you yield control and resume when the agent returns.",
-
   "terminates_turn": true,
   "summarization_policy": "ultra_concise",
   "summary_template": "Delegated to {assigned_to}: {task}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "to_agent": {
         "type": "string",
         "description": "ID of the agent to delegate to (e.g., 'scene_smith', 'gatekeeper')"
       },
       "to_archetype": {
         "type": "string",
-        "enum": ["orchestrator", "creator", "validator", "researcher", "curator"],
+        "enum": [
+          "orchestrator",
+          "creator",
+          "validator",
+          "researcher",
+          "curator"
+        ],
         "description": "Alternative: delegate to any agent of this archetype"
       },
       "task": {
@@ -30,12 +38,16 @@
         "properties": {
           "artifact_refs": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "IDs of relevant artifacts"
           },
           "knowledge_refs": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "References to relevant knowledge entries"
           },
           "notes": {
@@ -49,20 +61,31 @@
         "items": {
           "type": "object",
           "properties": {
-            "artifact_type": { "type": "string" },
-            "description": { "type": "string" }
+            "artifact_type": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
           }
         },
         "description": "What artifacts should be produced"
       },
       "quality_criteria": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Specific quality criteria to meet"
       },
       "priority": {
         "type": "string",
-        "enum": ["low", "normal", "high", "urgent"],
+        "enum": [
+          "low",
+          "normal",
+          "high",
+          "urgent"
+        ],
         "default": "normal"
       },
       "playbook_ref": {
@@ -74,9 +97,11 @@
         "description": "Reference to playbook phase"
       }
     },
-    "required": ["task"]
+    "required": [
+      "reasoning",
+      "task"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -86,7 +111,13 @@
       },
       "status": {
         "type": "string",
-        "enum": ["sent", "accepted", "in_progress", "completed", "blocked"],
+        "enum": [
+          "sent",
+          "accepted",
+          "in_progress",
+          "completed",
+          "blocked"
+        ],
         "description": "Current delegation status"
       },
       "assigned_to": {
@@ -95,7 +126,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Delegate section drafting to Scene Smith",
@@ -103,13 +133,21 @@
         "to_agent": "scene_smith",
         "task": "Draft section prose for SB-005 (The Lighthouse Lock)",
         "context": {
-          "artifact_refs": ["SB-005"],
+          "artifact_refs": [
+            "SB-005"
+          ],
           "notes": "Hub with 3 exits; player discovers lighthouse is locked"
         },
         "expected_outputs": [
-          { "artifact_type": "passage", "description": "Draft passage with 3 choices" }
+          {
+            "artifact_type": "passage",
+            "description": "Draft passage with 3 choices"
+          }
         ],
-        "quality_criteria": ["choice_integrity", "diegetic_gates"]
+        "quality_criteria": [
+          "choice_integrity",
+          "diegetic_gates"
+        ]
       }
     },
     {
@@ -118,10 +156,15 @@
         "to_agent": "gatekeeper",
         "task": "Gatecheck passage-005 for Cold merge",
         "context": {
-          "artifact_refs": ["passage-005"]
+          "artifact_refs": [
+            "passage-005"
+          ]
         },
         "expected_outputs": [
-          { "artifact_type": "gatecheck_report", "description": "All 8 bars assessed" }
+          {
+            "artifact_type": "gatecheck_report",
+            "description": "All 8 bars assessed"
+          }
         ]
       }
     }

--- a/domain-v4/tools/generate_audio.json
+++ b/domain-v4/tools/generate_audio.json
@@ -3,16 +3,17 @@
   "id": "generate_audio",
   "name": "Generate Audio",
   "summary": "Generate audio from a plan",
-  "description": "Generate an audio asset from an Audio Plan. Consults Style Guide for sonic aesthetic. Returns an audio asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Audio Plans should exist for ALL worthy moments, but generation is selective based on priority.\n\nRuntime provides implementation (TTS, music generation, sound library, commission queue, etc.).",
-
+  "description": "Generate an audio asset from an Audio Plan. Consults Style Guide for sonic aesthetic. Returns an audio asset with determinism log (kept off-surface).\n\nThis tool is expensive\u2014use only when budget allows. Audio Plans should exist for ALL worthy moments, but generation is selective based on priority.\n\nRuntime provides implementation (TTS, music generation, sound library, commission queue, etc.).",
   "cost_tier": "high",
-
   "summarization_policy": "ultra_concise",
   "summary_template": "Generated audio from {source_plan}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "audio_plan_ref": {
         "type": "string",
         "description": "Reference to the Audio Plan artifact (e.g., 'AUD-001')"
@@ -23,20 +24,33 @@
       },
       "reference_refs": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "References to Reference Sheets for recurring sonic elements (leitmotifs, location ambients)"
       },
       "output_format": {
         "type": "string",
-        "enum": ["mp3", "ogg", "wav", "flac"],
+        "enum": [
+          "mp3",
+          "ogg",
+          "wav",
+          "flac"
+        ],
         "default": "mp3",
         "description": "Output audio format"
       },
       "duration_hint": {
         "type": "object",
         "properties": {
-          "min_seconds": { "type": "number", "minimum": 0.5 },
-          "max_seconds": { "type": "number", "maximum": 600 }
+          "min_seconds": {
+            "type": "number",
+            "minimum": 0.5
+          },
+          "max_seconds": {
+            "type": "number",
+            "maximum": 600
+          }
         },
         "description": "Target duration range. If not specified, uses Audio Plan guidance."
       },
@@ -48,9 +62,11 @@
         "description": "Number of variants to generate for selection"
       }
     },
-    "required": ["audio_plan_ref"]
+    "required": [
+      "reasoning",
+      "audio_plan_ref"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -58,14 +74,30 @@
         "type": "object",
         "description": "The generated audio asset",
         "properties": {
-          "asset_id": { "type": "string" },
-          "file_path": { "type": "string" },
-          "file_hash": { "type": "string" },
-          "mime_type": { "type": "string" },
-          "size_bytes": { "type": "integer" },
-          "duration_seconds": { "type": "number" },
-          "sample_rate": { "type": "integer" },
-          "channels": { "type": "integer" }
+          "asset_id": {
+            "type": "string"
+          },
+          "file_path": {
+            "type": "string"
+          },
+          "file_hash": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          },
+          "duration_seconds": {
+            "type": "number"
+          },
+          "sample_rate": {
+            "type": "integer"
+          },
+          "channels": {
+            "type": "integer"
+          }
         }
       },
       "source_plan": {
@@ -76,12 +108,32 @@
         "type": "object",
         "description": "Off-surface generation details for reproducibility",
         "properties": {
-          "tool": { "type": "string", "description": "Generation tool used (e.g., 'elevenlabs', 'suno', 'stock-library')" },
-          "prompt_hash": { "type": "string", "description": "Hash of the prompt used" },
-          "seed": { "type": ["integer", "null"], "description": "Seed if deterministic generation supported" },
-          "model_version": { "type": "string" },
-          "settings": { "type": "object", "description": "Tool-specific settings" },
-          "timestamp": { "type": "string", "format": "date-time" }
+          "tool": {
+            "type": "string",
+            "description": "Generation tool used (e.g., 'elevenlabs', 'suno', 'stock-library')"
+          },
+          "prompt_hash": {
+            "type": "string",
+            "description": "Hash of the prompt used"
+          },
+          "seed": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Seed if deterministic generation supported"
+          },
+          "model_version": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "description": "Tool-specific settings"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "variants": {
@@ -90,29 +142,34 @@
         "items": {
           "type": "object",
           "properties": {
-            "variant_id": { "type": "string" },
-            "file_path": { "type": "string" },
-            "selected": { "type": "boolean" }
+            "variant_id": {
+              "type": "string"
+            },
+            "file_path": {
+              "type": "string"
+            },
+            "selected": {
+              "type": "boolean"
+            }
           }
         }
       }
     }
   },
-
   "timeout_ms": 180000,
-
   "retry_policy": {
     "max_retries": 1,
     "initial_delay_ms": 5000,
     "backoff_multiplier": 2,
-    "retryable_errors": ["timeout", "service_unavailable"]
+    "retryable_errors": [
+      "timeout",
+      "service_unavailable"
+    ]
   },
-
   "rate_limit": {
     "requests_per_minute": 10,
     "requests_per_agent_per_minute": 5
   },
-
   "examples": [
     {
       "description": "Generate ambient soundscape for a location",
@@ -120,7 +177,10 @@
         "audio_plan_ref": "AUD-001",
         "style_guide_ref": "SG-001",
         "output_format": "ogg",
-        "duration_hint": { "min_seconds": 30, "max_seconds": 60 }
+        "duration_hint": {
+          "min_seconds": 30,
+          "max_seconds": 60
+        }
       }
     },
     {

--- a/domain-v4/tools/generate_image.json
+++ b/domain-v4/tools/generate_image.json
@@ -3,16 +3,17 @@
   "id": "generate_image",
   "name": "Generate Image",
   "summary": "Generate an image from a plan",
-  "description": "Generate an illustration from an Art Plan. Consults Reference Sheets for visual consistency of recurring elements (characters, locations, objects). Returns an image asset with determinism log (kept off-surface).\n\nThis tool is expensive—use only when budget allows. Art Plans should exist for ALL worthy scenes, but generation is selective based on priority.\n\nRuntime provides implementation (DALL-E, Stable Diffusion, commission queue, etc.).",
-
+  "description": "Generate an illustration from an Art Plan. Consults Reference Sheets for visual consistency of recurring elements (characters, locations, objects). Returns an image asset with determinism log (kept off-surface).\n\nThis tool is expensive\u2014use only when budget allows. Art Plans should exist for ALL worthy scenes, but generation is selective based on priority.\n\nRuntime provides implementation (DALL-E, Stable Diffusion, commission queue, etc.).",
   "cost_tier": "high",
-
   "summarization_policy": "ultra_concise",
   "summary_template": "Generated image from {source_plan}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "art_plan_ref": {
         "type": "string",
         "description": "Reference to the Art Plan artifact (e.g., 'AP-001')"
@@ -23,20 +24,34 @@
       },
       "reference_sheet_refs": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "References to Reference Sheets for recurring elements in this image (characters, locations, objects)"
       },
       "output_format": {
         "type": "string",
-        "enum": ["png", "jpeg", "webp"],
+        "enum": [
+          "png",
+          "jpeg",
+          "webp"
+        ],
         "default": "png",
         "description": "Output image format"
       },
       "dimensions": {
         "type": "object",
         "properties": {
-          "width": { "type": "integer", "minimum": 256, "maximum": 4096 },
-          "height": { "type": "integer", "minimum": 256, "maximum": 4096 }
+          "width": {
+            "type": "integer",
+            "minimum": 256,
+            "maximum": 4096
+          },
+          "height": {
+            "type": "integer",
+            "minimum": 256,
+            "maximum": 4096
+          }
         },
         "description": "Target dimensions. If not specified, uses Art Plan guidance or defaults."
       },
@@ -48,9 +63,11 @@
         "description": "Number of variants to generate for selection"
       }
     },
-    "required": ["art_plan_ref"]
+    "required": [
+      "reasoning",
+      "art_plan_ref"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -58,13 +75,27 @@
         "type": "object",
         "description": "The generated illustration asset",
         "properties": {
-          "asset_id": { "type": "string" },
-          "file_path": { "type": "string" },
-          "file_hash": { "type": "string" },
-          "mime_type": { "type": "string" },
-          "size_bytes": { "type": "integer" },
-          "width": { "type": "integer" },
-          "height": { "type": "integer" }
+          "asset_id": {
+            "type": "string"
+          },
+          "file_path": {
+            "type": "string"
+          },
+          "file_hash": {
+            "type": "string"
+          },
+          "mime_type": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          },
+          "width": {
+            "type": "integer"
+          },
+          "height": {
+            "type": "integer"
+          }
         }
       },
       "source_plan": {
@@ -75,12 +106,32 @@
         "type": "object",
         "description": "Off-surface generation details for reproducibility",
         "properties": {
-          "tool": { "type": "string", "description": "Generation tool used (e.g., 'dalle-3', 'sdxl')" },
-          "prompt_hash": { "type": "string", "description": "Hash of the prompt used" },
-          "seed": { "type": ["integer", "null"], "description": "Seed if deterministic generation supported" },
-          "model_version": { "type": "string" },
-          "settings": { "type": "object", "description": "Tool-specific settings" },
-          "timestamp": { "type": "string", "format": "date-time" }
+          "tool": {
+            "type": "string",
+            "description": "Generation tool used (e.g., 'dalle-3', 'sdxl')"
+          },
+          "prompt_hash": {
+            "type": "string",
+            "description": "Hash of the prompt used"
+          },
+          "seed": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Seed if deterministic generation supported"
+          },
+          "model_version": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "description": "Tool-specific settings"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "variants": {
@@ -89,36 +140,43 @@
         "items": {
           "type": "object",
           "properties": {
-            "variant_id": { "type": "string" },
-            "file_path": { "type": "string" },
-            "selected": { "type": "boolean" }
+            "variant_id": {
+              "type": "string"
+            },
+            "file_path": {
+              "type": "string"
+            },
+            "selected": {
+              "type": "boolean"
+            }
           }
         }
       }
     }
   },
-
   "timeout_ms": 120000,
-
   "retry_policy": {
     "max_retries": 1,
     "initial_delay_ms": 5000,
     "backoff_multiplier": 2,
-    "retryable_errors": ["timeout", "service_unavailable"]
+    "retryable_errors": [
+      "timeout",
+      "service_unavailable"
+    ]
   },
-
   "rate_limit": {
     "requests_per_minute": 10,
     "requests_per_agent_per_minute": 5
   },
-
   "examples": [
     {
       "description": "Generate illustration for a signpost scene",
       "input": {
         "art_plan_ref": "AP-001",
         "style_guide_ref": "SG-001",
-        "reference_sheet_refs": ["RS-foreman"],
+        "reference_sheet_refs": [
+          "RS-foreman"
+        ],
         "output_format": "png",
         "variants_requested": 2
       }
@@ -129,7 +187,10 @@
         "art_plan_ref": "AP-015",
         "style_guide_ref": "SG-001",
         "output_format": "webp",
-        "dimensions": { "width": 1920, "height": 1080 }
+        "dimensions": {
+          "width": 1920,
+          "height": 1080
+        }
       }
     }
   ]

--- a/domain-v4/tools/get_artifact.json
+++ b/domain-v4/tools/get_artifact.json
@@ -4,24 +4,35 @@
   "name": "Get Artifact",
   "summary": "Retrieve an artifact by ID",
   "description": "Retrieve one or more artifacts by ID. Returns the current version from workspace or canon stores.\n\nAccepts a single ID or list of IDs. Use search_workspace instead to find artifacts by criteria (type, lifecycle state, content search).",
-
   "summarization_policy": "concise",
   "summary_template": "Retrieved {count} artifact(s)",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "artifact_ids": {
         "oneOf": [
-          { "type": "string" },
-          { "type": "array", "items": { "type": "string" } }
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         ],
         "description": "Artifact ID(s) to fetch - single string or array of strings"
       }
     },
-    "required": ["artifact_ids"]
+    "required": [
+      "reasoning",
+      "artifact_ids"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -35,12 +46,13 @@
       },
       "not_found": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "IDs that were not found (only present if some IDs not found)"
       }
     }
   },
-
   "examples": [
     {
       "description": "Fetch a single artifact by ID",
@@ -51,7 +63,11 @@
     {
       "description": "Fetch multiple artifacts at once",
       "input": {
-        "artifact_ids": ["passage_brief_abc123", "passage_brief_def456", "passage_brief_ghi789"]
+        "artifact_ids": [
+          "passage_brief_abc123",
+          "passage_brief_def456",
+          "passage_brief_ghi789"
+        ]
       }
     }
   ]

--- a/domain-v4/tools/list_agents.json
+++ b/domain-v4/tools/list_agents.json
@@ -4,16 +4,20 @@
   "name": "List Agents",
   "summary": "List available agents and their capabilities",
   "description": "List all agents available for delegation. Use this to discover what specialist agents exist and their archetypes before delegating work. Returns a compact list with id, name, archetypes, and brief description.",
-
   "summarization_policy": "drop",
   "summary_template": "Listed {count} agents",
-
   "input_schema": {
     "type": "object",
-    "properties": {},
-    "required": []
+    "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -27,15 +31,29 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Discover available agents for delegation",
       "input": {},
       "output": {
         "agents": [
-          {"id": "plotwright", "name": "Plotwright", "archetypes": ["architect"], "description": "Designs story topology and structure"},
-          {"id": "scene_smith", "name": "Scene Smith", "archetypes": ["author", "creator"], "description": "Transforms skeleton scenes into engaging prose"}
+          {
+            "id": "plotwright",
+            "name": "Plotwright",
+            "archetypes": [
+              "architect"
+            ],
+            "description": "Designs story topology and structure"
+          },
+          {
+            "id": "scene_smith",
+            "name": "Scene Smith",
+            "archetypes": [
+              "author",
+              "creator"
+            ],
+            "description": "Transforms skeleton scenes into engaging prose"
+          }
         ],
         "count": 2
       }

--- a/domain-v4/tools/list_agents.json
+++ b/domain-v4/tools/list_agents.json
@@ -34,7 +34,9 @@
   "examples": [
     {
       "description": "Discover available agents for delegation",
-      "input": {},
+      "input": {
+        "reasoning": "I want to see which specialist agents are available so I can decide which one to delegate my task to"
+      },
       "output": {
         "agents": [
           {

--- a/domain-v4/tools/list_artifact_types.json
+++ b/domain-v4/tools/list_artifact_types.json
@@ -38,7 +38,9 @@
   "examples": [
     {
       "description": "Discover available artifact types",
-      "input": {},
+      "input": {
+        "reasoning": "I want to see what artifact types are available before deciding which schema to consult"
+      },
       "output": {
         "artifact_types": [
           {

--- a/domain-v4/tools/list_artifact_types.json
+++ b/domain-v4/tools/list_artifact_types.json
@@ -4,16 +4,20 @@
   "name": "List Artifact Types",
   "summary": "List available artifact types",
   "description": "List all available artifact types with brief descriptions. Use this to discover what artifact types exist before consulting their full schemas. Returns a compact list with id, name, category, and brief description for each type.",
-
   "summarization_policy": "drop",
   "summary_template": "Listed {count} artifact types",
-
   "input_schema": {
     "type": "object",
-    "properties": {},
-    "required": []
+    "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -31,15 +35,24 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Discover available artifact types",
       "input": {},
       "output": {
         "artifact_types": [
-          {"id": "passage", "name": "Passage", "category": "narrative", "description": "Story passage with prose, choices, and gates"},
-          {"id": "passage_brief", "name": "Passage Brief", "category": "planning", "description": "Structural outline before prose writing"}
+          {
+            "id": "passage",
+            "name": "Passage",
+            "category": "narrative",
+            "description": "Story passage with prose, choices, and gates"
+          },
+          {
+            "id": "passage_brief",
+            "name": "Passage Brief",
+            "category": "planning",
+            "description": "Structural outline before prose writing"
+          }
         ],
         "count": 2,
         "recommended_action": "Call consult_schema(artifact_type_id) to get full field definitions for the type you need."

--- a/domain-v4/tools/list_stores.json
+++ b/domain-v4/tools/list_stores.json
@@ -34,7 +34,9 @@
   "examples": [
     {
       "description": "Discover available stores",
-      "input": {},
+      "input": {
+        "reasoning": "Need to discover what storage systems are available for artifact management"
+      },
       "output": {
         "stores": [
           {

--- a/domain-v4/tools/list_stores.json
+++ b/domain-v4/tools/list_stores.json
@@ -4,16 +4,20 @@
   "name": "List Stores",
   "summary": "List available stores and access levels",
   "description": "List all available stores with their semantics and descriptions. Use this to discover what stores exist and understand their access patterns (hot, cold, versioned, ephemeral).",
-
   "summarization_policy": "drop",
   "summary_template": "Listed {count} stores",
-
   "input_schema": {
     "type": "object",
-    "properties": {},
-    "required": []
+    "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -27,15 +31,24 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Discover available stores",
       "input": {},
       "output": {
         "stores": [
-          {"id": "workspace", "name": "Workspace", "semantics": "hot", "description": "Working memory for drafts and in-progress work"},
-          {"id": "canon", "name": "Canon Store", "semantics": "cold", "description": "Permanent storage for approved artifacts"}
+          {
+            "id": "workspace",
+            "name": "Workspace",
+            "semantics": "hot",
+            "description": "Working memory for drafts and in-progress work"
+          },
+          {
+            "id": "canon",
+            "name": "Canon Store",
+            "semantics": "cold",
+            "description": "Permanent storage for approved artifacts"
+          }
         ],
         "count": 2
       }

--- a/domain-v4/tools/request_lifecycle_transition.json
+++ b/domain-v4/tools/request_lifecycle_transition.json
@@ -3,15 +3,16 @@
   "id": "request_lifecycle_transition",
   "name": "Request Lifecycle Transition",
   "summary": "Request a lifecycle state change for an artifact",
-  "description": "Request a lifecycle state transition for an artifact. Transitions follow the path: draft → review → approved → cold.\n\nNot all agents can request all transitions - the runtime validates permissions and artifact state. Transitions to 'cold' (canon commitment) require Gatekeeper approval.\n\nReturns success or actionable error messages explaining what's required.",
-
+  "description": "Request a lifecycle state transition for an artifact. Transitions follow the path: draft \u2192 review \u2192 approved \u2192 cold.\n\nNot all agents can request all transitions - the runtime validates permissions and artifact state. Transitions to 'cold' (canon commitment) require Gatekeeper approval.\n\nReturns success or actionable error messages explaining what's required.",
   "summarization_policy": "preserve",
-
   "can_reject": true,
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "artifact_id": {
         "type": "string",
         "description": "ID of the artifact to transition"
@@ -25,16 +26,23 @@
         "description": "If true, bypasses requires_validation checks when the lifecycle permits it. Use with care."
       }
     },
-    "required": ["artifact_id", "target_state"]
+    "required": [
+      "reasoning",
+      "artifact_id",
+      "target_state"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
       "result": {
         "type": "string",
         "description": "Outcome of the transition request: 'committed' | 'rejected' | 'deferred'",
-        "enum": ["committed", "rejected", "deferred"]
+        "enum": [
+          "committed",
+          "rejected",
+          "deferred"
+        ]
       },
       "artifact_id": {
         "type": "string",
@@ -65,7 +73,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Promote a passage from draft to review after self-validation",

--- a/domain-v4/tools/return_to_orchestrator.json
+++ b/domain-v4/tools/return_to_orchestrator.json
@@ -4,36 +4,53 @@
   "name": "Return to Orchestrator",
   "summary": "Signal task completion and return control",
   "description": "Signal that your delegated task is complete and return control to the orchestrator.\n\nRequired fields:\n- summary: What you accomplished\n- result_assessment: pass/partial/fail/skip/info\n- recommendation: proceed/rework/escalate/hold\n\nIf you created or updated artifacts, include artifacts_produced with their IDs. This is CRITICAL for workflow continuity - without IDs, the orchestrator cannot pass your work to the next agent.",
-
   "terminates_turn": true,
   "summarization_policy": "ultra_concise",
   "summary_template": "Returned to orchestrator: {result_assessment} - {summary}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "summary": {
         "type": "string",
         "description": "Brief summary of what was accomplished or what's blocking progress"
       },
       "result_assessment": {
         "type": "string",
-        "enum": ["pass", "partial", "fail", "skip", "info"],
+        "enum": [
+          "pass",
+          "partial",
+          "fail",
+          "skip",
+          "info"
+        ],
         "description": "Quality assessment of your work product: pass (all good), partial (some issues found), fail (major problems), skip (not applicable to this task), info (informational only, no quality judgment)"
       },
       "recommendation": {
         "type": "string",
-        "enum": ["proceed", "rework", "escalate", "hold"],
+        "enum": [
+          "proceed",
+          "rework",
+          "escalate",
+          "hold"
+        ],
         "description": "What the orchestrator should do next: proceed (continue workflow), rework (route back for fixes), escalate (needs human decision), hold (blocked, cannot continue)"
       },
       "artifacts_produced": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "IDs of artifacts created or updated during this work"
       },
       "artifacts_ready_for_review": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "IDs of artifacts that are ready for quality gating"
       },
       "blockers": {
@@ -43,17 +60,29 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["missing_input", "quality_issue", "canon_conflict", "needs_clarification", "other"]
+              "enum": [
+                "missing_input",
+                "quality_issue",
+                "canon_conflict",
+                "needs_clarification",
+                "other"
+              ]
             },
-            "description": { "type": "string" }
+            "description": {
+              "type": "string"
+            }
           }
         },
         "description": "If there are issues, what specifically is problematic"
       }
     },
-    "required": ["summary", "result_assessment", "recommendation"]
+    "required": [
+      "reasoning",
+      "summary",
+      "result_assessment",
+      "recommendation"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -67,7 +96,6 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Scene Smith completes section drafting successfully",
@@ -75,8 +103,12 @@
         "summary": "Drafted section prose for SB-005 with 3 choices as specified in the brief",
         "result_assessment": "pass",
         "recommendation": "proceed",
-        "artifacts_produced": ["section-lighthouse-lock-v1"],
-        "artifacts_ready_for_review": ["section-lighthouse-lock-v1"]
+        "artifacts_produced": [
+          "section-lighthouse-lock-v1"
+        ],
+        "artifacts_ready_for_review": [
+          "section-lighthouse-lock-v1"
+        ]
       }
     },
     {
@@ -99,7 +131,9 @@
         "summary": "Gatecheck complete - 6/8 bars pass, 2 need rework",
         "result_assessment": "partial",
         "recommendation": "rework",
-        "artifacts_produced": ["gatecheck-section-005"],
+        "artifacts_produced": [
+          "gatecheck-section-005"
+        ],
         "blockers": [
           {
             "type": "quality_issue",
@@ -118,7 +152,9 @@
         "summary": "Pre-gate review complete - Integrity and Nonlinearity pass, Reachability deferred to post-Scene Weave",
         "result_assessment": "info",
         "recommendation": "proceed",
-        "artifacts_produced": ["pregate-report-section-briefs"]
+        "artifacts_produced": [
+          "pregate-report-section-briefs"
+        ]
       }
     }
   ]

--- a/domain-v4/tools/search_workspace.json
+++ b/domain-v4/tools/search_workspace.json
@@ -4,17 +4,26 @@
   "name": "Search Workspace",
   "summary": "Search for artifacts in the workspace",
   "description": "Search for artifacts in the Hot SoT (workspace store). Supports filtering by artifact type, lifecycle state, and text search within fields. Returns matching artifacts with their current state.\n\nUse this to find:\n- Drafts in progress\n- Passage briefs ready for implementation\n- Hooks awaiting triage\n- Related artifacts for context",
-
   "summarization_policy": "concise",
   "summary_template": "Found {total_count} artifacts matching query",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "query": {
         "oneOf": [
-          { "type": "string" },
-          { "type": "array", "items": { "type": "string" } }
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         ],
         "description": "Text search query - single string or array of strings (OR search)"
       },
@@ -29,7 +38,12 @@
         "type": "array",
         "items": {
           "type": "string",
-          "enum": ["draft", "review", "approved", "cold"]
+          "enum": [
+            "draft",
+            "review",
+            "approved",
+            "cold"
+          ]
         },
         "description": "Filter by lifecycle state(s). Valid states: draft (new/WIP), review (awaiting gating), approved (passed gates), cold (committed to canon)"
       },
@@ -53,9 +67,11 @@
         "default": 20,
         "description": "Maximum results to return"
       }
-    }
+    },
+    "required": [
+      "reasoning"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -64,12 +80,24 @@
         "items": {
           "type": "object",
           "properties": {
-            "artifact_id": { "type": "string" },
-            "artifact_type": { "type": "string" },
-            "lifecycle_state": { "type": "string" },
-            "summary": { "type": "string" },
-            "created_by": { "type": "string" },
-            "created_at": { "type": "string" }
+            "artifact_id": {
+              "type": "string"
+            },
+            "artifact_type": {
+              "type": "string"
+            },
+            "lifecycle_state": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "created_by": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string"
+            }
           }
         }
       },
@@ -79,45 +107,60 @@
       }
     }
   },
-
   "examples": [
     {
       "description": "Find all Passage Briefs in draft state",
       "input": {
-        "artifact_types": ["passage_brief"],
-        "lifecycle_states": ["draft"]
+        "artifact_types": [
+          "passage_brief"
+        ],
+        "lifecycle_states": [
+          "draft"
+        ]
       }
     },
     {
       "description": "Search for hooks mentioning 'lighthouse'",
       "input": {
         "query": "lighthouse",
-        "artifact_types": ["hook_card"]
+        "artifact_types": [
+          "hook_card"
+        ]
       }
     },
     {
       "description": "Find drafts created by Plotwright",
       "input": {
         "created_by": "plotwright",
-        "lifecycle_states": ["draft"]
+        "lifecycle_states": [
+          "draft"
+        ]
       }
     },
     {
       "description": "Search for multiple passage briefs by ID (OR search)",
       "input": {
-        "query": ["passage_brief_abc123", "passage_brief_def456", "passage_brief_ghi789"]
+        "query": [
+          "passage_brief_abc123",
+          "passage_brief_def456",
+          "passage_brief_ghi789"
+        ]
       }
     },
     {
       "description": "Find artifacts awaiting quality review",
       "input": {
-        "lifecycle_states": ["review"]
+        "lifecycle_states": [
+          "review"
+        ]
       }
     },
     {
       "description": "Find approved artifacts ready for canon",
       "input": {
-        "lifecycle_states": ["approved"]
+        "lifecycle_states": [
+          "approved"
+        ]
       }
     }
   ]

--- a/domain-v4/tools/terminate_session.json
+++ b/domain-v4/tools/terminate_session.json
@@ -9,9 +9,18 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "reason": {
         "type": "string",
-        "enum": ["complete", "user_requested", "error", "blocked"],
+        "enum": [
+          "complete",
+          "user_requested",
+          "error",
+          "blocked"
+        ],
         "description": "Why the session is ending:\n- complete: All requested work finished successfully\n- user_requested: User explicitly asked to end session\n- error: Unrecoverable error prevents further progress\n- blocked: Cannot proceed without human intervention that won't come"
       },
       "summary": {
@@ -20,12 +29,18 @@
       },
       "artifacts_produced": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "default": [],
         "description": "IDs of artifacts produced during session"
       }
     },
-    "required": ["reason", "summary"]
+    "required": [
+      "reasoning",
+      "reason",
+      "summary"
+    ]
   },
   "summarization_policy": "preserve",
   "summary_template": "Session terminated: {reason}"

--- a/domain-v4/tools/validate_artifact.json
+++ b/domain-v4/tools/validate_artifact.json
@@ -4,14 +4,15 @@
   "name": "Validate Artifact",
   "summary": "Check an artifact against quality criteria",
   "description": "Validate an artifact against its type schema and the 8 quality bars. Returns validation results with specific errors and suggested fixes.\n\nQuality Bars checked:\n1. Integrity - No contradictions or dead links\n2. Reachability - Critical content accessible\n3. Nonlinearity - Branches matter\n4. Gateways - Conditions enforceable\n5. Style - Voice consistent\n6. Determinism - Reproducible where promised\n7. Presentation - Spoiler-safe\n8. Accessibility - Navigation clear\n\nPattern: validate-with-feedback - strict validation, clear rejection messages with remediation guidance.",
-
   "summarization_policy": "preserve",
-
   "can_reject": true,
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "artifact_id": {
         "type": "string",
         "description": "ID of the artifact to validate"
@@ -26,7 +27,11 @@
       },
       "validation_mode": {
         "type": "string",
-        "enum": ["schema_only", "bars_only", "full"],
+        "enum": [
+          "schema_only",
+          "bars_only",
+          "full"
+        ],
         "default": "full",
         "description": "What to validate: schema compliance only, quality bars only, or both"
       },
@@ -34,14 +39,25 @@
         "type": "array",
         "items": {
           "type": "string",
-          "enum": ["integrity", "reachability", "nonlinearity", "gateways", "style", "determinism", "presentation", "accessibility"]
+          "enum": [
+            "integrity",
+            "reachability",
+            "nonlinearity",
+            "gateways",
+            "style",
+            "determinism",
+            "presentation",
+            "accessibility"
+          ]
         },
         "description": "Specific bars to check (default: all 8)"
       }
     },
-    "required": ["artifact_type_id"]
+    "required": [
+      "reasoning",
+      "artifact_type_id"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -54,9 +70,15 @@
         "items": {
           "type": "object",
           "properties": {
-            "field": { "type": "string" },
-            "error": { "type": "string" },
-            "suggested_fix": { "type": "string" }
+            "field": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            },
+            "suggested_fix": {
+              "type": "string"
+            }
           }
         }
       },
@@ -65,20 +87,32 @@
         "items": {
           "type": "object",
           "properties": {
-            "bar": { "type": "string", "description": "Name of the quality bar checked" },
+            "bar": {
+              "type": "string",
+              "description": "Name of the quality bar checked"
+            },
             "status": {
               "type": "string",
-              "enum": ["pass", "warn", "fail"],
+              "enum": [
+                "pass",
+                "warn",
+                "fail"
+              ],
               "description": "Result of the check: pass=meets requirements, warn=minor issues, fail=blocking issues"
             },
-            "evidence": { "type": "string", "description": "What was observed" },
-            "smallest_fix": { "type": "string", "description": "Minimal change needed to address issues" }
+            "evidence": {
+              "type": "string",
+              "description": "What was observed"
+            },
+            "smallest_fix": {
+              "type": "string",
+              "description": "Minimal change needed to address issues"
+            }
           }
         }
       }
     }
   },
-
   "examples": [
     {
       "description": "Validate a Passage before merging to Cold",
@@ -92,7 +126,10 @@
       "description": "Quick schema check on a draft",
       "input": {
         "artifact_type_id": "passage_brief",
-        "artifact_data": { "brief_id": "PB-001", "goal": "Test" },
+        "artifact_data": {
+          "brief_id": "PB-001",
+          "goal": "Test"
+        },
         "validation_mode": "schema_only"
       }
     }

--- a/domain-v4/tools/web_fetch.json
+++ b/domain-v4/tools/web_fetch.json
@@ -4,13 +4,15 @@
   "name": "Web Fetch",
   "summary": "Fetch content from a URL",
   "description": "Fetch and extract content from a specific URL. Returns cleaned text content from the page, suitable for reading and analysis. Handles HTML cleanup, removes navigation/ads, and extracts main content.\n\nBest for: deep-diving a specific source, reading full articles, extracting detailed information.\nFor discovering sources, use web_search first.",
-
   "summarization_policy": "concise",
   "summary_template": "Fetched content from {url}",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "url": {
         "type": "string",
         "format": "uri",
@@ -18,7 +20,11 @@
       },
       "extract_mode": {
         "type": "string",
-        "enum": ["article", "full", "summary"],
+        "enum": [
+          "article",
+          "full",
+          "summary"
+        ],
         "default": "article",
         "description": "article: extract main content only. full: include all text. summary: AI-generated summary of the page."
       },
@@ -30,9 +36,11 @@
         "description": "Maximum characters to return"
       }
     },
-    "required": ["url"]
+    "required": [
+      "reasoning",
+      "url"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -62,22 +70,22 @@
       }
     }
   },
-
   "timeout_ms": 30000,
-
   "retry_policy": {
     "max_retries": 2,
     "initial_delay_ms": 2000,
     "backoff_multiplier": 2,
-    "retryable_errors": ["timeout", "rate_limited", "service_unavailable"]
+    "retryable_errors": [
+      "timeout",
+      "rate_limited",
+      "service_unavailable"
+    ]
   },
-
   "rate_limit": {
     "requests_per_minute": 20,
     "requests_per_agent_per_minute": 5,
     "burst_limit": 3
   },
-
   "examples": [
     {
       "description": "Read a Wikipedia article for fact verification",

--- a/domain-v4/tools/web_search.json
+++ b/domain-v4/tools/web_search.json
@@ -4,13 +4,15 @@
   "name": "Web Search",
   "summary": "Search the web for information",
   "description": "Search the web for factual information. Returns a list of relevant results with titles, snippets, and URLs. Use this to find sources for verification, corroborate claims, or discover current information.\n\nBest for: broad queries, finding multiple sources, discovering what exists.\nFor deep-diving a specific page, use web_fetch instead.",
-
   "summarization_policy": "concise",
   "summary_template": "Web search for '{query}': found results",
-
   "input_schema": {
     "type": "object",
     "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Explain why you are calling this tool and what you expect to achieve. This helps ensure thoughtful tool usage."
+      },
       "query": {
         "type": "string",
         "description": "The search query. Be specific and include relevant context for better results."
@@ -28,14 +30,22 @@
       },
       "recency": {
         "type": "string",
-        "enum": ["all_time", "day", "week", "month", "year"],
+        "enum": [
+          "all_time",
+          "day",
+          "week",
+          "month",
+          "year"
+        ],
         "default": "all_time",
         "description": "Filter by content freshness. 'all_time' returns results regardless of date."
       }
     },
-    "required": ["query"]
+    "required": [
+      "reasoning",
+      "query"
+    ]
   },
-
   "output_schema": {
     "type": "object",
     "properties": {
@@ -44,10 +54,22 @@
         "items": {
           "type": "object",
           "properties": {
-            "title": { "type": "string", "description": "Page title" },
-            "url": { "type": "string", "description": "Full URL to the page" },
-            "snippet": { "type": "string", "description": "Content excerpt from the search result" },
-            "published_date": { "type": "string", "description": "Publication date if available (ISO 8601 format)" }
+            "title": {
+              "type": "string",
+              "description": "Page title"
+            },
+            "url": {
+              "type": "string",
+              "description": "Full URL to the page"
+            },
+            "snippet": {
+              "type": "string",
+              "description": "Content excerpt from the search result"
+            },
+            "published_date": {
+              "type": "string",
+              "description": "Publication date if available (ISO 8601 format)"
+            }
           }
         }
       },
@@ -61,21 +83,21 @@
       }
     }
   },
-
   "timeout_ms": 15000,
-
   "retry_policy": {
     "max_retries": 2,
     "initial_delay_ms": 1000,
     "backoff_multiplier": 2,
-    "retryable_errors": ["timeout", "rate_limited", "service_unavailable"]
+    "retryable_errors": [
+      "timeout",
+      "rate_limited",
+      "service_unavailable"
+    ]
   },
-
   "rate_limit": {
     "requests_per_minute": 30,
     "requests_per_agent_per_minute": 10
   },
-
   "examples": [
     {
       "description": "Verify a historical claim",

--- a/meta/schemas/core/tool-definition.schema.json
+++ b/meta/schemas/core/tool-definition.schema.json
@@ -116,7 +116,7 @@
   "$defs": {
     "tool_input_schema": {
       "type": "object",
-      "description": "JSON Schema for tool arguments. The Runtime validates agent tool calls against this schema before execution.",
+      "description": "JSON Schema for tool arguments. The Runtime validates agent tool calls against this schema before execution.\n\nRECOMMENDED: All tools should include a 'reasoning' property in their input_schema. This enables Chain-of-Thought prompting by requiring agents to explain WHY they are calling the tool before execution. The reasoning is logged at INFO level for observability.\n\nExample reasoning property:\n```json\n\"reasoning\": {\n  \"type\": \"string\",\n  \"description\": \"Explain why you are calling this tool and what you expect to achieve.\"\n}\n```",
       "properties": {
         "type": {
           "const": "object",
@@ -128,12 +128,12 @@
             "type": "object",
             "description": "JSON Schema for each argument"
           },
-          "description": "The tool's arguments"
+          "description": "The tool's arguments. RECOMMENDED: Include a 'reasoning' property for Chain-of-Thought prompting."
         },
         "required": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Which arguments are required"
+          "description": "Which arguments are required. RECOMMENDED: Include 'reasoning' in this array."
         }
       },
       "additionalProperties": true

--- a/src/questfoundry/runtime/agent/prompt.py
+++ b/src/questfoundry/runtime/agent/prompt.py
@@ -382,6 +382,13 @@ class PromptBuilder:
         """
         lines = ["## Your Tools\n"]
 
+        # Chain-of-Thought: Require reasoning for every tool call
+        lines.append("**IMPORTANT:** Before calling any tool, provide a `reasoning` parameter:")
+        lines.append("- Explain WHY you are using this specific tool")
+        lines.append("- State WHAT you expect to achieve")
+        lines.append("- Describe HOW it advances your current task")
+        lines.append("")
+
         for tool in tool_schemas:
             name = tool.get("name", "unknown")
             # Use summary if available, otherwise first line of description

--- a/src/questfoundry/runtime/agent/runtime.py
+++ b/src/questfoundry/runtime/agent/runtime.py
@@ -530,6 +530,11 @@ class AgentRuntime:
                 args=args,
             )
 
+        # Log reasoning at INFO level for Chain-of-Thought observability
+        reasoning = args.get("reasoning")
+        if reasoning:
+            logger.info("[%s] Tool %s reasoning: %s", agent.id, tool_id, reasoning)
+
         tool_trace_ctx = (
             self._tracing_manager.tool_call(
                 tool_id,

--- a/tests/runtime/agent/test_prompt.py
+++ b/tests/runtime/agent/test_prompt.py
@@ -381,3 +381,37 @@ class TestSandwichPattern:
 
         # The REMEMBER section should not be generated at all if it would be empty
         assert "REMEMBER" not in result.text
+
+
+class TestChainOfThoughtGuidance:
+    """Tests for Chain-of-Thought reasoning guidance in prompts."""
+
+    def test_tools_section_includes_reasoning_guidance(self, basic_agent: Agent) -> None:
+        """Tools section includes CoT reasoning instruction."""
+        builder = PromptBuilder()
+        tool_schemas = [
+            {"name": "test_tool", "description": "A test tool for testing."},
+        ]
+
+        result = builder.build_for_agent(basic_agent, tool_schemas=tool_schemas)
+
+        # Check that reasoning guidance is present
+        assert "reasoning" in result.text
+        assert "WHY" in result.text
+        assert "WHAT" in result.text
+        assert "HOW" in result.text
+
+    def test_reasoning_guidance_appears_before_tool_list(self, basic_agent: Agent) -> None:
+        """Reasoning guidance appears before the tool list."""
+        builder = PromptBuilder()
+        tool_schemas = [
+            {"name": "delegate", "description": "Delegate work to another agent."},
+        ]
+
+        result = builder.build_for_agent(basic_agent, tool_schemas=tool_schemas)
+
+        # Reasoning guidance should appear before the tool list
+        reasoning_pos = result.text.find("reasoning")
+        tool_pos = result.text.find("delegate")
+
+        assert reasoning_pos < tool_pos, "Reasoning guidance should appear before tool list"

--- a/tests/runtime/agent/test_runtime.py
+++ b/tests/runtime/agent/test_runtime.py
@@ -951,3 +951,151 @@ class TestProgressBasedIterationLimits:
             deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
             assert len(deprecation_warnings) >= 1
             assert "max_tool_iterations" in str(deprecation_warnings[0].message)
+
+
+class TestChainOfThoughtReasoningLogging:
+    """Tests for Chain-of-Thought reasoning logging in tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_reasoning_logged_at_info_level(
+        self,
+        mock_provider: MagicMock,
+        project: Project,
+        caplog,
+    ) -> None:
+        """Reasoning argument is logged at INFO level before tool execution."""
+        import logging
+        from typing import Any
+
+        from questfoundry.runtime.models.base import Agent, Capability, Studio, Tool
+        from questfoundry.runtime.tools.base import BaseTool, ToolContext, ToolResult
+        from questfoundry.runtime.tools.registry import ToolRegistry
+
+        # Create a mock tool
+        class MockTool(BaseTool):
+            async def execute(self, _args: dict[str, Any]) -> ToolResult:
+                return ToolResult(success=True, data={"result": "done"})
+
+        # Create tool definition
+        tool_def = Tool(
+            id="test_tool",
+            name="Test Tool",
+            description="A test tool",
+        )
+
+        # Create agent with capability to use the test tool
+        agent = Agent(
+            id="test_agent",
+            name="Test Agent",
+            description="Test agent",
+            archetypes=["creator"],
+            capabilities=[
+                Capability(
+                    id="use_test_tool",
+                    name="Use Test Tool",
+                    description="Can use test_tool",
+                    category="tools",
+                    tool_ref="test_tool",
+                ),
+            ],
+        )
+
+        # Create studio with the tool and agent
+        studio = Studio(
+            id="test_studio",
+            name="Test Studio",
+            agents=[agent],
+            tools=[tool_def],
+        )
+
+        tool_context = ToolContext(studio=studio, project=project)
+        mock_tool = MockTool(definition=tool_def, context=tool_context)
+
+        # Setup runtime with tool registry
+        runtime = AgentRuntime(provider=mock_provider, studio=studio, project=project)
+        runtime._tool_registry = ToolRegistry(studio=studio, project=project)
+        runtime._tool_registry._tool_cache["test_tool"] = mock_tool
+
+        # Execute tool with reasoning
+        with caplog.at_level(logging.INFO, logger="questfoundry.runtime.agent.runtime"):
+            await runtime.execute_tool(
+                agent=agent,
+                tool_id="test_tool",
+                args={"reasoning": "Testing CoT logging", "other_arg": "value"},
+                session_id="test-session",
+                turn_number=1,
+            )
+
+        # Check that reasoning was logged
+        assert any("Testing CoT logging" in record.message for record in caplog.records), (
+            f"Expected reasoning in log, got: {[r.message for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_log_when_reasoning_absent(
+        self,
+        mock_provider: MagicMock,
+        project: Project,
+        caplog,
+    ) -> None:
+        """No reasoning log when reasoning argument is not provided."""
+        import logging
+        from typing import Any
+
+        from questfoundry.runtime.models.base import Agent, Capability, Studio, Tool
+        from questfoundry.runtime.tools.base import BaseTool, ToolContext, ToolResult
+        from questfoundry.runtime.tools.registry import ToolRegistry
+
+        class MockTool(BaseTool):
+            async def execute(self, _args: dict[str, Any]) -> ToolResult:
+                return ToolResult(success=True, data={"result": "done"})
+
+        tool_def = Tool(
+            id="test_tool",
+            name="Test Tool",
+            description="A test tool",
+        )
+
+        agent = Agent(
+            id="test_agent",
+            name="Test Agent",
+            description="Test agent",
+            archetypes=["creator"],
+            capabilities=[
+                Capability(
+                    id="use_test_tool",
+                    name="Use Test Tool",
+                    description="Can use test_tool",
+                    category="tools",
+                    tool_ref="test_tool",
+                ),
+            ],
+        )
+
+        studio = Studio(
+            id="test_studio",
+            name="Test Studio",
+            agents=[agent],
+            tools=[tool_def],
+        )
+
+        tool_context = ToolContext(studio=studio, project=project)
+        mock_tool = MockTool(definition=tool_def, context=tool_context)
+
+        runtime = AgentRuntime(provider=mock_provider, studio=studio, project=project)
+        runtime._tool_registry = ToolRegistry(studio=studio, project=project)
+        runtime._tool_registry._tool_cache["test_tool"] = mock_tool
+
+        # Execute tool WITHOUT reasoning
+        with caplog.at_level(logging.INFO, logger="questfoundry.runtime.agent.runtime"):
+            await runtime.execute_tool(
+                agent=agent,
+                tool_id="test_tool",
+                args={"other_arg": "value"},  # No reasoning
+                session_id="test-session",
+                turn_number=1,
+            )
+
+        # Check that no reasoning-related log was emitted
+        reasoning_logs = [r for r in caplog.records if "reasoning" in r.message.lower()]
+        assert len(reasoning_logs) == 0, f"Unexpected reasoning log: {reasoning_logs}"

--- a/tests/runtime/agent/test_runtime.py
+++ b/tests/runtime/agent/test_runtime.py
@@ -956,34 +956,21 @@ class TestProgressBasedIterationLimits:
 class TestChainOfThoughtReasoningLogging:
     """Tests for Chain-of-Thought reasoning logging in tool execution."""
 
-    @pytest.mark.asyncio
-    async def test_reasoning_logged_at_info_level(
-        self,
-        mock_provider: MagicMock,
-        project: Project,
-        caplog,
-    ) -> None:
-        """Reasoning argument is logged at INFO level before tool execution."""
-        import logging
+    def _setup_runtime_and_agent(
+        self, mock_provider: MagicMock, project: Project
+    ) -> tuple[AgentRuntime, Agent]:
+        """Helper to set up a mock tool, agent, and runtime for CoT tests."""
         from typing import Any
 
         from questfoundry.runtime.models.base import Agent, Capability, Studio, Tool
         from questfoundry.runtime.tools.base import BaseTool, ToolContext, ToolResult
         from questfoundry.runtime.tools.registry import ToolRegistry
 
-        # Create a mock tool
         class MockTool(BaseTool):
             async def execute(self, _args: dict[str, Any]) -> ToolResult:
                 return ToolResult(success=True, data={"result": "done"})
 
-        # Create tool definition
-        tool_def = Tool(
-            id="test_tool",
-            name="Test Tool",
-            description="A test tool",
-        )
-
-        # Create agent with capability to use the test tool
+        tool_def = Tool(id="test_tool", name="Test Tool", description="A test tool")
         agent = Agent(
             id="test_agent",
             name="Test Agent",
@@ -999,24 +986,26 @@ class TestChainOfThoughtReasoningLogging:
                 ),
             ],
         )
-
-        # Create studio with the tool and agent
-        studio = Studio(
-            id="test_studio",
-            name="Test Studio",
-            agents=[agent],
-            tools=[tool_def],
-        )
-
+        studio = Studio(id="test_studio", name="Test Studio", agents=[agent], tools=[tool_def])
         tool_context = ToolContext(studio=studio, project=project)
         mock_tool = MockTool(definition=tool_def, context=tool_context)
-
-        # Setup runtime with tool registry
         runtime = AgentRuntime(provider=mock_provider, studio=studio, project=project)
         runtime._tool_registry = ToolRegistry(studio=studio, project=project)
         runtime._tool_registry._tool_cache["test_tool"] = mock_tool
+        return runtime, agent
 
-        # Execute tool with reasoning
+    @pytest.mark.asyncio
+    async def test_reasoning_logged_at_info_level(
+        self,
+        mock_provider: MagicMock,
+        project: Project,
+        caplog,
+    ) -> None:
+        """Reasoning argument is logged at INFO level before tool execution."""
+        import logging
+
+        runtime, agent = self._setup_runtime_and_agent(mock_provider, project)
+
         with caplog.at_level(logging.INFO, logger="questfoundry.runtime.agent.runtime"):
             await runtime.execute_tool(
                 agent=agent,
@@ -1026,7 +1015,6 @@ class TestChainOfThoughtReasoningLogging:
                 turn_number=1,
             )
 
-        # Check that reasoning was logged
         assert any("Testing CoT logging" in record.message for record in caplog.records), (
             f"Expected reasoning in log, got: {[r.message for r in caplog.records]}"
         )
@@ -1040,53 +1028,9 @@ class TestChainOfThoughtReasoningLogging:
     ) -> None:
         """No reasoning log when reasoning argument is not provided."""
         import logging
-        from typing import Any
 
-        from questfoundry.runtime.models.base import Agent, Capability, Studio, Tool
-        from questfoundry.runtime.tools.base import BaseTool, ToolContext, ToolResult
-        from questfoundry.runtime.tools.registry import ToolRegistry
+        runtime, agent = self._setup_runtime_and_agent(mock_provider, project)
 
-        class MockTool(BaseTool):
-            async def execute(self, _args: dict[str, Any]) -> ToolResult:
-                return ToolResult(success=True, data={"result": "done"})
-
-        tool_def = Tool(
-            id="test_tool",
-            name="Test Tool",
-            description="A test tool",
-        )
-
-        agent = Agent(
-            id="test_agent",
-            name="Test Agent",
-            description="Test agent",
-            archetypes=["creator"],
-            capabilities=[
-                Capability(
-                    id="use_test_tool",
-                    name="Use Test Tool",
-                    description="Can use test_tool",
-                    category="tools",
-                    tool_ref="test_tool",
-                ),
-            ],
-        )
-
-        studio = Studio(
-            id="test_studio",
-            name="Test Studio",
-            agents=[agent],
-            tools=[tool_def],
-        )
-
-        tool_context = ToolContext(studio=studio, project=project)
-        mock_tool = MockTool(definition=tool_def, context=tool_context)
-
-        runtime = AgentRuntime(provider=mock_provider, studio=studio, project=project)
-        runtime._tool_registry = ToolRegistry(studio=studio, project=project)
-        runtime._tool_registry._tool_cache["test_tool"] = mock_tool
-
-        # Execute tool WITHOUT reasoning
         with caplog.at_level(logging.INFO, logger="questfoundry.runtime.agent.runtime"):
             await runtime.execute_tool(
                 agent=agent,
@@ -1096,6 +1040,5 @@ class TestChainOfThoughtReasoningLogging:
                 turn_number=1,
             )
 
-        # Check that no reasoning-related log was emitted
         reasoning_logs = [r for r in caplog.records if "reasoning" in r.message.lower()]
         assert len(reasoning_logs) == 0, f"Unexpected reasoning log: {reasoning_logs}"


### PR DESCRIPTION
## Summary
- Add mandatory `reasoning` parameter to all 22 domain tool schemas
- Log reasoning at INFO level before tool execution for CoT observability
- Add behavioral guidance in prompts instructing agents to explain WHY/WHAT/HOW before using tools
- Update meta schema with recommendation for reasoning parameter

## Details

This implements **Phase 2** of #297 (Chain-of-Thought via Tool Reasoning Parameter).

**Decision**: Option B - Structured reasoning via tool parameter
- More structured than thought blocks
- Easier for small LLMs to follow
- Automatically captured in event logs

**Changes by commit**:
1. `docs(meta)`: Add reasoning parameter recommendation to meta schema
2. `feat(domain)`: Add reasoning parameter to all 22 tools
3. `feat(runtime)`: Log tool reasoning at INFO level
4. `feat(prompt)`: Add CoT guidance to tools section
5. `test(runtime)`: Add tests for CoT reasoning

**Example tool parameter**:
```json
"reasoning": {
  "type": "string",
  "description": "Explain why you are calling this tool and what you expect to achieve."
}
```

**Example prompt guidance**:
```
**IMPORTANT:** Before calling any tool, provide a `reasoning` parameter:
- Explain WHY you are using this specific tool
- State WHAT you expect to achieve
- Describe HOW it advances your current task
```

## Test plan
- [x] All 4 new CoT tests pass
- [x] JSON schema validation passes on all 22 tools
- [x] Pre-commit hooks pass on all commits
- [ ] Verify reasoning appears in logs during actual workflow run

Closes #297 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)